### PR TITLE
Convert from menu bar app to regular Mac app

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,15 @@
 
 > **What can this USB-C cable actually do?**
 
-A small macOS menu bar app that tells you, in plain English, what each USB-C cable plugged into your Mac can actually do, and **why your Mac might be charging slowly**.
+A small macOS app that tells you, in plain English, what each USB-C cable plugged into your Mac can actually do, and **why your Mac might be charging slowly**.
 
-USB-C hides a lot under one connector. Anything from a USB 2.0 charge-only cable to a 240W / 40 Gbps Thunderbolt 4 cable, all looking identical in your drawer. macOS already exposes the relevant info via IOKit; WhatCable surfaces it as a friendly menu bar popover.
+USB-C hides a lot under one connector. Anything from a USB 2.0 charge-only cable to a 240W / 40 Gbps Thunderbolt 4 cable, all looking identical in your drawer. macOS already exposes the relevant info via IOKit; WhatCable surfaces it as a friendly Mac app.
 
 [![Latest release](https://img.shields.io/github/v/release/darrylmorley/whatcable)](https://github.com/darrylmorley/whatcable/releases/latest)
 [![Platform](https://img.shields.io/badge/platform-macOS%2014%2B-blue)](https://github.com/darrylmorley/whatcable)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 
-![WhatCable popover](docs/screenshot.png)
+![WhatCable](docs/screenshot.png)
 
 ## What it shows
 
@@ -26,16 +26,16 @@ Per port, in plain English:
 - **Connected device identity:** vendor name and product type, decoded from the PD Discover Identity response
 - **Attached USB devices:** storage, hubs, and peripherals listed under the physical port they're plugged into, with their negotiated speed
 - **Active transports:** USB 2 / USB 3 / Thunderbolt / DisplayPort
-- **⌥-click** the menu bar icon (or flip the toggle in Settings) to reveal the underlying IOKit properties for engineers
+- Toggle **Show technical details** in Settings to reveal the underlying IOKit properties for engineers
 
-Click the **gear icon** in the popover header to open Settings, where you can:
+Click the **gear icon** in the window header to open Settings, where you can:
 
 - Hide empty ports
 - Launch at login
-- Run as a regular Dock app instead of a menu bar icon
+- Show technical details for engineers
 - Get notifications when cables are connected or disconnected
 
-Right-click the menu bar icon for **Refresh**, a **Keep window open** toggle (handy for screenshots and demos), **Check for Updates…**, **About**, **WhatCable on GitHub**, and **Quit**.
+Standard Mac menus: **File → Refresh** (⌘R), **WhatCable → Check for Updates…**, **WhatCable → About**, **Help → WhatCable on GitHub**, **WhatCable → Quit** (⌘Q).
 
 ## Install
 
@@ -45,7 +45,7 @@ The app is universal (Apple silicon + Intel), signed with a Developer ID, and no
 
 Requires macOS 14 (Sonoma) or later. Apple Silicon only. On Intel Macs, the USB-C ports are driven by Intel Titan Ridge / JHL9580 Thunderbolt 3 controllers, and the USB-PD state and cable e-marker data WhatCable depends on are not exposed through any public IOKit accessor.
 
-> **Note:** The manual install gives you the menu bar app only. The `whatcable` CLI is bundled inside the `.app` and is not on your PATH by default. If you want to use it from the shell, see the [Command-line interface](#command-line-interface) section below for the one-line symlink. Or install via Homebrew, which sets up the CLI automatically.
+> **Note:** The manual install gives you the app only. The `whatcable` CLI is bundled inside the `.app` and is not on your PATH by default. If you want to use it from the shell, see the [Command-line interface](#command-line-interface) section below for the one-line symlink. Or install via Homebrew, which sets up the CLI automatically.
 
 ### Homebrew
 
@@ -54,11 +54,11 @@ brew tap darrylmorley/whatcable
 brew install --cask whatcable
 ```
 
-This installs the menu bar app and symlinks the `whatcable` CLI into your PATH.
+This installs the app and symlinks the `whatcable` CLI into your PATH.
 
 ## Command-line interface
 
-A `whatcable` binary ships alongside the menu bar app, driven by the same diagnostic engine:
+A `whatcable` binary ships alongside the app, driven by the same diagnostic engine:
 
 ```bash
 whatcable                # human-readable summary of every port
@@ -93,7 +93,7 @@ Cable speed and power decoding follow the USB Power Delivery 3.x spec.
 ## Build from source
 
 ```bash
-swift run WhatCable          # menu bar app
+swift run WhatCable          # Mac app
 swift run whatcable-cli      # CLI
 ```
 
@@ -158,7 +158,7 @@ cp .env.example .env
 
 ## Contributing
 
-Issues and PRs welcome. The code is small and tries to stay readable. Start at [`Sources/WhatCable/ContentView.swift`](Sources/WhatCable/ContentView.swift) for the UI, [`Sources/WhatCableCore/PortSummary.swift`](Sources/WhatCableCore/PortSummary.swift) for the plain-English logic, or [`Sources/WhatCableCore/PDVDO.swift`](Sources/WhatCableCore/PDVDO.swift) for the bit-twiddling. The diagnostic engine lives in `WhatCableCore`, which is shared by the menu bar app and the `whatcable` CLI in `Sources/WhatCableCLI/`.
+Issues and PRs welcome. The code is small and tries to stay readable. Start at [`Sources/WhatCable/ContentView.swift`](Sources/WhatCable/ContentView.swift) for the UI, [`Sources/WhatCableCore/PortSummary.swift`](Sources/WhatCableCore/PortSummary.swift) for the plain-English logic, or [`Sources/WhatCableCore/PDVDO.swift`](Sources/WhatCableCore/PDVDO.swift) for the bit-twiddling. The diagnostic engine lives in `WhatCableCore`, which is shared by the app and the `whatcable` CLI in `Sources/WhatCableCLI/`.
 
 ## Credits
 

--- a/Sources/WhatCable/App.swift
+++ b/Sources/WhatCable/App.swift
@@ -1,6 +1,5 @@
 import SwiftUI
 import AppKit
-import Combine
 import WhatCableCore
 
 @main
@@ -8,25 +7,36 @@ struct WhatCableApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) private var delegate
 
     var body: some Scene {
-        // Headless — UI is owned by AppDelegate (status item + popover, or
-        // a regular window, depending on AppSettings.useMenuBarMode).
-        Settings { EmptyView() }
+        WindowGroup(AppInfo.name) {
+            ContentView()
+                .environmentObject(AppDelegate.refreshSignal)
+                .frame(minWidth: 760, minHeight: 540)
+        }
+        .windowResizability(.contentSize)
+        .commands {
+            CommandGroup(after: .appInfo) {
+                Button("Check for Updates…") {
+                    UpdateChecker.shared.check(silent: false)
+                }
+            }
+            CommandGroup(after: .newItem) {
+                Button("Refresh") {
+                    AppDelegate.refreshSignal.bump()
+                }
+                .keyboardShortcut("r")
+            }
+            CommandGroup(replacing: .help) {
+                Button("\(AppInfo.name) on GitHub") {
+                    NSWorkspace.shared.open(AppInfo.helpURL)
+                }
+            }
+        }
     }
 }
 
 @MainActor
-final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate, NSWindowDelegate {
+final class AppDelegate: NSObject, NSApplicationDelegate {
     static let refreshSignal = RefreshSignal()
-
-    // Menu bar mode
-    private var statusItem: NSStatusItem?
-    private var popover: NSPopover?
-    private var isPinned = false
-
-    // Window mode
-    private var window: NSWindow?
-
-    private var cancellables: Set<AnyCancellable> = []
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         // Override the process name so the About panel and menus use the
@@ -35,202 +45,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate, NSW
 
         NotificationManager.shared.start()
         UpdateChecker.shared.start()
-
-        applyDisplayMode(menuBar: AppSettings.shared.useMenuBarMode)
-
-        // Live-switch when the user flips the toggle in Settings.
-        AppSettings.shared.$useMenuBarMode
-            .removeDuplicates()
-            .dropFirst()
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] menuBar in
-                self?.applyDisplayMode(menuBar: menuBar)
-            }
-            .store(in: &cancellables)
     }
 
     func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
-        // In window mode, closing the window quits the app. In menu bar mode
-        // there's no window to close, so this is harmless either way.
-        !AppSettings.shared.useMenuBarMode
-    }
-
-    // MARK: - Display mode
-
-    private func applyDisplayMode(menuBar: Bool) {
-        if menuBar {
-            tearDownWindowMode()
-            setUpMenuBarMode()
-            NSApp.setActivationPolicy(.accessory)
-        } else {
-            tearDownMenuBarMode()
-            NSApp.setActivationPolicy(.regular)
-            setUpWindowMode()
-            NSApp.activate(ignoringOtherApps: true)
-        }
-    }
-
-    private func setUpMenuBarMode() {
-        if popover == nil {
-            let p = NSPopover()
-            p.behavior = isPinned ? .applicationDefined : .transient
-            p.animates = true
-            p.contentSize = NSSize(width: 760, height: 540)
-            p.contentViewController = NSHostingController(
-                rootView: ContentView().environmentObject(Self.refreshSignal)
-            )
-            p.delegate = self
-            popover = p
-        }
-        if statusItem == nil {
-            let item = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
-            if let button = item.button {
-                button.image = NSImage(systemSymbolName: "cable.connector", accessibilityDescription: AppInfo.name)
-                button.target = self
-                button.action = #selector(handleClick(_:))
-                button.sendAction(on: [.leftMouseUp, .rightMouseUp])
-            }
-            statusItem = item
-        }
-    }
-
-    private func tearDownMenuBarMode() {
-        if let popover, popover.isShown { popover.performClose(nil) }
-        popover = nil
-        if let statusItem {
-            NSStatusBar.system.removeStatusItem(statusItem)
-        }
-        statusItem = nil
-    }
-
-    private func setUpWindowMode() {
-        if let window {
-            window.makeKeyAndOrderFront(nil)
-            return
-        }
-        let host = NSHostingController(
-            rootView: ContentView().environmentObject(Self.refreshSignal)
-        )
-        let w = NSWindow(contentViewController: host)
-        w.title = AppInfo.name
-        w.styleMask = [.titled, .closable, .miniaturizable, .resizable]
-        w.setContentSize(NSSize(width: 760, height: 540))
-        w.center()
-        w.delegate = self
-        w.isReleasedWhenClosed = false
-        window = w
-        w.makeKeyAndOrderFront(nil)
-    }
-
-    private func tearDownWindowMode() {
-        window?.delegate = nil
-        window?.close()
-        window = nil
-    }
-
-    // MARK: - Status item handling (menu bar mode)
-
-    @objc private func handleClick(_ sender: NSStatusBarButton) {
-        guard let event = NSApp.currentEvent else { return }
-        if event.type == .rightMouseUp {
-            showMenu(from: sender)
-        } else {
-            // ⌥-click momentarily reveals the technical-details view,
-            // matching the macOS convention used by Wi-Fi / Volume /
-            // Bluetooth menus. The flag is cleared when the popover closes
-            // (see popoverDidClose), so the persistent preference in
-            // AppSettings is what survives across opens.
-            Self.refreshSignal.optionHeld = event.modifierFlags.contains(.option)
-            togglePopover(from: sender)
-        }
-    }
-
-    private func togglePopover(from button: NSStatusBarButton) {
-        guard let popover else { return }
-        if popover.isShown {
-            popover.performClose(nil)
-        } else {
-            Self.refreshSignal.bump()
-            popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
-            popover.contentViewController?.view.window?.makeKey()
-        }
-    }
-
-    private func showMenu(from button: NSStatusBarButton) {
-        guard let statusItem else { return }
-        let menu = NSMenu()
-        menu.addItem(.init(title: "Refresh", action: #selector(menuRefresh), keyEquivalent: "r"))
-        let pinItem = NSMenuItem(title: "Keep window open", action: #selector(menuTogglePin), keyEquivalent: "p")
-        pinItem.state = isPinned ? .on : .off
-        menu.addItem(pinItem)
-        menu.addItem(.separator())
-        menu.addItem(.init(title: "Check for Updates…", action: #selector(menuCheckUpdates), keyEquivalent: ""))
-        menu.addItem(.init(title: "About \(AppInfo.name)", action: #selector(menuAbout), keyEquivalent: ""))
-        menu.addItem(.init(title: "WhatCable on GitHub", action: #selector(menuHelp), keyEquivalent: ""))
-        menu.addItem(.separator())
-        menu.addItem(.init(title: "Quit \(AppInfo.name)", action: #selector(menuQuit), keyEquivalent: "q"))
-        for item in menu.items where item.action != nil { item.target = self }
-
-        statusItem.menu = menu
-        statusItem.button?.performClick(nil)
-        statusItem.menu = nil
-    }
-
-    @objc private func menuTogglePin() {
-        isPinned.toggle()
-        popover?.behavior = isPinned ? .applicationDefined : .transient
-    }
-
-    @objc private func menuRefresh() {
-        Self.refreshSignal.bump()
-    }
-
-    @objc private func menuAbout() {
-        NSApp.activate(ignoringOtherApps: true)
-        let credits = NSAttributedString(
-            string: "\(AppInfo.tagline)\n\nBuilt by \(AppInfo.credit).",
-            attributes: [
-                .foregroundColor: NSColor.labelColor,
-                .font: NSFont.systemFont(ofSize: 11)
-            ]
-        )
-        NSApp.orderFrontStandardAboutPanel(options: [
-            .applicationName: AppInfo.name,
-            .applicationVersion: AppInfo.version,
-            .version: "",
-            .credits: credits,
-            .init(rawValue: "Copyright"): AppInfo.copyright
-        ])
-    }
-
-    @objc private func menuCheckUpdates() {
-        UpdateChecker.shared.check(silent: false)
-    }
-
-    @objc private func menuHelp() {
-        NSWorkspace.shared.open(AppInfo.helpURL)
-    }
-
-    @objc private func menuQuit() {
-        NSApp.terminate(nil)
-    }
-
-    // MARK: - NSPopoverDelegate
-
-    nonisolated func popoverDidClose(_ notification: Notification) {
-        Task { @MainActor in
-            Self.refreshSignal.optionHeld = false
-        }
+        true
     }
 }
 
 final class RefreshSignal: ObservableObject {
     @Published var tick: Int = 0
-    /// Ephemeral momentary-reveal flag for the advanced IOKit detail view.
-    /// Set true while a ⌥-click on the menu bar icon is opening the popover,
-    /// cleared when the popover closes. The persistent preference lives on
-    /// `AppSettings.showTechnicalDetails`; the effective state is the OR
-    /// of the two.
-    @Published var optionHeld: Bool = false
     func bump() { tick &+= 1 }
 }

--- a/Sources/WhatCable/AppSettings.swift
+++ b/Sources/WhatCable/AppSettings.swift
@@ -13,7 +13,6 @@ final class AppSettings: ObservableObject {
     private enum Keys {
         static let notifyOnChanges = "notifyOnChanges"
         static let hideEmptyPorts = "hideEmptyPorts"
-        static let useMenuBarMode = "useMenuBarMode"
         static let showTechnicalDetails = "showTechnicalDetails"
     }
 
@@ -41,18 +40,7 @@ final class AppSettings: ObservableObject {
         }
     }
 
-    /// When true (default), WhatCable lives in the menu bar with no Dock
-    /// icon. When false, it runs as a regular Dock app with a window.
-    @Published var useMenuBarMode: Bool {
-        didSet {
-            guard useMenuBarMode != oldValue else { return }
-            UserDefaults.standard.set(useMenuBarMode, forKey: Keys.useMenuBarMode)
-        }
-    }
-
-    /// Persistent preference for the advanced IOKit detail view. A momentary
-    /// reveal via ⌥-click on the menu bar icon is layered on top of this in
-    /// `RefreshSignal.optionHeld`.
+    /// Persistent preference for the advanced IOKit detail view.
     @Published var showTechnicalDetails: Bool {
         didSet {
             guard showTechnicalDetails != oldValue else { return }
@@ -66,13 +54,6 @@ final class AppSettings: ObservableObject {
         // Notifications default off — opt in to avoid noise.
         self.notifyOnChanges = UserDefaults.standard.bool(forKey: Keys.notifyOnChanges)
         self.hideEmptyPorts = UserDefaults.standard.bool(forKey: Keys.hideEmptyPorts)
-        // Menu bar mode is the default; UserDefaults returns false for unset
-        // bool keys, so explicitly check presence.
-        if UserDefaults.standard.object(forKey: Keys.useMenuBarMode) == nil {
-            self.useMenuBarMode = true
-        } else {
-            self.useMenuBarMode = UserDefaults.standard.bool(forKey: Keys.useMenuBarMode)
-        }
         self.showTechnicalDetails = UserDefaults.standard.bool(forKey: Keys.showTechnicalDetails)
     }
 

--- a/Sources/WhatCable/ContentView.swift
+++ b/Sources/WhatCable/ContentView.swift
@@ -12,7 +12,7 @@ struct ContentView: View {
     @State private var showSettings = false
 
     private var showAdvanced: Bool {
-        settings.showTechnicalDetails || refresh.optionHeld
+        settings.showTechnicalDetails
     }
 
     var body: some View {

--- a/Sources/WhatCable/SettingsView.swift
+++ b/Sources/WhatCable/SettingsView.swift
@@ -20,12 +20,6 @@ struct SettingsView: View {
                     }
                     section("Behavior") {
                         Toggle("Launch at login", isOn: $settings.launchAtLogin)
-                        Toggle("Show in menu bar", isOn: $settings.useMenuBarMode)
-                        Text(settings.useMenuBarMode
-                             ? "Lives in the menu bar with no Dock icon."
-                             : "Runs as a regular Dock app with a window.")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
                     }
                     section("Notifications") {
                         Toggle("Notify on cable changes", isOn: $settings.notifyOnChanges)

--- a/scripts/build-app.sh
+++ b/scripts/build-app.sh
@@ -97,8 +97,6 @@ cat > "${CONTENTS_DIR}/Info.plist" <<PLIST
     <string>${BUILD_NUMBER}</string>
     <key>LSMinimumSystemVersion</key>
     <string>${MIN_OS}</string>
-    <key>LSUIElement</key>
-    <true/>
     <key>NSHumanReadableCopyright</key>
     <string>© $(date +%Y) Darryl Morley</string>
     <key>NSHighResolutionCapable</key>


### PR DESCRIPTION
Replaces the dual-mode menu-bar/window arrangement with a single-window dock app.

- App.swift: WindowGroup hosts ContentView, with .commands adding Refresh (⌘R), Check for Updates…, and a Help → GitHub link. Drops NSStatusItem, NSPopover, mode switching, and the custom NSMenu/About panel — the standard top-of-screen menu provides those for free. AppDelegate shrinks from ~225 lines to ~20.
- AppSettings: drop useMenuBarMode preference and the Combine subscription that switched modes at runtime.
- SettingsView: drop the "Show in menu bar" toggle.
- ContentView: simplify showAdvanced now that ⌥-click momentary reveal no longer applies (no more menu bar icon to ⌥-click).
- build-app.sh: drop LSUIElement from generated Info.plist so the dock icon shows on launch.
- README: refresh prose to describe a single-window app.