### PR TITLE
Add cable trust signals (Phase 1)

### DIFF
--- a/Sources/WhatCable/ContentView.swift
+++ b/Sources/WhatCable/ContentView.swift
@@ -406,6 +406,12 @@ struct PortCard: View {
             }
 
             if let cable = cableEmarker {
+                let trust = CableTrustReport(identity: cable)
+                if !trust.isEmpty {
+                    TrustFlagsCard(flags: trust.flags)
+                        .padding(.leading, 48)
+                }
+
                 HStack {
                     Spacer()
                     Button {
@@ -544,6 +550,34 @@ struct AdvancedPortDetails: View {
     private func bool(_ v: Bool?) -> String {
         guard let v else { return "—" }
         return v ? "Yes" : "No"
+    }
+}
+
+private struct TrustFlagsCard: View {
+    let flags: [TrustFlag]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 6) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundStyle(.orange)
+                Text("Cable trust signals")
+                    .font(.caption).bold()
+                    .foregroundStyle(.secondary)
+            }
+            ForEach(flags, id: \.code) { flag in
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(flag.title).font(.callout).bold()
+                    Text(flag.detail)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+        }
+        .padding(8)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color.orange.opacity(0.12), in: RoundedRectangle(cornerRadius: 8))
     }
 }
 

--- a/Sources/WhatCableCore/CableTrustReport.swift
+++ b/Sources/WhatCableCore/CableTrustReport.swift
@@ -1,0 +1,89 @@
+import Foundation
+
+/// Heuristic flags raised against a cable's e-marker data. We trust the
+/// e-marker by design, so wording is hedged: "looks unusual," "common
+/// counterfeit pattern," never "this cable is fake."
+public struct CableTrustReport: Hashable {
+    public let flags: [TrustFlag]
+
+    public var isEmpty: Bool { flags.isEmpty }
+
+    public init(flags: [TrustFlag]) {
+        self.flags = flags
+    }
+
+    /// Build a report from an SOP' / SOP'' e-marker identity. Returns an
+    /// empty report when no flags fire so callers can decide whether to
+    /// render anything.
+    public init(identity: PDIdentity) {
+        guard identity.endpoint == .sopPrime || identity.endpoint == .sopDoublePrime else {
+            self.flags = []
+            return
+        }
+
+        var collected: [TrustFlag] = []
+
+        if identity.vendorID == 0 {
+            collected.append(.zeroVendorID)
+        }
+
+        if let cv = identity.cableVDO {
+            for warning in cv.decodeWarnings {
+                switch warning {
+                case .reservedSpeedEncoding(let bits):
+                    collected.append(.reservedSpeedEncoding(bits))
+                case .reservedCurrentEncoding(let bits):
+                    collected.append(.reservedCurrentEncoding(bits))
+                }
+            }
+        }
+
+        self.flags = collected
+    }
+}
+
+public enum TrustFlag: Hashable {
+    /// E-marker present but vendor ID is zero. Legitimate USB-IF members
+    /// have non-zero VIDs, so this is a common counterfeit signature.
+    case zeroVendorID
+
+    /// Cable VDO speed field uses a reserved bit pattern (5, 6, or 7).
+    /// Real e-marker chips shouldn't emit reserved values.
+    case reservedSpeedEncoding(Int)
+
+    /// Cable VDO current field uses the reserved bit pattern (3).
+    case reservedCurrentEncoding(Int)
+
+    /// Short identifier suitable for JSON output. Stable across releases.
+    public var code: String {
+        switch self {
+        case .zeroVendorID: return "zeroVendorID"
+        case .reservedSpeedEncoding: return "reservedSpeedEncoding"
+        case .reservedCurrentEncoding: return "reservedCurrentEncoding"
+        }
+    }
+
+    /// One-line headline for UI surfacing.
+    public var title: String {
+        switch self {
+        case .zeroVendorID:
+            return "E-marker reports no vendor identity"
+        case .reservedSpeedEncoding:
+            return "E-marker uses a reserved data-speed value"
+        case .reservedCurrentEncoding:
+            return "E-marker uses a reserved current-rating value"
+        }
+    }
+
+    /// Longer hedged explanation, safe to show next to the title.
+    public var detail: String {
+        switch self {
+        case .zeroVendorID:
+            return "Legitimate USB-IF members ship cables with a non-zero vendor ID. A zeroed VID is a common counterfeit signature."
+        case .reservedSpeedEncoding(let bits):
+            return "The cable's e-marker reports speed value \(bits), which is reserved by the USB-PD spec. Real e-marker chips should not emit reserved values."
+        case .reservedCurrentEncoding(let bits):
+            return "The cable's e-marker reports current value \(bits), which is reserved by the USB-PD spec. Real e-marker chips should not emit reserved values."
+        }
+    }
+}

