### PR TITLE
Fix temp file leak in Installer

### DIFF
--- a/Sources/WhatCable/Installer.swift
+++ b/Sources/WhatCable/Installer.swift
@@ -31,12 +31,13 @@ final class Installer: ObservableObject {
         state = .downloading
 
         Task {
+            var workDir: URL?
             do {
-                let workDir = try makeWorkDir()
-                let zipURL = try await download(from: downloadURL, into: workDir)
+                workDir = try makeWorkDir()
+                let zipURL = try await download(from: downloadURL, into: workDir!)
 
                 state = .verifying
-                let extractedApp = try unzipAndLocate(zip: zipURL, in: workDir)
+                let extractedApp = try unzipAndLocate(zip: zipURL, in: workDir!)
                 try stripQuarantine(at: extractedApp)
                 try verifySignatureMatches(new: extractedApp, current: Bundle.main.bundleURL)
 
@@ -47,6 +48,9 @@ final class Installer: ObservableObject {
                 try await Task.sleep(nanoseconds: 250_000_000)
                 NSApp.terminate(nil)
             } catch {
+                if let workDir {
+                    try? FileManager.default.removeItem(at: workDir)
+                }
                 Self.log.error("Install failed: \(error.localizedDescription, privacy: .public)")
                 state = .failed(error.localizedDescription)
             }
@@ -126,6 +130,10 @@ final class Installer: ObservableObject {
         rm -rf "$OLD"
         mv "$NEW" "$OLD"
         open "$OLD"
+
+        # Clean up this script and the temp directory.
+        rm -rf "$(dirname "$0")"
+        rm -f "$0"
         """
 
         let scriptURL = FileManager.default.temporaryDirectory


### PR DESCRIPTION
## Summary
- Clean up the temporary work directory when the install fails (download, unzip, or verification error).
- Self-delete the swap script and its parent temp directory after a successful app swap.

## Why
The `Installer` creates a temporary directory in `/tmp` for each update attempt (downloaded zip + extracted app). On failure this directory was never removed, leaking disk space. On success the swap shell script was left behind indefinitely.

## Test plan
- [x] `swift build` succeeds
- [ ] Verify that cancelling an update (e.g. signature mismatch) removes the temp directory
- [ ] Verify that a successful update removes the swap script and temp directory after the swap completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)