### PR TITLE
Replace technical-details toggle with ⌥-click on menu bar icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Per port, in plain English:
 - **Charger PDO list** — every voltage profile the charger advertises (5V / 9V / 12V / 15V / 20V…) with the currently negotiated profile highlighted in real time
 - **Connected device identity** — vendor name and product type, decoded from the PD Discover Identity response
 - **Active transports** — USB 2 / USB 3 / Thunderbolt / DisplayPort
-- **"Show technical details"** toggle revealing the underlying IOKit properties for engineers
+- **⌥-click the menu bar icon** to reveal the underlying IOKit properties for engineers
 
 Right-click the menu bar icon for **Refresh**, a **Keep window open** toggle (handy for screenshots and demos), **About**, and **Quit**.
 

--- a/Sources/CableTest/App.swift
+++ b/Sources/CableTest/App.swift
@@ -46,6 +46,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         if event.type == .rightMouseUp {
             showMenu(from: sender)
         } else {
+            Self.refreshSignal.showAdvanced = event.modifierFlags.contains(.option)
             togglePopover(from: sender)
         }
     }
@@ -111,5 +112,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
 
 final class RefreshSignal: ObservableObject {
     @Published var tick: Int = 0
+    @Published var showAdvanced: Bool = false
     func bump() { tick &+= 1 }
 }

--- a/Sources/CableTest/ContentView.swift
+++ b/Sources/CableTest/ContentView.swift
@@ -6,7 +6,6 @@ struct ContentView: View {
     @StateObject private var powerWatcher = PowerSourceWatcher()
     @StateObject private var pdWatcher = PDIdentityWatcher()
     @EnvironmentObject private var refresh: RefreshSignal
-    @State private var showAdvanced = false
 
     var body: some View {
         VStack(spacing: 0) {
@@ -23,7 +22,7 @@ struct ContentView: View {
                                 devices: matchingDevices(for: port),
                                 powerSources: powerWatcher.sources(for: port),
                                 identities: pdWatcher.identities(for: port),
-                                showAdvanced: showAdvanced
+                                showAdvanced: refresh.showAdvanced
                             )
                         }
                     }
@@ -76,9 +75,9 @@ struct ContentView: View {
 
     private var footer: some View {
         HStack(spacing: 8) {
-            Toggle("Show technical details", isOn: $showAdvanced)
-                .toggleStyle(.switch)
-                .controlSize(.small)
+            Text("Tip: ⌥-click the menu bar icon for technical details")
+                .font(.caption)
+                .foregroundStyle(.tertiary)
             Spacer()
             Text("\(deviceWatcher.devices.count) USB device\(deviceWatcher.devices.count == 1 ? "" : "s")")
                 .font(.caption)


### PR DESCRIPTION
## Summary
- Removes the persistent **Show technical details** toggle from the popover footer.
- ⌥-click (Option-click) on the menu bar icon now opens the popover with technical details visible — matches the common macOS menu-bar convention (e.g. Wi-Fi, Volume, Bluetooth menus revealing extended info on Option-click).
- A small footer hint (`Tip: ⌥-click the menu bar icon for technical details`) replaces the toggle so the affordance stays discoverable.

## Implementation notes
- `RefreshSignal` gains a `@Published var showAdvanced` so the AppDelegate can publish the modifier state to the SwiftUI tree without new plumbing.
- The status-item click handler reads `event.modifierFlags.contains(.option)` and writes it onto the signal before toggling the popover. Each click sets the state deterministically — no stale advanced view from a previous open.
- README feature list updated to reflect the new affordance.

## Test plan
- [x] `swift build` clean
- [x] Plain left-click → popover opens, advanced section hidden
- [x] ⌥ + left-click → popover opens with `AdvancedPortDetails` visible (Connection / Transports groups, raw IOKit DisclosureGroup)
- [x] Right-click → context menu still works (Refresh / Keep window open / About / Quit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