--- a/Sources/WhatCableCore/JSONFormatter.swift
+++ b/Sources/WhatCableCore/JSONFormatter.swift
@@ -124,6 +124,7 @@ private struct CableDTO: Codable {
     let maxVolts: Int?
     let maxWatts: Int?
     let type: String?
+    let trustFlags: [TrustFlagDTO]?
 
     init(identity: PDIdentity) {
         self.endpoint = identity.endpoint.rawValue
@@ -142,6 +143,21 @@ private struct CableDTO: Codable {
             self.maxWatts = nil
             self.type = nil
         }
+
+        let report = CableTrustReport(identity: identity)
+        self.trustFlags = report.isEmpty ? nil : report.flags.map(TrustFlagDTO.init)
+    }
+}
+
+private struct TrustFlagDTO: Codable {
+    let code: String
+    let title: String
+    let detail: String
+
+    init(_ flag: TrustFlag) {
+        self.code = flag.code
+        self.title = flag.title
+        self.detail = flag.detail
     }
 }
 

--- a/Sources/WhatCableCore/PDVDO.swift
+++ b/Sources/WhatCableCore/PDVDO.swift
@@ -111,6 +111,11 @@ public enum PDVDO {
         case other = 2
     }
 
+    public enum DecodeWarning: Hashable {
+        case reservedSpeedEncoding(Int)
+        case reservedCurrentEncoding(Int)
+    }
+
     public struct CableVDO: Hashable {
         public let speed: CableSpeed
         public let current: CableCurrent
@@ -120,6 +125,7 @@ public enum PDVDO {
         public let vbusThroughCable: Bool
         /// Encoded "Maximum VBUS Voltage" field. 0=20V, 1=30V, 2=40V, 3=50V.
         public let maxVoltageEncoded: Int
+        public let decodeWarnings: [DecodeWarning]
 
         public var maxVolts: Int {
             switch maxVoltageEncoded {
@@ -134,12 +140,21 @@ public enum PDVDO {
 
     public static func decodeCableVDO(_ vdo: UInt32, isActive: Bool) -> CableVDO {
         let speedBits = Int(vdo & 0b111)
-        let speed = CableSpeed(rawValue: speedBits) ?? .usb20
+        let decodedSpeed = CableSpeed(rawValue: speedBits)
+        let speed = decodedSpeed ?? .usb20
         let vbusThrough = (vdo >> 4) & 1 == 1
         let currentBits = Int((vdo >> 5) & 0b11)
-        let current = CableCurrent(rawValue: currentBits) ?? .usbDefault
+        let decodedCurrent = CableCurrent(rawValue: currentBits)
+        let current = decodedCurrent ?? .usbDefault
         let maxV = Int((vdo >> 9) & 0b11)
         let cableType: CableType = isActive ? .active : .passive
+        var warnings: [DecodeWarning] = []
+        if decodedSpeed == nil {
+            warnings.append(.reservedSpeedEncoding(speedBits))
+        }
+        if decodedCurrent == nil {
+            warnings.append(.reservedCurrentEncoding(currentBits))
+        }
 
         let volts: Double
         switch maxV {
@@ -157,7 +172,8 @@ public enum PDVDO {
             maxWatts: watts,
             cableType: cableType,
             vbusThroughCable: vbusThrough,
-            maxVoltageEncoded: maxV
+            maxVoltageEncoded: maxV,
+            decodeWarnings: warnings
         )
     }
 

--- a/Tests/WhatCableCoreTests/CableTrustReportTests.swift
+++ b/Tests/WhatCableCoreTests/CableTrustReportTests.swift
@@ -1,0 +1,78 @@
+import XCTest
+@testable import WhatCableCore
+
+final class CableTrustReportTests: XCTestCase {
+
+    /// Build a synthetic SOP' identity. `cableVDO` is the raw VDO[3].
+    private func cableIdentity(
+        vendorID: Int = 0x05AC,
+        endpoint: PDIdentity.Endpoint = .sopPrime,
+        cableVDO: UInt32 = (0b10 << 5) | 0b011 // USB4 Gen 3, 5A
+    ) -> PDIdentity {
+        PDIdentity(
+            id: 1,
+            endpoint: endpoint,
+            parentPortType: 0,
+            parentPortNumber: 0,
+            vendorID: vendorID,
+            productID: 0x1234,
+            bcdDevice: 0,
+            vdos: [
+                (3 << 27) | UInt32(vendorID),
+                0,
+                0,
+                cableVDO
+            ],
+            specRevision: 3
+        )
+    }
+
+    func testCleanCableProducesNoFlags() {
+        let report = CableTrustReport(identity: cableIdentity())
+        XCTAssertTrue(report.isEmpty)
+        XCTAssertEqual(report.flags, [])
+    }
+
+    func testNonCableEndpointProducesNoFlags() {
+        // SOP (port partner) shouldn't be evaluated as a cable.
+        let report = CableTrustReport(identity: cableIdentity(vendorID: 0, endpoint: .sop))
+        XCTAssertTrue(report.isEmpty)
+    }
+
+    func testZeroVendorIDFlags() {
+        let report = CableTrustReport(identity: cableIdentity(vendorID: 0))
+        XCTAssertEqual(report.flags, [.zeroVendorID])
+    }
+
+    func testReservedSpeedEncodingFlags() {
+        // speed=5 (reserved), current=1 (3A)
+        let vdo = UInt32(0b101) | UInt32(1 << 5)
+        let report = CableTrustReport(identity: cableIdentity(cableVDO: vdo))
+        XCTAssertEqual(report.flags, [.reservedSpeedEncoding(5)])
+    }
+
+    func testReservedCurrentEncodingFlags() {
+        // speed=1 (USB 3.2 Gen1), current=3 (reserved)
+        let vdo = UInt32(0b001) | UInt32(3 << 5)
+        let report = CableTrustReport(identity: cableIdentity(cableVDO: vdo))
+        XCTAssertEqual(report.flags, [.reservedCurrentEncoding(3)])
+    }
+
+    func testAllThreeFlagsTogether() {
+        // VID=0, speed=6 (reserved), current=3 (reserved)
+        let vdo = UInt32(0b110) | UInt32(3 << 5)
+        let report = CableTrustReport(identity: cableIdentity(vendorID: 0, cableVDO: vdo))
+        XCTAssertEqual(report.flags, [
+            .zeroVendorID,
+            .reservedSpeedEncoding(6),
+            .reservedCurrentEncoding(3)
+        ])
+    }
+
+    func testFlagCodesAreStable() {
+        // Codes are part of the JSON contract; pin them.
+        XCTAssertEqual(TrustFlag.zeroVendorID.code, "zeroVendorID")
+        XCTAssertEqual(TrustFlag.reservedSpeedEncoding(5).code, "reservedSpeedEncoding")
+        XCTAssertEqual(TrustFlag.reservedCurrentEncoding(3).code, "reservedCurrentEncoding")
+    }
+}

--- a/Tests/WhatCableCoreTests/JSONFormatterTests.swift
+++ b/Tests/WhatCableCoreTests/JSONFormatterTests.swift
@@ -172,6 +172,64 @@ final class JSONFormatterTests: XCTestCase {
         )
     }
 
+    // MARK: - Trust flags
+
+    private func cableIdentity(vendorID: Int, cableVDO: UInt32) -> PDIdentity {
+        PDIdentity(
+            id: 1,
+            endpoint: .sopPrime,
+            parentPortType: 2,
+            parentPortNumber: 1,
+            vendorID: vendorID,
+            productID: 0x1234,
+            bcdDevice: 0,
+            vdos: [
+                (3 << 27) | UInt32(vendorID),
+                0,
+                0,
+                cableVDO
+            ],
+            specRevision: 3
+        )
+    }
+
+    func testTrustFlagsOmittedForCleanCable() throws {
+        let port = makePort()
+        // VID 0x05AC (Apple), USB4 Gen3, 5A: no flags expected.
+        let id = cableIdentity(vendorID: 0x05AC, cableVDO: (0b10 << 5) | 0b011)
+        let json = try JSONFormatter.render(
+            ports: [port], sources: [], identities: [id], showRaw: false
+        )
+        let obj = parse(json)
+        let portObj = (obj["ports"] as? [[String: Any]])?.first ?? [:]
+        let cable = try XCTUnwrap(portObj["cable"] as? [String: Any])
+        XCTAssertNil(cable["trustFlags"])
+    }
+
+    func testTrustFlagsPopulatedForZeroVidAndReservedBits() throws {
+        let port = makePort()
+        // VID=0, speed=6 (reserved), current=3 (reserved): all three flags.
+        let vdo = UInt32(0b110) | UInt32(3 << 5)
+        let id = cableIdentity(vendorID: 0, cableVDO: vdo)
+        let json = try JSONFormatter.render(
+            ports: [port], sources: [], identities: [id], showRaw: false
+        )
+        let obj = parse(json)
+        let portObj = (obj["ports"] as? [[String: Any]])?.first ?? [:]
+        let cable = try XCTUnwrap(portObj["cable"] as? [String: Any])
+        let flags = try XCTUnwrap(cable["trustFlags"] as? [[String: Any]])
+        XCTAssertEqual(flags.count, 3)
+
+        let codes = flags.compactMap { $0["code"] as? String }
+        XCTAssertEqual(codes, ["zeroVendorID", "reservedSpeedEncoding", "reservedCurrentEncoding"])
+
+        // Each flag carries title + detail.
+        for flag in flags {
+            XCTAssertNotNil(flag["title"] as? String)
+            XCTAssertNotNil(flag["detail"] as? String)
+        }
+    }
+
     // MARK: - Raw properties gating
 
     func testRawPropertiesOmittedByDefault() throws {

--- a/Tests/WhatCableCoreTests/PDVDOTests.swift
+++ b/Tests/WhatCableCoreTests/PDVDOTests.swift
@@ -49,6 +49,7 @@ final class PDVDOTests: XCTestCase {
         XCTAssertEqual(cable.maxVolts, 20)
         XCTAssertEqual(cable.maxWatts, 100) // 20V * 5A
         XCTAssertEqual(cable.cableType, .passive)
+        XCTAssertTrue(cable.decodeWarnings.isEmpty)
     }
 
     func testCheap_USB2_3A() {
@@ -58,6 +59,7 @@ final class PDVDOTests: XCTestCase {
         XCTAssertEqual(cable.speed, .usb20)
         XCTAssertEqual(cable.current, .threeAmp)
         XCTAssertEqual(cable.maxWatts, 60) // 20V * 3A
+        XCTAssertTrue(cable.decodeWarnings.isEmpty)
     }
 
     func testEPRCable_50V_5A() {
@@ -69,12 +71,43 @@ final class PDVDOTests: XCTestCase {
         XCTAssertEqual(cable.maxVoltageEncoded, 3)
         XCTAssertEqual(cable.maxVolts, 50)
         XCTAssertEqual(cable.maxWatts, 250) // 50V * 5A — EPR cable
+        XCTAssertTrue(cable.decodeWarnings.isEmpty)
     }
 
     func testActiveCableType() {
         let vdo: UInt32 = 0
         let cable = PDVDO.decodeCableVDO(vdo, isActive: true)
         XCTAssertEqual(cable.cableType, .active)
+        XCTAssertTrue(cable.decodeWarnings.isEmpty)
+    }
+
+    func testReservedSpeedEncodingFallsBackAndWarns() {
+        for speedBits in 5...7 {
+            let vdo = UInt32(speedBits) | UInt32(1 << 5)
+            let cable = PDVDO.decodeCableVDO(vdo, isActive: false)
+            XCTAssertEqual(cable.speed, .usb20)
+            XCTAssertEqual(cable.current, .threeAmp)
+            XCTAssertEqual(cable.decodeWarnings, [.reservedSpeedEncoding(speedBits)])
+        }
+    }
+
+    func testReservedCurrentEncodingFallsBackAndWarns() {
+        let vdo: UInt32 = 0b001 | UInt32(3 << 5)
+        let cable = PDVDO.decodeCableVDO(vdo, isActive: false)
+        XCTAssertEqual(cable.speed, .usb32Gen1)
+        XCTAssertEqual(cable.current, .usbDefault)
+        XCTAssertEqual(cable.decodeWarnings, [.reservedCurrentEncoding(3)])
+    }
+
+    func testReservedSpeedAndCurrentEncodingsBothWarn() {
+        let vdo: UInt32 = 0b101 | UInt32(3 << 5)
+        let cable = PDVDO.decodeCableVDO(vdo, isActive: false)
+        XCTAssertEqual(cable.speed, .usb20)
+        XCTAssertEqual(cable.current, .usbDefault)
+        XCTAssertEqual(
+            cable.decodeWarnings,
+            [.reservedSpeedEncoding(5), .reservedCurrentEncoding(3)]
+        )
     }
 
     // MARK: - VDO from Data


### PR DESCRIPTION
## Summary

- Phase 1 of the cable trust signals feature: surface hedged heuristic flags when a cable's e-marker data looks unusual.
- Three flags ship in this PR: zeroed vendor ID, reserved speed encoding (USB-PD bits 5/6/7), reserved current encoding (bit 3).
- Decoder now exposes a `decodeWarnings` side channel on `CableVDO` so the trust layer can spot reserved encodings without re-parsing raw bits. UI fallback behaviour for those cables is unchanged.
- JSON CLI output gains a `trustFlags` array on the `cable` object, omitted when no flags fire. Each flag has a stable `code`, a `title`, and a hedged `detail` string.
- Menu bar popover renders a new `TrustFlagsCard` above the "Report this cable" button whenever any flag is present.

## What is intentionally not in this PR

- H1b (zero PID): needs a way to tell "Product VDO absent" from "Product VDO present and zero" before it can flag without false positives.
- H2 (power vs speed mismatch): original premise was wrong (USB Type-C R2.0 explicitly allows e-marked USB 2.0 cables above 3A). Will be reframed around certification / marketing mismatch and the Apple-cable carve-out work.
- H3 / H4 (vendor-DB-driven flags): need full USB-IF list or curated category data first.

All wording stays hedged ("looks unusual," "common counterfeit pattern"). We trust the e-marker by design.

## Test plan

- [x] `swift test` (115 tests, all green; +13 new across `PDVDOTests`, `CableTrustReportTests`, `JSONFormatterTests`)
- [x] `scripts/build-app.sh` — full build, sign, notarise, staple, Gatekeeper accepts. Both GUI and CLI binaries alive in the proper `.app` bundle.
- [ ] Smoke-test on a real machine with a known cable (post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
