### PR TITLE
Detect cable e-markers via SOP' / SOP'' IOKit classes (#35)

### DIFF
--- a/Sources/WhatCable/ContentView.swift
+++ b/Sources/WhatCable/ContentView.swift
@@ -497,7 +497,7 @@ struct AdvancedPortDetails: View {
         VStack(alignment: .leading, spacing: 8) {
             group("Connection") {
                 row("Active", bool(port.connectionActive))
-                row("E-marker chip", bool(port.activeCable))
+                row("Active cable electronics", bool(port.activeCable))
                 row("Optical", bool(port.opticalCable))
                 row("USB active", bool(port.usbActive))
                 row("SuperSpeed", bool(port.superSpeedActive))

--- a/Sources/WhatCableCore/PortSummary.swift
+++ b/Sources/WhatCableCore/PortSummary.swift
@@ -47,7 +47,15 @@ extension PortSummary {
         let hasUSB2 = active.contains("USB2")
         let hasTB = active.contains("CIO") // Thunderbolt = Converged I/O
         let hasDP = active.contains("DisplayPort")
-        let hasEmarker = port.activeCable == true
+        // E-marker presence is "did the cable respond to Discover Identity?",
+        // which means we have an SOP'/SOP'' PDIdentity for this port. The
+        // port's `ActiveCable` IOKit flag means "this cable contains active
+        // signal-conditioning electronics", which is unrelated: passive
+        // cables (including high-end USB4 / 240W EPR cables) carry e-markers
+        // too.
+        let hasEmarker = identities.contains {
+            $0.endpoint == .sopPrime || $0.endpoint == .sopDoublePrime
+        }
         let portLabel = port.portDescription ?? port.serviceName
 
         if !connected {

--- a/Sources/WhatCableDarwinBackend/PDIdentityWatcher.swift
+++ b/Sources/WhatCableDarwinBackend/PDIdentityWatcher.swift
@@ -3,16 +3,22 @@ import Foundation
 import IOKit
 import WhatCableCore
 
-/// Watches `IOPortTransportComponentCCUSBPDSOP` services. These hold the PD
-/// Discover Identity response for the port partner (SOP) and any e-marker
-/// chips on the cable (SOP', SOP'').
+/// Watches `IOPortTransportComponentCCUSBPDSOP` (port partner) and
+/// `IOPortTransportComponentCCUSBPDSOPp` (cable e-marker SOP') services.
+/// macOS exposes these as separate IOKit classes, so we have to match both.
+/// Some hardware also exposes SOP'' as a third class.
 @MainActor
 public final class PDIdentityWatcher: ObservableObject {
     @Published public private(set) var identities: [PDIdentity] = []
 
+    private static let matchedClasses = [
+        "IOPortTransportComponentCCUSBPDSOP",
+        "IOPortTransportComponentCCUSBPDSOPp",
+        "IOPortTransportComponentCCUSBPDSOPpp",
+    ]
+
     private var notifyPort: IONotificationPortRef?
-    private var addedIter: io_iterator_t = 0
-    private var removedIter: io_iterator_t = 0
+    private var iterators: [io_iterator_t] = []
 
     public init() {}
 
@@ -35,31 +41,39 @@ public final class PDIdentityWatcher: ObservableObject {
             Task { @MainActor in w.handleRemoved(iter) }
         }
 
-        IOServiceAddMatchingNotification(port, kIOMatchedNotification,
-            IOServiceMatching("IOPortTransportComponentCCUSBPDSOP"),
-            added, selfPtr, &addedIter)
-        handleAdded(addedIter)
+        for className in Self.matchedClasses {
+            var addedIter: io_iterator_t = 0
+            IOServiceAddMatchingNotification(port, kIOMatchedNotification,
+                IOServiceMatching(className),
+                added, selfPtr, &addedIter)
+            handleAdded(addedIter)
+            iterators.append(addedIter)
 
-        IOServiceAddMatchingNotification(port, kIOTerminatedNotification,
-            IOServiceMatching("IOPortTransportComponentCCUSBPDSOP"),
-            removed, selfPtr, &removedIter)
-        handleRemoved(removedIter)
+            var removedIter: io_iterator_t = 0
+            IOServiceAddMatchingNotification(port, kIOTerminatedNotification,
+                IOServiceMatching(className),
+                removed, selfPtr, &removedIter)
+            handleRemoved(removedIter)
+            iterators.append(removedIter)
+        }
     }
 
     public func stop() {
-        if addedIter != 0 { IOObjectRelease(addedIter); addedIter = 0 }
-        if removedIter != 0 { IOObjectRelease(removedIter); removedIter = 0 }
+        for iter in iterators where iter != 0 { IOObjectRelease(iter) }
+        iterators.removeAll()
         if let p = notifyPort { IONotificationPortDestroy(p); notifyPort = nil }
         identities.removeAll()
     }
 
     public func refresh() {
         identities.removeAll()
-        var iter: io_iterator_t = 0
-        if IOServiceGetMatchingServices(kIOMainPortDefault,
-            IOServiceMatching("IOPortTransportComponentCCUSBPDSOP"), &iter) == KERN_SUCCESS {
-            handleAdded(iter)
-            IOObjectRelease(iter)
+        for className in Self.matchedClasses {
+            var iter: io_iterator_t = 0
+            if IOServiceGetMatchingServices(kIOMainPortDefault,
+                IOServiceMatching(className), &iter) == KERN_SUCCESS {
+                handleAdded(iter)
+                IOObjectRelease(iter)
+            }
         }
     }
 
@@ -92,7 +106,12 @@ public final class PDIdentityWatcher: ObservableObject {
             return nil
         }
 
-        let endpoint = Self.endpoint(from: dict)
+        var classNameBuf = [CChar](repeating: 0, count: 128)
+        let className: String? = (IOObjectGetClass(service, &classNameBuf) == KERN_SUCCESS)
+            ? String(cString: classNameBuf)
+            : nil
+
+        let endpoint = Self.endpoint(from: dict, className: className)
         let parent = Self.parentPortIdentity(from: dict)
         let specRev = (dict["Specification Revision"] as? NSNumber)?.intValue ?? 0
 
@@ -127,11 +146,20 @@ public final class PDIdentityWatcher: ObservableObject {
             ?? "Unknown"
     }
 
-    nonisolated static func endpoint(from dict: [String: Any]) -> PDIdentity.Endpoint {
+    nonisolated static func endpoint(from dict: [String: Any], className: String? = nil) -> PDIdentity.Endpoint {
         if let name = (dict["ComponentName"] as? String)
             ?? (dict["AddressDescription"] as? String)
             ?? (dict["Address Description"] as? String) {
             return PDIdentity.Endpoint(rawValue: name) ?? .unknown
+        }
+        // The IOKit class name is the most reliable signal: macOS exposes
+        // SOP' as a separate `IOPortTransportComponentCCUSBPDSOPp` class
+        // (and SOP'' as `...SOPpp`), even when ComponentName is absent.
+        switch className {
+        case "IOPortTransportComponentCCUSBPDSOP": return .sop
+        case "IOPortTransportComponentCCUSBPDSOPp": return .sopPrime
+        case "IOPortTransportComponentCCUSBPDSOPpp": return .sopDoublePrime
+        default: break
         }
         // MagSafe CC transport has no ComponentName; map "CC" only from
         // TransportTypeDescription so a future node with ComponentName="CC"
@@ -139,6 +167,7 @@ public final class PDIdentityWatcher: ObservableObject {
         switch dict["TransportTypeDescription"] as? String {
         case "SOP": return .sop
         case "SOP'", "CC": return .sopPrime
+        case "SOP''": return .sopDoublePrime
         default: return .unknown
         }
     }

--- a/Tests/WhatCableCoreTests/PortSummaryTests.swift
+++ b/Tests/WhatCableCoreTests/PortSummaryTests.swift
@@ -155,8 +155,14 @@ final class PortSummaryTests: XCTestCase {
     // MARK: - Bullets
 
     func testEmarkerCableProducesEmarkerBullet() {
-        let port = makePort(active: ["USB3"], superSpeed: true, emarker: true)
-        let summary = PortSummary(port: port)
+        let port = makePort(active: ["USB3"], superSpeed: true)
+        let cable = PDIdentity(
+            id: 99, endpoint: .sopPrime,
+            parentPortType: 0, parentPortNumber: 0,
+            vendorID: 0, productID: 0, bcdDevice: 0,
+            vdos: [], specRevision: 0
+        )
+        let summary = PortSummary(port: port, identities: [cable])
         XCTAssertTrue(
             summary.bullets.contains(where: { $0.contains("e-marker") && $0.contains("advertises") }),
             "expected an e-marker bullet, got bullets: \(summary.bullets)"


### PR DESCRIPTION
Closes #35.

## Summary
- `PDIdentityWatcher` now subscribes to `IOPortTransportComponentCCUSBPDSOP`, `...SOPp` (cable e-marker SOP'), and `...SOPpp` (SOP'') services. Previously only the SOP class was matched, so passive e-marked cables (including the CalDigit TS4 reported in the issue) appeared to have no e-marker at all.
- Endpoint detection uses the IOKit class name as a reliable fallback when `ComponentName` is absent, while keeping the existing MagSafe `CC` mapping.
- `PortSummary.hasEmarker` now derives from the presence of an SOP'/SOP'' identity rather than `port.activeCable`. The IOKit `ActiveCable` flag means "active signal-conditioning electronics", not "has an e-marker chip"; passive e-marked cables were being misreported as basic cables.
- The advanced-details UI row was relabelled from "E-marker chip" to "Active cable electronics" to match what the underlying flag actually represents.

## Credit
Root-cause analysis from @coder543 in the issue thread.

## Test plan
- [x] `swift build` succeeds.
- [x] `swift test` (103 tests) passes; the e-marker bullet test was updated to pass an SOP' identity instead of relying on `activeCable`.
- [ ] Manual verification on the reporter's cable (CalDigit TS4): now reports an e-marker.
