### PR TITLE
Unify Settings Shortcut with In-Place Settings View

### DIFF
--- a/Sources/WhatCable/App.swift
+++ b/Sources/WhatCable/App.swift
@@ -10,7 +10,9 @@ struct WhatCableApp: App {
     var body: some Scene {
         // Headless — UI is owned by AppDelegate (status item + popover, or
         // a regular window, depending on AppSettings.useMenuBarMode).
-        Settings { EmptyView() }
+        Settings {
+            SettingsView()
+        }
     }
 }
 
@@ -164,7 +166,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate, NSW
         pinItem.state = isPinned ? .on : .off
         menu.addItem(pinItem)
         menu.addItem(.separator())
+        menu.addItem(.init(title: "Settings…", action: #selector(menuSettings), keyEquivalent: ","))
         menu.addItem(.init(title: "Check for Updates…", action: #selector(menuCheckUpdates), keyEquivalent: ""))
+        menu.addItem(.separator())
         menu.addItem(.init(title: "About \(AppInfo.name)", action: #selector(menuAbout), keyEquivalent: ""))
         menu.addItem(.init(title: "WhatCable on GitHub", action: #selector(menuHelp), keyEquivalent: ""))
         menu.addItem(.separator())
@@ -183,6 +187,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate, NSW
 
     @objc private func menuRefresh() {
         Self.refreshSignal.bump()
+    }
+
+    @objc private func menuSettings() {
+        NSApp.activate(ignoringOtherApps: true)
+        NSApp.sendAction(Selector(("showSettingsPanel:")), to: nil, from: nil)
     }
 
     @objc private func menuAbout() {

--- a/Sources/WhatCable/App.swift
+++ b/Sources/WhatCable/App.swift
@@ -11,6 +11,14 @@ struct WhatCableApp: App {
         // Headless — UI is owned by AppDelegate (status item + popover, or
         // a regular window, depending on AppSettings.useMenuBarMode).
         Settings { EmptyView() }
+            .commands {
+                CommandGroup(replacing: .appSettings) {
+                    Button("Settings…") {
+                        delegate.showSettingsPanel(nil)
+                    }
+                    .keyboardShortcut(",", modifiers: .command)
+                }
+            }
     }
 }
 

--- a/Sources/WhatCable/App.swift
+++ b/Sources/WhatCable/App.swift
@@ -10,9 +10,7 @@ struct WhatCableApp: App {
     var body: some Scene {
         // Headless — UI is owned by AppDelegate (status item + popover, or
         // a regular window, depending on AppSettings.useMenuBarMode).
-        Settings {
-            SettingsView()
-        }
+        Settings { EmptyView() }
     }
 }
 
@@ -190,8 +188,27 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate, NSW
     }
 
     @objc private func menuSettings() {
+        showSettings()
+    }
+
+    @objc func showSettingsPanel(_ sender: Any?) {
+        showSettings()
+    }
+
+    private func showSettings() {
         NSApp.activate(ignoringOtherApps: true)
-        NSApp.sendAction(Selector(("showSettingsPanel:")), to: nil, from: nil)
+        Self.refreshSignal.showSettings = true
+        if AppSettings.shared.useMenuBarMode {
+            if let button = statusItem?.button, let popover, !popover.isShown {
+                togglePopover(from: button)
+            }
+        } else {
+            if let window {
+                window.makeKeyAndOrderFront(nil)
+            } else {
+                setUpWindowMode()
+            }
+        }
     }
 
     @objc private func menuAbout() {
@@ -241,5 +258,7 @@ final class RefreshSignal: ObservableObject {
     /// `AppSettings.showTechnicalDetails`; the effective state is the OR
     /// of the two.
     @Published var optionHeld: Bool = false
+    @Published var showSettings: Bool = false
+
     func bump() { tick &+= 1 }
 }

--- a/Sources/WhatCable/ContentView.swift
+++ b/Sources/WhatCable/ContentView.swift
@@ -103,9 +103,16 @@ struct ContentView: View {
             }
             .buttonStyle(.borderless)
             .help("Settings")
-            .keyboardShortcut(",", modifiers: .command)
         }
         .padding(12)
+        .background(
+            Button("") {
+                refresh.showSettings = true
+            }
+            .keyboardShortcut(",", modifiers: .command)
+            .opacity(0)
+            .allowsHitTesting(false)
+        )
     }
 
     private var footer: some View {

--- a/Sources/WhatCable/ContentView.swift
+++ b/Sources/WhatCable/ContentView.swift
@@ -9,7 +9,6 @@ struct ContentView: View {
     @EnvironmentObject private var refresh: RefreshSignal
     @ObservedObject private var settings = AppSettings.shared
     @ObservedObject private var updates = UpdateChecker.shared
-    @State private var showSettings = false
 
     private var showAdvanced: Bool {
         settings.showTechnicalDetails || refresh.optionHeld
@@ -17,8 +16,8 @@ struct ContentView: View {
 
     var body: some View {
         Group {
-            if showSettings {
-                SettingsView(dismiss: { showSettings = false })
+            if refresh.showSettings {
+                SettingsView(dismiss: { refresh.showSettings = false })
             } else {
                 mainContent
             }
@@ -98,12 +97,13 @@ struct ContentView: View {
             .buttonStyle(.borderless)
             .help("Refresh")
             Button {
-                showSettings = true
+                refresh.showSettings = true
             } label: {
                 Image(systemName: "gearshape")
             }
             .buttonStyle(.borderless)
             .help("Settings")
+            .keyboardShortcut(",", modifiers: .command)
         }
         .padding(12)
     }

--- a/Sources/WhatCable/SettingsView.swift
+++ b/Sources/WhatCable/SettingsView.swift
@@ -4,40 +4,26 @@ import SwiftUI
 /// "Done" header and groups toggles by purpose. All preferences live on
 /// `AppSettings` and are persisted to UserDefaults.
 struct SettingsView: View {
-    let dismiss: () -> Void
+    var dismiss: (() -> Void)? = nil
 
     @ObservedObject private var settings = AppSettings.shared
 
     var body: some View {
         VStack(spacing: 0) {
-            header
-            Divider()
+            if let dismiss {
+                header(dismiss: dismiss)
+                Divider()
+            }
             ScrollView {
-                VStack(alignment: .leading, spacing: 18) {
-                    section("Display") {
-                        Toggle("Show technical details", isOn: $settings.showTechnicalDetails)
-                        Toggle("Hide empty ports", isOn: $settings.hideEmptyPorts)
-                    }
-                    section("Behavior") {
-                        Toggle("Launch at login", isOn: $settings.launchAtLogin)
-                        Toggle("Show in menu bar", isOn: $settings.useMenuBarMode)
-                        Text(settings.useMenuBarMode
-                             ? "Lives in the menu bar with no Dock icon."
-                             : "Runs as a regular Dock app with a window.")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                    }
-                    section("Notifications") {
-                        Toggle("Notify on cable changes", isOn: $settings.notifyOnChanges)
-                    }
-                }
-                .padding(16)
-                .frame(maxWidth: .infinity, alignment: .leading)
+                SettingsForm()
+                    .padding(16)
+                    .frame(maxWidth: .infinity, alignment: .leading)
             }
         }
+        .frame(minWidth: 400, minHeight: 300)
     }
 
-    private var header: some View {
+    private func header(dismiss: @escaping () -> Void) -> some View {
         HStack {
             Image(systemName: "gearshape")
                 .font(.title2)
@@ -47,6 +33,31 @@ struct SettingsView: View {
                 .keyboardShortcut(.defaultAction)
         }
         .padding(12)
+    }
+}
+
+struct SettingsForm: View {
+    @ObservedObject private var settings = AppSettings.shared
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            section("Display") {
+                Toggle("Show technical details", isOn: $settings.showTechnicalDetails)
+                Toggle("Hide empty ports", isOn: $settings.hideEmptyPorts)
+            }
+            section("Behavior") {
+                Toggle("Launch at login", isOn: $settings.launchAtLogin)
+                Toggle("Show in menu bar", isOn: $settings.useMenuBarMode)
+                Text(settings.useMenuBarMode
+                     ? "Lives in the menu bar with no Dock icon."
+                     : "Runs as a regular Dock app with a window.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            section("Notifications") {
+                Toggle("Notify on cable changes", isOn: $settings.notifyOnChanges)
+            }
+        }
     }
 
     @ViewBuilder

--- a/Tests/WhatCableTests/RefreshSignalTests.swift
+++ b/Tests/WhatCableTests/RefreshSignalTests.swift
@@ -1,0 +1,53 @@
+import XCTest
+import Combine
+@testable import WhatCable
+
+final class RefreshSignalTests: XCTestCase {
+    private var signal: RefreshSignal!
+    private var cancellables: Set<AnyCancellable>!
+
+    override func setUp() {
+        super.setUp()
+        signal = RefreshSignal()
+        cancellables = []
+    }
+
+    func testInitialState() {
+        XCTAssertEqual(signal.tick, 0)
+        XCTAssertFalse(signal.optionHeld)
+        XCTAssertFalse(signal.showSettings)
+    }
+
+    func testBumpIncrementsTick() {
+        signal.bump()
+        XCTAssertEqual(signal.tick, 1)
+        signal.bump()
+        XCTAssertEqual(signal.tick, 2)
+    }
+
+    func testShowSettingsToggle() {
+        var observedValue = false
+        let expectation = expectation(description: "showSettings published")
+
+        signal.$showSettings
+            .dropFirst()
+            .sink { value in
+                observedValue = value
+                expectation.fulfill()
+            }
+            .store(in: &cancellables)
+
+        signal.showSettings = true
+        XCTAssertTrue(signal.showSettings)
+
+        waitForExpectations(timeout: 1.0)
+        XCTAssertTrue(observedValue)
+    }
+
+    func testOptionHeldToggle() {
+        signal.optionHeld = true
+        XCTAssertTrue(signal.optionHeld)
+        signal.optionHeld = false
+        XCTAssertFalse(signal.optionHeld)
+    }
+}


### PR DESCRIPTION
**Problem**
Previously, the Command + , keyboard shortcut opened a standard macOS
settings window which appeared blank because the app's Settings scene
was empty.
Meanwhile, clicking the gear icon in the main UI toggled an "in-place"
settings view within the existing popover or window. This inconsistency
led to a confusing user experience where the standard shortcut felt
broken.

**Solution**
This PR refactors the settings logic to ensure that Command + ,, the
status menu "Settings..." item, and the gear icon all trigger the same
in-place SettingsView. 

**Key Changes**

1. UI Refactoring (SettingsView.swift)
- Extracted the core settings UI into a reusable SettingsForm.
- Refactored SettingsView to make the "Done" header optional. This allows
the view to be used both as an in-place replacement (with a "Done"
button) and as content for the standard settings window (without a
redundant header) if needed.

2. Global State Management (App.swift)
- Added showSettings to RefreshSignal (the app's shared observable state).
This allows the AppDelegate to programmatically trigger the settings
view in response to external events like the menu bar item or keyboard
shortcut.

3. Unified Shortcut Handling (App.swift & ContentView.swift)
- AppDelegate: Implemented showSettingsPanel: to intercept the system-wide
settings action. It now activates the app and toggles the showSettings
flag, automatically opening the menu bar popover or main window if they
aren't visible.
- ContentView: Added a persistent, hidden keyboard shortcut handler for
Command + ,. This ensures that if the window is already focused, the
shortcut correctly targets the in-place view even if it's already
showing (preventing it from falling through to the system default).
- App Structure: Replaced the default .appSettings command group in the
App scene with a custom one that calls our internal showSettings logic,
effectively disabling the blank standalone window.

Verification
- [x] Command + , opens settings in-place within the popover (Menu Bar mode).
- [x] Command + , opens settings in-place within the main window (Window mode).
- [x] Clicking the gear icon works as before.
- [x] Right-clicking the menu bar icon and selecting "Settings..." opens the popover to the settings view.
- [x] Pressing Command + , while settings are already open is a no-op (no new window is created).

Co-authored-by: Gemini CLI <gemini-cli@google.com>