### PR TITLE
Fix Apple Silicon USB-C and MagSafe matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ WhatCable reads four families of IOKit services. No entitlements, no private API
 
 | Service | What it gives us |
 | --- | --- |
-| `AppleHPMInterfaceType10/11/12` (M3-era) and `AppleTCControllerType10/11` (M1 / M2) | Per-port state: connection, transports, plug orientation, e-marker presence. `Type11` is what M2 MacBook Air uses for its MagSafe 3 port. |
+| `AppleHPMInterfaceType10/11/12` (M3-era), `AppleTCControllerType10/11` (M1 / M2), and `IOPort` (M4 Mac mini front ports) | Per-port state: connection, transports, plug orientation, e-marker presence. `Type11` is what M2 MacBook Air uses for its MagSafe 3 port. |
 | `IOPortFeaturePowerSource` | Full PDO list from the connected source, with the live "winning" PDO |
 | `IOPortTransportComponentCCUSBPDSOP` | PD Discover Identity VDOs for SOP (port partner) and SOP' (cable e-marker) |
 | XHCI controller subtree | Each connected USB device is paired to its physical port via the XHCI port node's `UsbIOPort` registry path, falling back to a bus-index derived from the controller's `locationID` upper byte and the port's `hpm` SPMI ancestor on machines that don't expose `UsbIOPort`. |

--- a/Sources/WhatCable/ContentView.swift
+++ b/Sources/WhatCable/ContentView.swift
@@ -175,29 +175,7 @@ struct ContentView: View {
     /// is worse than showing none, and it caused the bug that issue #21
     /// reported.
     private func matchingDevices(for port: USBCPort) -> [USBDevice] {
-        guard port.connectionActive == true else { return [] }
-        guard portCarriesUSB(port) else { return [] }
-        let byPortName = deviceWatcher.devices.filter { $0.controllerPortName == port.serviceName }
-        if !byPortName.isEmpty {
-            return byPortName
-        }
-        // No device claims this port via UsbIOPort. Only fall back to bus-index
-        // matching if at least one device exposes a controllerPortName, which
-        // tells us UsbIOPort is supported on this machine and an empty result
-        // is meaningful (no device is on this port). Otherwise UsbIOPort isn't
-        // available and we use the older busIndex heuristic.
-        let anyDeviceHasPortName = deviceWatcher.devices.contains { $0.controllerPortName != nil }
-        if anyDeviceHasPortName {
-            return []
-        }
-        if let portBus = port.busIndex {
-            return deviceWatcher.devices.filter { $0.busIndex == portBus }
-        }
-        return []
-    }
-
-    private func portCarriesUSB(_ port: USBCPort) -> Bool {
-        port.transportsActive.contains { $0 == "USB2" || $0 == "USB3" }
+        port.matchingDevices(from: deviceWatcher.devices)
     }
 }
 

