### PR TITLE
Add gear menu in popover header for About / Help / Quit

### DIFF
--- a/Sources/CableTest/App.swift
+++ b/Sources/CableTest/App.swift
@@ -87,6 +87,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     }
 
     @objc private func menuAbout() {
+        Self.showAboutPanel()
+    }
+
+    @objc private func menuQuit() {
+        NSApp.terminate(nil)
+    }
+
+    static func showAboutPanel() {
         NSApp.activate(ignoringOtherApps: true)
         let credits = NSAttributedString(
             string: "\(AppInfo.tagline)\n\nBuilt by \(AppInfo.credit).",
@@ -102,10 +110,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
             .credits: credits,
             .init(rawValue: "Copyright"): AppInfo.copyright
         ])
-    }
-
-    @objc private func menuQuit() {
-        NSApp.terminate(nil)
     }
 }
 

--- a/Sources/CableTest/AppInfo.swift
+++ b/Sources/CableTest/AppInfo.swift
@@ -6,4 +6,5 @@ enum AppInfo {
     static let credit = "Darryl Morley"
     static let tagline = "What can this USB-C cable actually do?"
     static let copyright = "© \(Calendar.current.component(.year, from: Date())) \(credit)"
+    static let helpURL = URL(string: "https://github.com/darrylmorley/whatcable")!
 }

--- a/Sources/CableTest/ContentView.swift
+++ b/Sources/CableTest/ContentView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import AppKit
 
 struct ContentView: View {
     @StateObject private var portWatcher = USBCPortWatcher()
@@ -53,7 +54,7 @@ struct ContentView: View {
     }
 
     private var header: some View {
-        HStack {
+        HStack(spacing: 10) {
             Image(systemName: "cable.connector.horizontal")
                 .font(.title2)
             VStack(alignment: .leading, spacing: 2) {
@@ -70,6 +71,18 @@ struct ContentView: View {
             }
             .buttonStyle(.borderless)
             .help("Refresh")
+            Menu {
+                Button("About \(AppInfo.name)") { AppDelegate.showAboutPanel() }
+                Button("Help") { NSWorkspace.shared.open(AppInfo.helpURL) }
+                Divider()
+                Button("Quit \(AppInfo.name)") { NSApp.terminate(nil) }
+            } label: {
+                Image(systemName: "gearshape")
+            }
+            .menuStyle(.borderlessButton)
+            .menuIndicator(.hidden)
+            .fixedSize()
+            .help("More options")
         }
         .padding(12)
     }


### PR DESCRIPTION
## Summary
- Adds a **gear icon menu** to the popover header, next to the refresh button, surfacing **About / Help / Quit**.
- Quitting the app previously required right-clicking the menu bar icon — a hidden affordance most users won't try. The gear menu makes the standard macOS menu-bar-app actions discoverable from the popover itself.
- **Help** opens the GitHub repo (`https://github.com/darrylmorley/whatcable`) so users have a one-click path to docs and issues.

## Implementation notes
- `AppDelegate.showAboutPanel()` is extracted as a static function so the existing right-click menu (`menuAbout`) and the new gear menu share a single implementation of the About-panel construction.
- The gear menu is a SwiftUI `Menu` with `.menuStyle(.borderlessButton)` + `.menuIndicator(.hidden)` so the trigger renders as a plain `gearshape` icon matching the refresh button.
- The right-click context menu on the menu bar icon is unchanged — it remains the power-user path (still has Refresh + Keep window open).
- `AppInfo.helpURL` is the new constant; `NSWorkspace.shared.open` handles the Help action.

## Test plan
- [x] `swift build` clean
- [x] Gear icon visible in header next to refresh, no chevron
- [x] Click gear → menu shows About / Help / ―― / Quit
- [x] About → standard About panel with version, tagline, credit
- [x] Help → opens the GitHub repo in the default browser
- [x] Quit → app exits
- [x] Refresh button still works
- [x] Right-click on the menu bar icon still shows the existing context menu (Refresh / Keep window open / About / Quit)
- [x] Opening the gear menu does not dismiss the transient popover

🤖 Generated with [Claude Code](https://claude.com/claude-code)
