### PR TITLE
Add --tb-debug CLI flag for Thunderbolt fabric data gathering

### DIFF
--- a/Sources/WhatCableCLI/WhatCableCLI.swift
+++ b/Sources/WhatCableCLI/WhatCableCLI.swift
@@ -18,13 +18,18 @@ struct WhatCableCLI {
             return
         }
 
+        if args.contains("--tb-debug") {
+            print(ThunderboltProbe.dump(), terminator: "")
+            return
+        }
+
         let showRaw = args.contains("--raw")
         let asJSON = args.contains("--json")
         let watch = args.contains("--watch")
         let report = args.contains("--report")
 
         // Reject unknown flags so typos don't silently produce default output.
-        let knownFlags: Set<String> = ["--raw", "--json", "--watch", "--report", "-h", "--help", "--version"]
+        let knownFlags: Set<String> = ["--raw", "--json", "--watch", "--report", "--tb-debug", "-h", "--help", "--version"]
         for arg in args where arg.hasPrefix("-") && !knownFlags.contains(arg) {
             FileHandle.standardError.write(Data("whatcable: unknown option \(arg)\n".utf8))
             FileHandle.standardError.write(Data(helpText.utf8))
@@ -63,6 +68,8 @@ struct WhatCableCLI {
       --json         Output as JSON instead of human-readable text
       --raw          Include raw IOKit properties for each port
       --report       Print a cable report (markdown + GitHub URL) and exit
+      --tb-debug     Dump the IOThunderboltSwitch tree (for contributors helping
+                     us design the Thunderbolt fabric feature). See issue tracker.
       --version      Print version and exit
       -h, --help     Show this help and exit
 

--- a/Sources/WhatCableDarwinBackend/ThunderboltProbe.swift
+++ b/Sources/WhatCableDarwinBackend/ThunderboltProbe.swift
@@ -1,0 +1,131 @@
+import Foundation
+import IOKit
+import WhatCableCore
+
+/// Read-only IOKit walker that dumps the IOThunderboltSwitch tree as plain
+/// text. Used by `whatcable --tb-debug` to gather field shapes from real
+/// Thunderbolt hardware so we can design the rendering layer with evidence
+/// rather than guesses. No interpretation, no rendering, just a paste-ready
+/// dump of every property on every switch and port.
+public enum ThunderboltProbe {
+    public static func dump() -> String {
+        var output = ""
+        output += "# WhatCable Thunderbolt probe\n"
+        output += "# whatcable \(AppInfo.version) on macOS \(ProcessInfo.processInfo.operatingSystemVersionString)\n"
+        output += "# Generated \(ISO8601DateFormatter().string(from: Date()))\n"
+        output += "\n"
+
+        // IOThunderboltSwitch is the abstract parent class. Matching against it
+        // catches all subclass variants (IOThunderboltSwitchType7, USB4, etc.).
+        let matching = IOServiceMatching("IOThunderboltSwitch")
+        var iter: io_iterator_t = 0
+        let kr = IOServiceGetMatchingServices(kIOMainPortDefault, matching, &iter)
+        guard kr == KERN_SUCCESS else {
+            output += "ERROR: IOServiceGetMatchingServices returned \(kr)\n"
+            return output
+        }
+        defer { IOObjectRelease(iter) }
+
+        var switchCount = 0
+        while case let service = IOIteratorNext(iter), service != 0 {
+            defer { IOObjectRelease(service) }
+            switchCount += 1
+            output += dumpSwitch(service, index: switchCount)
+            output += "\n"
+        }
+
+        if switchCount == 0 {
+            output += "No IOThunderboltSwitch services found.\n"
+            output += "(This is unexpected on Apple Silicon — please flag in the issue.)\n"
+        } else {
+            output += "# \(switchCount) switch(es) total\n"
+        }
+        return output
+    }
+
+    private static func dumpSwitch(_ service: io_service_t, index: Int) -> String {
+        var output = ""
+        let className = ioClassName(service) ?? "<unknown class>"
+        output += "## Switch #\(index): \(className)\n"
+
+        if let props = ioProperties(service) {
+            output += renderProperties(props, indent: "  ")
+        }
+
+        // Walk port children.
+        var childIter: io_iterator_t = 0
+        let kr = IORegistryEntryGetChildIterator(service, kIOServicePlane, &childIter)
+        guard kr == KERN_SUCCESS else {
+            output += "  ERROR: child iterator failed (\(kr))\n"
+            return output
+        }
+        defer { IOObjectRelease(childIter) }
+
+        var portIndex = 0
+        while case let child = IOIteratorNext(childIter), child != 0 {
+            defer { IOObjectRelease(child) }
+            let childClass = ioClassName(child) ?? "<unknown>"
+            // Filter to IOThunderboltPort and its subclasses. Skip the adapter
+            // children (AppleThunderboltUSBDownAdapter etc.) — they're driver
+            // matches, not link-state carriers.
+            guard childClass.contains("Port") else { continue }
+            portIndex += 1
+            output += "\n  ### Port @\(portIndex): \(childClass)\n"
+            if let props = ioProperties(child) {
+                output += renderProperties(props, indent: "    ")
+            }
+        }
+        return output
+    }
+
+    private static func ioClassName(_ service: io_service_t) -> String? {
+        var buf = [CChar](repeating: 0, count: 128)
+        let kr = IOObjectGetClass(service, &buf)
+        guard kr == KERN_SUCCESS else { return nil }
+        return String(cString: buf)
+    }
+
+    private static func ioProperties(_ service: io_service_t) -> [String: Any]? {
+        var unmanaged: Unmanaged<CFMutableDictionary>?
+        let kr = IORegistryEntryCreateCFProperties(service, &unmanaged, kCFAllocatorDefault, 0)
+        guard kr == KERN_SUCCESS, let dict = unmanaged?.takeRetainedValue() else { return nil }
+        return dict as? [String: Any]
+    }
+
+    private static func renderProperties(_ props: [String: Any], indent: String) -> String {
+        // Sort keys for stable, paste-friendly output. Skip noisy fields that
+        // don't help with the design (IOPowerManagement dict, large binary blobs
+        // that aren't useful without decoding).
+        let skip: Set<String> = ["IOPowerManagement"]
+        var output = ""
+        for key in props.keys.sorted() where !skip.contains(key) {
+            let value = props[key]!
+            output += "\(indent)\(key) = \(renderValue(value))\n"
+        }
+        return output
+    }
+
+    private static func renderValue(_ value: Any) -> String {
+        switch value {
+        case let s as String:
+            return "\"\(s)\""
+        case let n as NSNumber:
+            return n.stringValue
+        case let b as Bool:
+            return b ? "true" : "false"
+        case let data as Data:
+            // Hex dump short blobs; truncate long ones.
+            let hex = data.prefix(64).map { String(format: "%02x", $0) }.joined()
+            let suffix = data.count > 64 ? "...(\(data.count) bytes total)" : ""
+            return "<\(hex)\(suffix)>"
+        case let arr as [Any]:
+            let parts = arr.map { renderValue($0) }
+            return "[\(parts.joined(separator: ", "))]"
+        case let dict as [String: Any]:
+            let parts = dict.keys.sorted().map { "\($0)=\(renderValue(dict[$0]!))" }
+            return "{\(parts.joined(separator: ", "))}"
+        default:
+            return "\(value)"
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a `--tb-debug` CLI flag that dumps the full `IOThunderboltSwitch` tree as plain text.
- Read-only IOKit walker, no rendering or interpretation. Designed to be paste-friendly for GitHub issue comments.
- Foundation for the planned Thunderbolt fabric feature: we need real-hardware samples from contributors with TB docks, displays, SSDs, eGPUs, and daisy-chains before we can design the rendering layer with confidence.

## Why

Probing on the dev machine (M5 Pro, no TB devices on hand) confirmed that `IOThunderboltPort` link-state fields (`Current Link Speed`, `Current Link Width`, `Link Bandwidth`) only populate for TB-protocol partners. USB-only devices flow through the controller's internal USB Adapter without lighting these up. Without a real TB device to test against, any rendering we wrote would be guesswork on the meaning of the encoded values.

This flag lets the community help fill that gap. Once merged and shipped (planned for 0.6.1), a follow-up GitHub issue will ask for testers to run the probe and paste output.

## Test plan

- [x] `swift test` (103 tests pass)
- [x] `.build/debug/whatcable-cli --tb-debug` produces a clean, paste-friendly dump on the dev M5 Pro
- [x] Help text includes the new flag
- [x] Unknown-flag rejection still works (flag added to `knownFlags` set)