--- a/Sources/WhatCableCore/ChargingDiagnostic.swift
+++ b/Sources/WhatCableCore/ChargingDiagnostic.swift
@@ -26,9 +26,14 @@ public struct ChargingDiagnostic {
 }
 
 extension ChargingDiagnostic {
-    public init?(port: USBCPort, sources: [PowerSource], identities: [PDIdentity]) {
-        guard let usbPD = sources.first(where: { $0.name == "USB-PD" }) else {
-            return nil // No PD source on this port, no diagnostic to make.
+    public init?(
+        port: USBCPort,
+        sources: [PowerSource],
+        identities: [PDIdentity],
+        systemAdapter: SystemPower.AdapterInfo? = SystemPower.currentAdapter()
+    ) {
+        guard let source = PowerSource.preferredChargingSource(in: sources) else {
+            return nil // No USB-PD or MagSafe Brick ID source on this port.
         }
         // MagSafe (and at least some USB-C ports) keep the last negotiated
         // PDO around as cached data even after the charger is unplugged, so
@@ -37,8 +42,17 @@ extension ChargingDiagnostic {
         // the PowerSource node alone.
         guard port.connectionActive == true else { return nil }
 
-        let chargerMaxW = Int((Double(usbPD.maxPowerMW) / 1000).rounded())
-        let negotiatedW = usbPD.winning.map { Int((Double($0.maxPowerMW) / 1000).rounded()) }
+        var chargerMaxW = Int((Double(source.maxPowerMW) / 1000).rounded())
+        var negotiatedW = source.winning.map { Int((Double($0.maxPowerMW) / 1000).rounded()) }
+
+        if negotiatedW.map({ $0 <= 0 }) ?? true,
+           let watts = systemAdapter?.watts,
+           watts > 0 {
+            negotiatedW = watts
+            if chargerMaxW <= 0 {
+                chargerMaxW = watts
+            }
+        }
 
         let cableMaxW: Int? = identities
             .first(where: { $0.endpoint == .sopPrime || $0.endpoint == .sopDoublePrime })?

--- a/Sources/WhatCableCore/PDIdentityWatcher.swift
+++ b/Sources/WhatCableCore/PDIdentityWatcher.swift
@@ -90,22 +90,14 @@ public final class PDIdentityWatcher: ObservableObject {
             return nil
         }
 
-        let endpointName = (dict["ComponentName"] as? String)
-            ?? (dict["AddressDescription"] as? String)
-            ?? (dict["Address Description"] as? String)
-            ?? "Unknown"
-        let endpoint = PDIdentity.Endpoint(rawValue: endpointName) ?? .unknown
-
-        let parentType = (dict["ParentPortType"] as? NSNumber)?.intValue ?? 0
-        let parentNum = (dict["ParentPortNumber"] as? NSNumber)?.intValue ?? 0
+        let endpoint = Self.endpoint(from: dict)
+        let parent = Self.parentPortIdentity(from: dict)
         let specRev = (dict["Specification Revision"] as? NSNumber)?.intValue ?? 0
 
-        let metadata = dict["Metadata"] as? [String: Any] ?? [:]
-        let vendorID = (metadata["Vendor ID"] as? NSNumber)?.intValue
-            ?? (dict["Vendor ID"] as? NSNumber)?.intValue ?? 0
-        let productID = (metadata["Product ID"] as? NSNumber)?.intValue
-            ?? (dict["Product ID"] as? NSNumber)?.intValue ?? 0
-        let bcdDevice = (metadata["bcdDevice"] as? NSNumber)?.intValue ?? 0
+        let metadata = Self.metadataDictionary(from: dict)
+        let vendorID = Self.vendorID(from: dict, metadata: metadata)
+        let productID = Self.productID(from: dict, metadata: metadata)
+        let bcdDevice = Self.bcdDevice(from: metadata)
 
         let vdos: [UInt32] = ((metadata["VDOs"] as? [Any]) ?? []).compactMap { value in
             guard let data = value as? Data else { return nil }
@@ -115,14 +107,74 @@ public final class PDIdentityWatcher: ObservableObject {
         return PDIdentity(
             id: entryID,
             endpoint: endpoint,
-            parentPortType: parentType,
-            parentPortNumber: parentNum,
+            parentPortType: parent.type,
+            parentPortNumber: parent.number,
             vendorID: vendorID,
             productID: productID,
             bcdDevice: bcdDevice,
             vdos: vdos,
             specRevision: specRev
         )
+    }
+
+    nonisolated static func endpointName(from dict: [String: Any]) -> String {
+        (dict["ComponentName"] as? String)
+            ?? (dict["AddressDescription"] as? String)
+            ?? (dict["Address Description"] as? String)
+            ?? (dict["TransportTypeDescription"] as? String)
+            ?? "Unknown"
+    }
+
+    nonisolated static func endpoint(from dict: [String: Any]) -> PDIdentity.Endpoint {
+        let name = endpointName(from: dict)
+        if name == "CC" {
+            return .sopPrime
+        }
+        return PDIdentity.Endpoint(rawValue: name) ?? .unknown
+    }
+
+    nonisolated static func parentPortIdentity(from dict: [String: Any]) -> (type: Int, number: Int) {
+        let type = (dict["ParentPortType"] as? NSNumber)?.intValue
+            ?? (dict["ParentBuiltInPortType"] as? NSNumber)?.intValue
+            ?? 0
+        let number = (dict["ParentPortNumber"] as? NSNumber)?.intValue
+            ?? (dict["ParentBuiltInPortNumber"] as? NSNumber)?.intValue
+            ?? 0
+        return (type, number)
+    }
+
+    nonisolated static func metadataDictionary(from dict: [String: Any]) -> [String: Any] {
+        if let metadata = dict["Metadata"] as? [String: Any] {
+            return metadata
+        }
+        if let nsMetadata = dict["Metadata"] as? NSDictionary {
+            var converted: [String: Any] = [:]
+            for case let (key, value) as (String, Any) in nsMetadata {
+                converted[key] = value
+            }
+            return converted
+        }
+        return [:]
+    }
+
+    nonisolated static func vendorID(from dict: [String: Any], metadata: [String: Any]) -> Int {
+        (metadata["Vendor ID"] as? NSNumber)?.intValue
+            ?? (metadata["Vendor ID (SOP1)"] as? NSNumber)?.intValue
+            ?? (dict["Vendor ID (SOP1)"] as? NSNumber)?.intValue
+            ?? (dict["Vendor ID"] as? NSNumber)?.intValue
+            ?? 0
+    }
+
+    nonisolated static func productID(from dict: [String: Any], metadata: [String: Any]) -> Int {
+        (metadata["Product ID"] as? NSNumber)?.intValue
+            ?? (metadata["Product ID (SOP1)"] as? NSNumber)?.intValue
+            ?? (dict["Product ID (SOP1)"] as? NSNumber)?.intValue
+            ?? (dict["Product ID"] as? NSNumber)?.intValue
+            ?? 0
+    }
+
+    nonisolated static func bcdDevice(from metadata: [String: Any]) -> Int {
+        (metadata["bcdDevice"] as? NSNumber)?.intValue ?? 0
     }
 
     public func identities(for port: USBCPort) -> [PDIdentity] {

--- a/Sources/WhatCableCore/PortSummary.swift
+++ b/Sources/WhatCableCore/PortSummary.swift
@@ -70,15 +70,15 @@ extension PortSummary {
             bullets.append("Optical cable")
         }
 
-        // Power summary from PD power sources
-        let usbPD = sources.first(where: { $0.name == "USB-PD" })
-        if let usbPD {
-            let maxW = Int((Double(usbPD.maxPowerMW) / 1000).rounded())
-            let hasOptions = !usbPD.options.isEmpty
+        // Power summary from PD or MagSafe power sources.
+        let chargingSource = PowerSource.preferredChargingSource(in: sources)
+        if let chargingSource {
+            let maxW = Int((Double(chargingSource.maxPowerMW) / 1000).rounded())
+            let hasOptions = !chargingSource.options.isEmpty
             if hasOptions && maxW > 0 {
                 bullets.append("Charger advertises up to \(maxW)W")
             }
-            if let win = usbPD.winning {
+            if let win = chargingSource.winning {
                 bullets.append("Currently negotiated: \(win.voltsLabel) @ \(win.ampsLabel) (\(win.wattsLabel))")
             }
         }
@@ -111,8 +111,8 @@ extension PortSummary {
         // Only show a wattage suffix if we have a real number (>0 and we have
         // options, not just the winning PDO).
         let chargerW: Int? = {
-            guard let usbPD, !usbPD.options.isEmpty else { return nil }
-            let w = Int((Double(usbPD.maxPowerMW) / 1000).rounded())
+            guard let chargingSource, !chargingSource.options.isEmpty else { return nil }
+            let w = Int((Double(chargingSource.maxPowerMW) / 1000).rounded())
             return w > 0 ? w : nil
         }()
         let chargerSuffix = chargerW.map { " · \($0)W charger" } ?? ""
@@ -137,7 +137,7 @@ extension PortSummary {
             self.status = .dataDevice
             self.headline = "Slow USB device or charge-only cable" + chargerSuffix
             self.subtitle = "Only USB 2.0 is active. If you expected high speed, the cable may not support it."
-        } else if usbPD != nil {
+        } else if chargingSource != nil {
             self.status = .charging
             self.headline = "Charging" + chargerSuffix
             self.subtitle = "Power is flowing. No data connection."

--- a/Sources/WhatCableCore/PowerSource.swift
+++ b/Sources/WhatCableCore/PowerSource.swift
@@ -61,11 +61,22 @@ public struct PowerSource: Identifiable, Hashable {
     public var portKey: String { "\(parentPortType)/\(parentPortNumber)" }
 }
 
+extension PowerSource {
+    public static func preferredChargingSource(in sources: [PowerSource]) -> PowerSource? {
+        sources.first { $0.name == "USB-PD" }
+            ?? sources.first { $0.name == "Brick ID" }
+    }
+}
+
 extension USBCPort {
     public var portKey: String? {
         guard let n = portNumber else { return nil }
-        // PortType lives in raw properties; pull it out for matching.
-        let rawType = (rawProperties["PortType"]).flatMap { Int($0) } ?? 0x2
+        let rawType: Int
+        if portTypeDescription?.hasPrefix("MagSafe") == true {
+            rawType = 0x11
+        } else {
+            rawType = rawProperties["PortType"].flatMap { Int($0) } ?? 0x2
+        }
         return "\(rawType)/\(n)"
     }
 }

--- a/Sources/WhatCableCore/PowerSourceWatcher.swift
+++ b/Sources/WhatCableCore/PowerSourceWatcher.swift
@@ -86,8 +86,7 @@ public final class PowerSourceWatcher: ObservableObject {
         }
 
         let name = (dict["PowerSourceName"] as? String) ?? "Unknown"
-        let parentType = (dict["ParentPortType"] as? NSNumber)?.intValue ?? 0
-        let parentNum = (dict["ParentPortNumber"] as? NSNumber)?.intValue ?? 0
+        let parent = Self.parentPortIdentity(from: dict)
 
         let options: [PowerOption] = parseOptions(dict["PowerSourceOptions"])
         let winning: PowerOption? = parseOption(dict["WinningPowerSourceOption"])
@@ -95,11 +94,21 @@ public final class PowerSourceWatcher: ObservableObject {
         return PowerSource(
             id: entryID,
             name: name,
-            parentPortType: parentType,
-            parentPortNumber: parentNum,
+            parentPortType: parent.type,
+            parentPortNumber: parent.number,
             options: options,
             winning: winning
         )
+    }
+
+    nonisolated static func parentPortIdentity(from dict: [String: Any]) -> (type: Int, number: Int) {
+        let type = (dict["ParentBuiltInPortType"] as? NSNumber)?.intValue
+            ?? (dict["ParentPortType"] as? NSNumber)?.intValue
+            ?? 0
+        let number = (dict["ParentBuiltInPortNumber"] as? NSNumber)?.intValue
+            ?? (dict["ParentPortNumber"] as? NSNumber)?.intValue
+            ?? Int(((dict["Priority"] as? NSNumber)?.uint64Value ?? 0) & 0xFF)
+        return (type, number)
     }
 
     private func parseOptions(_ value: Any?) -> [PowerOption] {

--- a/Sources/WhatCableCore/USBCPort.swift
+++ b/Sources/WhatCableCore/USBCPort.swift
@@ -140,6 +140,85 @@ public struct USBCPort: Identifiable, Hashable {
         self.busIndex = busIndex
         self.rawProperties = rawProperties
     }
+
+    public func matchingDevices(from devices: [USBDevice]) -> [USBDevice] {
+        guard connectionActive == true else { return [] }
+
+        let portNames = [serviceName, portDescription].compactMap(Self.cleanPortName)
+
+        if !portNames.isEmpty {
+            let directMatches = devices.filter { device in
+                guard let name = device.controllerPortName else { return false }
+                return portNames.contains { portName in
+                    Self.portNameMatches(
+                        portName,
+                        deviceName: name,
+                        portBusIndex: busIndex,
+                        deviceBusIndex: device.busIndex
+                    )
+                }
+            }
+            if !directMatches.isEmpty {
+                return directMatches
+            }
+        }
+
+        guard carriesUSB, let busIndex else { return [] }
+        return devices.filter { device in
+            device.controllerPortName == nil && device.busIndex == busIndex
+        }
+    }
+
+    private var carriesUSB: Bool {
+        if usbActive == true || superSpeedActive == true {
+            return true
+        }
+        return transportsActive.contains { transport in
+            transport == "USB2" || transport == "USB3" || transport == "USB4" || transport == "CIO"
+        }
+    }
+
+    private static func portNameMatches(
+        _ portName: String,
+        deviceName: String,
+        portBusIndex: Int?,
+        deviceBusIndex: Int?
+    ) -> Bool {
+        guard let portName = cleanPortName(portName),
+              let deviceName = cleanPortName(deviceName) else {
+            return false
+        }
+        if portName == deviceName {
+            return true
+        }
+        guard busIndexesAreCompatible(portBusIndex, deviceBusIndex) else {
+            return false
+        }
+        if basePortName(portName) == deviceName {
+            return true
+        }
+        if basePortName(deviceName) == portName {
+            return true
+        }
+        return false
+    }
+
+    private static func cleanPortName(_ value: String?) -> String? {
+        guard let value else { return nil }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private static func basePortName(_ value: String) -> String? {
+        guard let at = value.firstIndex(of: "@") else { return nil }
+        let base = String(value[..<at])
+        return base.hasPrefix("Port-") ? base : nil
+    }
+
+    private static func busIndexesAreCompatible(_ lhs: Int?, _ rhs: Int?) -> Bool {
+        guard let lhs, let rhs else { return true }
+        return lhs == rhs
+    }
 }
 
 // MARK: - Property-dictionary parsing helpers

--- a/Sources/WhatCableCore/USBCPortWatcher.swift
+++ b/Sources/WhatCableCore/USBCPortWatcher.swift
@@ -12,7 +12,7 @@ public final class USBCPortWatcher: ObservableObject {
     // ports — those have no physical connector and just confuse the UI.
     // The exact IOKit class for a USB-C port node varies by chip
     // generation. M3-era machines expose `AppleHPMInterfaceType10/11/12`;
-    // M1 and M2 expose `AppleTCControllerType10`. We register against
+    // M1 and M2 expose `AppleTCControllerType10/11`. We register against
     // both. The `PortTypeDescription` / `Port-` filter in `makePort`
     // drops anything that isn't a real physical port.
     private static let candidateClasses = [
@@ -133,36 +133,51 @@ public final class USBCPortWatcher: ObservableObject {
         )
     }
 
-    /// Walks the IOKit parent chain looking for an `hpm<N>@…` SPMI node and
-    /// returns N. On M3+ machines this N matches the upper byte of the
-    /// associated XHCI controller's `locationID`, giving a bus index that
-    /// can be matched against `USBDevice.busIndex`. Returns `nil` on
-    /// machines that don't expose the hpm hierarchy (M1/M2, where ports
-    /// register directly under `AppleTCControllerType10/11`).
+    /// Walks the IOKit parent chain looking for a controller-index node. M3-era
+    /// Macs commonly expose `hpm<N>`, while M1/M2 machines can expose `atc<N>`
+    /// or `usb-drd<N>`. Direct `UsbIOPort` paths are still preferred.
     private func busIndex(for service: io_service_t) -> Int? {
         var current = service
         IOObjectRetain(current)
         defer { IOObjectRelease(current) }
 
         for _ in 0..<8 {
+            var nameBuf = [CChar](repeating: 0, count: 128)
+            IORegistryEntryGetName(current, &nameBuf)
+            if let n = Self.busIndex(fromRegistryName: String(cString: nameBuf)) {
+                return n
+            }
+
             var parent: io_service_t = 0
             guard IORegistryEntryGetParentEntry(current, kIOServicePlane, &parent) == KERN_SUCCESS else {
-                return nil
+                break
             }
             IOObjectRelease(current)
             current = parent
+        }
 
-            var nameBuf = [CChar](repeating: 0, count: 128)
-            IORegistryEntryGetName(current, &nameBuf)
-            let name = String(cString: nameBuf)
-            if name.hasPrefix("hpm"), let at = name.firstIndex(of: "@") {
-                let digits = name[name.index(name.startIndex, offsetBy: 3)..<at]
-                if let n = Int(digits) {
-                    return n
-                }
+        var locBuf = [CChar](repeating: 0, count: 128)
+        if IORegistryEntryGetLocationInPlane(service, kIOServicePlane, &locBuf) == KERN_SUCCESS,
+           let n = Self.busIndex(fromLocation: String(cString: locBuf)) {
+            return n
+        }
+
+        return nil
+    }
+
+    nonisolated static func busIndex(fromRegistryName name: String) -> Int? {
+        for prefix in ["hpm", "atc", "usb-drd"] where name.hasPrefix(prefix) {
+            let suffix = name.dropFirst(prefix.count)
+            let digits = suffix.prefix { $0.isNumber }
+            if !digits.isEmpty, let n = Int(digits) {
+                return n
             }
         }
         return nil
     }
 
+    nonisolated static func busIndex(fromLocation location: String) -> Int? {
+        guard !location.isEmpty else { return nil }
+        return Int(location, radix: 16)
+    }
 }

--- a/Sources/WhatCableCore/USBCPortWatcher.swift
+++ b/Sources/WhatCableCore/USBCPortWatcher.swift
@@ -12,15 +12,17 @@ public final class USBCPortWatcher: ObservableObject {
     // ports — those have no physical connector and just confuse the UI.
     // The exact IOKit class for a USB-C port node varies by chip
     // generation. M3-era machines expose `AppleHPMInterfaceType10/11/12`;
-    // M1 and M2 expose `AppleTCControllerType10/11`. We register against
-    // both. The `PortTypeDescription` / `Port-` filter in `makePort`
-    // drops anything that isn't a real physical port.
-    private static let candidateClasses = [
+    // M1 and M2 expose `AppleTCControllerType10/11`; M4 Mac mini front
+    // USB-C ports can expose the physical port as `IOPort`. The
+    // `PortTypeDescription` / `Port-` filter in `makePort` drops anything
+    // that isn't a real physical port.
+    nonisolated static let candidateClasses = [
         "AppleHPMInterfaceType10",
         "AppleHPMInterfaceType11",
         "AppleHPMInterfaceType12",
         "AppleTCControllerType10",
-        "AppleTCControllerType11"
+        "AppleTCControllerType11",
+        "IOPort"
     ]
 
     private var notifyPort: IONotificationPortRef?

--- a/Sources/WhatCableCore/USBWatcher.swift
+++ b/Sources/WhatCableCore/USBWatcher.swift
@@ -140,9 +140,7 @@ public final class USBWatcher: ObservableObject {
     ///     kept as a fallback for older topologies that don't expose
     ///     `UsbIOPort` (and for the advanced view).
     ///
-    /// Walks up to 16 hops to handle devices behind a hub: a device behind
-    /// a USB 2.0 hub sits ~5 hops below the `usb-drd*-port-hs` node and
-    /// ~6 below the XHCI controller.
+    /// Walks up to 20 hops to handle devices behind deeper hub chains.
     private func controllerInfo(for service: io_service_t, fallback locationID: UInt32) -> (Int?, String?) {
         var current = service
         IOObjectRetain(current)
@@ -151,7 +149,7 @@ public final class USBWatcher: ObservableObject {
         var portName: String?
         var bus: Int?
 
-        for _ in 0..<16 {
+        for _ in 0..<20 {
             var parent: io_service_t = 0
             guard IORegistryEntryGetParentEntry(current, kIOServicePlane, &parent) == KERN_SUCCESS else {
                 break
@@ -160,9 +158,15 @@ public final class USBWatcher: ObservableObject {
             current = parent
 
             if portName == nil,
-               let raw = IORegistryEntryCreateCFProperty(current, "UsbIOPort" as CFString, kCFAllocatorDefault, 0)?.takeRetainedValue() as? String,
-               let last = raw.split(separator: "/").last {
-                portName = String(last)
+               let raw = IORegistryEntryCreateCFProperty(
+                    current,
+                    "UsbIOPort" as CFString,
+                    kCFAllocatorDefault,
+                    0
+               )?.takeRetainedValue(),
+               let portPath = Self.usbIOPortPath(from: raw),
+               let name = Self.portName(fromUSBIOPortPath: portPath) {
+                portName = name
             }
 
             var classBuf = [CChar](repeating: 0, count: 128)
@@ -182,6 +186,27 @@ public final class USBWatcher: ObservableObject {
             bus = Int((locationID >> 24) & 0xFF)
         }
         return (bus, portName)
+    }
+
+    nonisolated static func busIndex(fromLocationID locationID: UInt32) -> Int {
+        Int((locationID >> 24) & 0xFF)
+    }
+
+    nonisolated static func usbIOPortPath(from value: Any) -> String? {
+        if let string = value as? String {
+            return string
+        }
+        if let data = value as? Data {
+            return String(data: data, encoding: .utf8)?
+                .trimmingCharacters(in: .controlCharacters)
+        }
+        return nil
+    }
+
+    nonisolated static func portName(fromUSBIOPortPath path: String) -> String? {
+        guard let last = path.split(separator: "/").last else { return nil }
+        let name = String(last)
+        return name.hasPrefix("Port-") ? name : nil
     }
 
     private func formatBCD(_ value: UInt16) -> String {

--- a/Tests/WhatCableTests/ChargingDiagnosticTests.swift
+++ b/Tests/WhatCableTests/ChargingDiagnosticTests.swift
@@ -45,6 +45,22 @@ final class ChargingDiagnosticTests: XCTestCase {
         )
     }
 
+    private func brickID(maxW: Int, winningW: Int) -> PowerSource {
+        let winning = PowerOption(voltageMV: 20_000, maxCurrentMA: winningW * 50, maxPowerMW: winningW * 1000)
+        let max = PowerOption(voltageMV: 20_000, maxCurrentMA: maxW * 50, maxPowerMW: maxW * 1000)
+        return PowerSource(
+            id: 2, name: "Brick ID", parentPortType: 0x11, parentPortNumber: 1,
+            options: [max], winning: winning
+        )
+    }
+
+    private func brickIDWithoutPDOs() -> PowerSource {
+        PowerSource(
+            id: 2, name: "Brick ID", parentPortType: 0x11, parentPortNumber: 1,
+            options: [], winning: nil
+        )
+    }
+
     /// Build a cable e-marker identity advertising the given watt rating.
     /// We pin watts via maxV/current bits: 5A @ 20V = 100W, 3A @ 20V = 60W.
     private func cableIdentity(watts: Int) -> PDIdentity {
@@ -155,6 +171,43 @@ final class ChargingDiagnosticTests: XCTestCase {
         )
         if case .fine = diag?.bottleneck { return }
         XCTFail("expected .fine without cable identity, got \(String(describing: diag?.bottleneck))")
+    }
+
+    func testBrickIDPowerSourceIsValidForMagSafe() {
+        let diag = ChargingDiagnostic(
+            port: port,
+            sources: [brickID(maxW: 140, winningW: 140)],
+            identities: []
+        )
+        guard case .fine(let n) = diag?.bottleneck else {
+            return XCTFail("expected .fine from Brick ID source, got \(String(describing: diag?.bottleneck))")
+        }
+        XCTAssertEqual(n, 140)
+    }
+
+    func testUSBPDIsPreferredWhenUSBPDAndBrickIDAreBothPresent() {
+        let diag = ChargingDiagnostic(
+            port: port,
+            sources: [brickID(maxW: 30, winningW: 30), usbPD(maxW: 96, winningW: 96)],
+            identities: [cableIdentity(watts: 100)]
+        )
+        guard case .fine(let n) = diag?.bottleneck else {
+            return XCTFail("expected .fine from USB-PD source, got \(String(describing: diag?.bottleneck))")
+        }
+        XCTAssertEqual(n, 96)
+    }
+
+    func testSystemPowerAdapterWattsFallbackCanSupplyNegotiatedWattage() {
+        let diag = ChargingDiagnostic(
+            port: port,
+            sources: [brickIDWithoutPDOs()],
+            identities: [],
+            systemAdapter: .init(watts: 140, isCharging: nil, source: "AC")
+        )
+        guard case .fine(let n) = diag?.bottleneck else {
+            return XCTFail("expected .fine from system adapter wattage, got \(String(describing: diag?.bottleneck))")
+        }
+        XCTAssertEqual(n, 140)
     }
 
     // MARK: - Edge cases (#15)

--- a/Tests/WhatCableTests/PortSummaryTests.swift
+++ b/Tests/WhatCableTests/PortSummaryTests.swift
@@ -60,6 +60,23 @@ final class PortSummaryTests: XCTestCase {
         )
     }
 
+    private func brickID(maxW: Int, winningW: Int) -> PowerSource {
+        let winning = PowerOption(
+            voltageMV: 20_000,
+            maxCurrentMA: winningW * 50,
+            maxPowerMW: winningW * 1000
+        )
+        let max = PowerOption(
+            voltageMV: 20_000,
+            maxCurrentMA: maxW * 50,
+            maxPowerMW: maxW * 1000
+        )
+        return PowerSource(
+            id: 2, name: "Brick ID", parentPortType: 0x11, parentPortNumber: 1,
+            options: [max], winning: winning
+        )
+    }
+
     // MARK: - Disconnected
 
     func testNothingConnectedHeadline() {
@@ -84,6 +101,13 @@ final class PortSummaryTests: XCTestCase {
         let summary = PortSummary(port: port)
         XCTAssertEqual(summary.status, .charging)
         XCTAssertEqual(summary.headline, "Charging only")
+    }
+
+    func testMagSafeBrickIDSourceCountsAsChargingPower() {
+        let port = makePort(connected: true, active: [], supported: [])
+        let summary = PortSummary(port: port, sources: [brickID(maxW: 140, winningW: 140)])
+        XCTAssertEqual(summary.status, .charging)
+        XCTAssertEqual(summary.headline, "Charging · 140W charger")
     }
 
     // MARK: - USB

--- a/Tests/WhatCableTests/RegistryParsingTests.swift
+++ b/Tests/WhatCableTests/RegistryParsingTests.swift
@@ -1,0 +1,78 @@
+import XCTest
+@testable import WhatCableCore
+
+final class RegistryParsingTests: XCTestCase {
+    func testUSBCPortWatcherExtractsBusIndexAcrossControllerNameShapes() {
+        XCTAssertEqual(USBCPortWatcher.busIndex(fromRegistryName: "hpm4@3"), 4)
+        XCTAssertEqual(USBCPortWatcher.busIndex(fromRegistryName: "atc1"), 1)
+        XCTAssertEqual(USBCPortWatcher.busIndex(fromRegistryName: "usb-drd2@2280000"), 2)
+        XCTAssertNil(USBCPortWatcher.busIndex(fromRegistryName: "hpm@3"))
+        XCTAssertNil(USBCPortWatcher.busIndex(fromRegistryName: "AppleT6000USBXHCI"))
+    }
+
+    func testUSBCPortWatcherExtractsLocationFallbackAsHex() {
+        XCTAssertEqual(USBCPortWatcher.busIndex(fromLocation: "1"), 1)
+        XCTAssertEqual(USBCPortWatcher.busIndex(fromLocation: "0A"), 10)
+        XCTAssertNil(USBCPortWatcher.busIndex(fromLocation: ""))
+        XCTAssertNil(USBCPortWatcher.busIndex(fromLocation: "Port-USB-C"))
+    }
+
+    func testUSBWatcherParsesUsbIOPortStringAndData() {
+        let path = "AppleARMIO/Port-USB-C@1"
+        XCTAssertEqual(USBWatcher.usbIOPortPath(from: path), path)
+
+        let data = Data("AppleARMIO/Port-USB-C@2\u{0}".utf8)
+        XCTAssertEqual(USBWatcher.usbIOPortPath(from: data), "AppleARMIO/Port-USB-C@2")
+    }
+
+    func testUSBWatcherExtractsPortNameAndBusIndex() {
+        XCTAssertEqual(
+            USBWatcher.portName(fromUSBIOPortPath: "AppleARMIO/Port-USB-C@1"),
+            "Port-USB-C@1"
+        )
+        XCTAssertNil(USBWatcher.portName(fromUSBIOPortPath: "AppleARMIO/AppleUSBHostPort@1"))
+        XCTAssertEqual(USBWatcher.busIndex(fromLocationID: 0x0300_0000), 3)
+    }
+
+    func testPowerSourceWatcherHandlesBuiltInParentFieldsAndPriorityFallback() {
+        let builtIn: [String: Any] = [
+            "ParentBuiltInPortType": NSNumber(value: 0x11),
+            "ParentBuiltInPortNumber": NSNumber(value: 2),
+            "ParentPortType": NSNumber(value: 2),
+            "ParentPortNumber": NSNumber(value: 1)
+        ]
+        let builtInParent = PowerSourceWatcher.parentPortIdentity(from: builtIn)
+        XCTAssertEqual(builtInParent.type, 0x11)
+        XCTAssertEqual(builtInParent.number, 2)
+
+        let priority: [String: Any] = [
+            "ParentPortType": NSNumber(value: 0x11),
+            "Priority": NSNumber(value: 0x0201)
+        ]
+        let priorityParent = PowerSourceWatcher.parentPortIdentity(from: priority)
+        XCTAssertEqual(priorityParent.type, 0x11)
+        XCTAssertEqual(priorityParent.number, 1)
+    }
+
+    func testPDIdentityWatcherHandlesMagSafeCCAndSOP1Metadata() {
+        let dict: [String: Any] = [
+            "TransportTypeDescription": "CC",
+            "ParentBuiltInPortType": NSNumber(value: 0x11),
+            "ParentBuiltInPortNumber": NSNumber(value: 1),
+            "Metadata": [
+                "Vendor ID (SOP1)": NSNumber(value: 0x05AC),
+                "Product ID (SOP1)": NSNumber(value: 0x1234),
+                "bcdDevice": NSNumber(value: 0x0100)
+            ]
+        ]
+        let metadata = PDIdentityWatcher.metadataDictionary(from: dict)
+        let parent = PDIdentityWatcher.parentPortIdentity(from: dict)
+
+        XCTAssertEqual(PDIdentityWatcher.endpoint(from: dict), .sopPrime)
+        XCTAssertEqual(parent.type, 0x11)
+        XCTAssertEqual(parent.number, 1)
+        XCTAssertEqual(PDIdentityWatcher.vendorID(from: dict, metadata: metadata), 0x05AC)
+        XCTAssertEqual(PDIdentityWatcher.productID(from: dict, metadata: metadata), 0x1234)
+        XCTAssertEqual(PDIdentityWatcher.bcdDevice(from: metadata), 0x0100)
+    }
+}

--- a/Tests/WhatCableTests/RegistryParsingTests.swift
+++ b/Tests/WhatCableTests/RegistryParsingTests.swift
@@ -2,6 +2,10 @@ import XCTest
 @testable import WhatCableCore
 
 final class RegistryParsingTests: XCTestCase {
+    func testUSBCPortWatcherScansM4MiniFrontPortClass() {
+        XCTAssertTrue(USBCPortWatcher.candidateClasses.contains("IOPort"))
+    }
+
     func testUSBCPortWatcherExtractsBusIndexAcrossControllerNameShapes() {
         XCTAssertEqual(USBCPortWatcher.busIndex(fromRegistryName: "hpm4@3"), 4)
         XCTAssertEqual(USBCPortWatcher.busIndex(fromRegistryName: "atc1"), 1)

--- a/Tests/WhatCableTests/USBPortMatchingTests.swift
+++ b/Tests/WhatCableTests/USBPortMatchingTests.swift
@@ -1,0 +1,154 @@
+import XCTest
+@testable import WhatCableCore
+
+final class USBPortMatchingTests: XCTestCase {
+    func testMatchesDevicesByUsbIOPortPhysicalPortName() {
+        let port = makePort(serviceName: "Port-USB-C@1", busIndex: 2)
+        let matching = makeDevice(id: 1, controllerPortName: "Port-USB-C@1", busIndex: 9)
+        let other = makeDevice(id: 2, controllerPortName: "Port-USB-C@2", busIndex: 2)
+
+        XCTAssertEqual(port.matchingDevices(from: [other, matching]), [matching])
+    }
+
+    func testMatchesDeviceBasePortNameVariation() {
+        let port = makePort(serviceName: "Port-USB-C@1", busIndex: 2)
+        let matching = makeDevice(id: 1, controllerPortName: "Port-USB-C", busIndex: 2)
+
+        XCTAssertEqual(port.matchingDevices(from: [matching]), [matching])
+    }
+
+    func testMatchesPortBaseNameVariation() {
+        let port = makePort(serviceName: "Port-USB-C", busIndex: 2)
+        let matching = makeDevice(id: 1, controllerPortName: "Port-USB-C@1", busIndex: 2)
+
+        XCTAssertEqual(port.matchingDevices(from: [matching]), [matching])
+    }
+
+    func testDecoratedPortNameVariationsDoNotCrossMatch() {
+        let port = makePort(serviceName: "Port-USB-C@1", busIndex: 1)
+        let other = makeDevice(id: 1, controllerPortName: "Port-USB-C@2", busIndex: 2)
+
+        XCTAssertEqual(port.matchingDevices(from: [other]), [])
+    }
+
+    func testDirectUsbIOPortPresencePreventsBusFallback() {
+        let port = makePort(serviceName: "Port-USB-C@1", busIndex: 1)
+        let deviceOnOtherPort = makeDevice(id: 1, controllerPortName: "Port-USB-C@2", busIndex: 1)
+
+        XCTAssertEqual(port.matchingDevices(from: [deviceOnOtherPort]), [])
+    }
+
+    func testFallsBackToBusIndexOnlyForNamelessDevices() {
+        let port = makePort(serviceName: "Port-USB-C@1", busIndex: 3)
+        let namedElsewhere = makeDevice(id: 1, controllerPortName: "Port-USB-C@2", busIndex: 3)
+        let namelessMatch = makeDevice(id: 2, busIndex: 3)
+
+        XCTAssertEqual(port.matchingDevices(from: [namedElsewhere, namelessMatch]), [namelessMatch])
+    }
+
+    func testNoMatchKeyReturnsNoDevicesInsteadOfAllDevices() {
+        let port = makePort(serviceName: "Port-USB-C@1")
+        let devices = [
+            makeDevice(id: 1, busIndex: 1),
+            makeDevice(id: 2, busIndex: 2)
+        ]
+
+        XCTAssertEqual(port.matchingDevices(from: devices), [])
+    }
+
+    func testBusFallbackRequiresUSBTransport() {
+        let port = makePort(
+            serviceName: "Port-MagSafe 3@1",
+            busIndex: 1,
+            usbActive: false,
+            transportsActive: []
+        )
+        let device = makeDevice(id: 1, busIndex: 1)
+
+        XCTAssertEqual(port.matchingDevices(from: [device]), [])
+    }
+
+    func testBusFallbackTreatsCIOAsUSBCapable() {
+        let port = makePort(
+            serviceName: "Port-USB-C@1",
+            busIndex: 1,
+            usbActive: false,
+            transportsActive: ["CIO"]
+        )
+        let device = makeDevice(id: 1, busIndex: 1)
+
+        XCTAssertEqual(port.matchingDevices(from: [device]), [device])
+    }
+
+    func testMagSafePortKeyUsesMagSafePortTypeWithoutRawPortType() {
+        let port = makePort(
+            serviceName: "Port-MagSafe 3@1",
+            portTypeDescription: "MagSafe 3",
+            rawProperties: [:]
+        )
+
+        XCTAssertEqual(port.portKey, "17/1")
+    }
+
+    private func makePort(
+        serviceName: String,
+        portDescription: String? = nil,
+        portTypeDescription: String = "USB-C",
+        busIndex: Int? = nil,
+        usbActive: Bool? = true,
+        transportsActive: [String] = ["USB2"],
+        rawProperties: [String: String] = ["PortType": "2"]
+    ) -> USBCPort {
+        USBCPort(
+            id: UInt64(abs(serviceName.hashValue)),
+            serviceName: serviceName,
+            className: "AppleHPMInterfaceType10",
+            portDescription: portDescription,
+            portTypeDescription: portTypeDescription,
+            portNumber: 1,
+            connectionActive: true,
+            activeCable: nil,
+            opticalCable: nil,
+            usbActive: usbActive,
+            superSpeedActive: nil,
+            usbModeType: nil,
+            usbConnectString: nil,
+            transportsSupported: ["USB2", "USB3"],
+            transportsActive: transportsActive,
+            transportsProvisioned: ["CC"],
+            plugOrientation: nil,
+            plugEventCount: nil,
+            connectionCount: nil,
+            overcurrentCount: nil,
+            pinConfiguration: [:],
+            powerCurrentLimits: [],
+            firmwareVersion: nil,
+            bootFlagsHex: nil,
+            busIndex: busIndex,
+            rawProperties: rawProperties
+        )
+    }
+
+    private func makeDevice(
+        id: UInt64,
+        controllerPortName: String? = nil,
+        busIndex: Int? = nil
+    ) -> USBDevice {
+        USBDevice(
+            id: id,
+            locationID: 0,
+            vendorID: 0,
+            productID: 0,
+            vendorName: nil,
+            productName: "Device \(id)",
+            serialNumber: nil,
+            usbVersion: nil,
+            speedRaw: nil,
+            busPowerMA: nil,
+            currentMA: nil,
+            busIndex: busIndex,
+            controllerPortName: controllerPortName,
+            rawProperties: [:]
+        )
+    }
+}


### PR DESCRIPTION
## Summary

This is the narrow upstreamable slice from `0x687931/whatcable`: Apple Silicon USB-C matching, MagSafe power/source matching, M4 Mac mini front-port discovery, and focused regression tests. It intentionally excludes the fork's menu-bar simplification, updater endpoint changes, release/version bumps, and design assets from PR #29.

## Changes

- Match Apple Silicon port-controller bus indices across `hpm`, `atc`, and `usb-drd` registry node names, with a location fallback.
- Discover M4 Mac mini front USB-C ports that expose the physical port as `IOPort`, while still filtering to real `Port-*` USB-C/MagSafe ports.
- Walk USB device parent chains up to 20 hops and parse `UsbIOPort` when IOKit returns either `String` or `Data`.
- Move USB device-to-port matching into `WhatCableCore` and handle `Port-USB-C` / `Port-USB-C@1` name variants without falling back to every device.
- Support MagSafe `Brick ID` as a charging source and use system adapter wattage as a fallback when per-port PDO wattage is missing.
- Match MagSafe power/identity nodes through `ParentBuiltInPortType` / `ParentBuiltInPortNumber`, priority-byte fallback, `TransportTypeDescription == CC`, and SOP1 vendor/product metadata.
- Treat MagSafe ports as port type `0x11` even when raw `PortType` is absent.

Fixes #33.

## Validation

- `swift test`: 92 tests, 0 failures.
- `bash scripts/build-app.sh`: passes; builds universal app and CLI, verifies the ad-hoc signed app bundle, smoke-tests the GUI and CLI, and creates `dist/WhatCable.zip`.