### PR TITLE
Don't claim "basic cable" on USB-only ports (no PD)

### DIFF
--- a/Sources/WhatCableCore/JSONFormatter.swift
+++ b/Sources/WhatCableCore/JSONFormatter.swift
@@ -37,6 +37,7 @@ private struct PortDTO: Codable {
     let type: String?
     let className: String
     let connectionActive: Bool
+    let pdCapable: Bool
     let status: String
     let headline: String
     let subtitle: String
@@ -53,6 +54,7 @@ private struct PortDTO: Codable {
         self.type = port.portTypeDescription
         self.className = port.className
         self.connectionActive = port.connectionActive ?? false
+        self.pdCapable = port.transportsSupported.contains("CC")
 
         let summary = PortSummary(port: port, sources: sources, identities: identities)
         self.status = String(describing: summary.status)

--- a/Sources/WhatCableCore/PortSummary.swift
+++ b/Sources/WhatCableCore/PortSummary.swift
@@ -47,6 +47,12 @@ extension PortSummary {
         let hasUSB2 = active.contains("USB2")
         let hasTB = active.contains("CIO") // Thunderbolt = Converged I/O
         let hasDP = active.contains("DisplayPort")
+        // Configuration Channel: required for USB-PD. Without CC the OS cannot
+        // run Discover Identity, so we can't infer anything about the cable's
+        // e-marker. M4 Mac Mini front USB-C ports are an example: they hang
+        // off a plain xHCI controller (no PD), so reporting "basic cable" on
+        // them wrongly blames the cable. See issue #50.
+        let pdCapable = supported.contains("CC")
         // E-marker presence is "did the cable respond to Discover Identity?",
         // which means we have an SOP'/SOP'' PDIdentity for this port. The
         // port's `ActiveCable` IOKit flag means "this cable contains active
@@ -85,7 +91,11 @@ extension PortSummary {
         if hasEmarker {
             bullets.append("Cable has an e-marker chip (advertises its capabilities)")
         } else if !active.isEmpty {
-            bullets.append("Cable does not advertise an e-marker (basic cable)")
+            if pdCapable {
+                bullets.append("Cable does not advertise an e-marker (basic cable)")
+            } else {
+                bullets.append("This port can't read cable details (USB-only port, no Power Delivery)")
+            }
         }
 
         if port.opticalCable == true {

--- a/Tests/WhatCableCoreTests/JSONFormatterTests.swift
+++ b/Tests/WhatCableCoreTests/JSONFormatterTests.swift
@@ -27,7 +27,7 @@ final class JSONFormatterTests: XCTestCase {
             superSpeedActive: true,
             usbModeType: nil,
             usbConnectString: nil,
-            transportsSupported: ["USB2", "USB3"],
+            transportsSupported: ["CC", "USB2", "USB3"],
             transportsActive: ["USB3"],
             transportsProvisioned: [],
             plugOrientation: nil,
@@ -98,7 +98,7 @@ final class JSONFormatterTests: XCTestCase {
         // rawProperties are optional and only appear when relevant data is
         // available; their presence is exercised in dedicated tests below.
         let expected: Set<String> = [
-            "name", "type", "className", "connectionActive", "status",
+            "name", "type", "className", "connectionActive", "pdCapable", "status",
             "headline", "subtitle", "bullets", "transports", "powerSources"
         ]
         let actual = Set(first.keys)
@@ -120,7 +120,7 @@ final class JSONFormatterTests: XCTestCase {
         let obj = parse(json)
         let port = (obj["ports"] as? [[String: Any]])?.first ?? [:]
         let transports = try XCTUnwrap(port["transports"] as? [String: Any])
-        XCTAssertEqual(transports["supported"] as? [String], ["USB2", "USB3"])
+        XCTAssertEqual(transports["supported"] as? [String], ["CC", "USB2", "USB3"])
         XCTAssertEqual(transports["active"] as? [String], ["USB3"])
         XCTAssertNotNil(transports["provisioned"] as? [String])
     }
@@ -249,6 +249,48 @@ final class JSONFormatterTests: XCTestCase {
         let port = (obj["ports"] as? [[String: Any]])?.first ?? [:]
         let raw = try XCTUnwrap(port["rawProperties"] as? [String: String])
         XCTAssertEqual(raw["PortType"], "2")
+    }
+
+    // MARK: - pdCapable
+
+    func testPDCapableTrueWhenCCPresent() throws {
+        let json = try JSONFormatter.render(
+            ports: [makePort()], sources: [], identities: [], showRaw: false
+        )
+        let obj = parse(json)
+        let port = (obj["ports"] as? [[String: Any]])?.first ?? [:]
+        XCTAssertEqual(port["pdCapable"] as? Bool, true)
+    }
+
+    func testPDCapableFalseWhenCCAbsent() throws {
+        // Mimic an M4 Mac Mini front USB-C port: USB-only, no Configuration
+        // Channel, so no PD and no SOP' query possible.
+        let port = USBCPort(
+            id: 5, serviceName: "Port-USB-C@5", className: "IOPort",
+            portDescription: "Port-USB-C@5", portTypeDescription: "USB-C",
+            portNumber: 5, connectionActive: true, activeCable: nil,
+            opticalCable: nil, usbActive: true, superSpeedActive: true,
+            usbModeType: nil, usbConnectString: nil,
+            transportsSupported: ["USB2", "USB3"],
+            transportsActive: ["USB3"],
+            transportsProvisioned: ["USB2", "USB3"],
+            plugOrientation: nil, plugEventCount: nil, connectionCount: nil,
+            overcurrentCount: nil, pinConfiguration: [:],
+            powerCurrentLimits: [], firmwareVersion: nil, bootFlagsHex: nil,
+            rawProperties: [:]
+        )
+        let json = try JSONFormatter.render(
+            ports: [port], sources: [], identities: [], showRaw: false
+        )
+        let obj = parse(json)
+        let portJSON = (obj["ports"] as? [[String: Any]])?.first ?? [:]
+        XCTAssertEqual(portJSON["pdCapable"] as? Bool, false)
+        // And the port-level bullet should not claim "basic cable".
+        let bullets = portJSON["bullets"] as? [String] ?? []
+        XCTAssertFalse(bullets.contains(where: { $0.contains("does not advertise") }),
+                       "no-PD port should not claim 'basic cable', got: \(bullets)")
+        XCTAssertTrue(bullets.contains(where: { $0.contains("can't read cable details") }),
+                      "expected 'port can't read cable details' bullet, got: \(bullets)")
     }
 
     // MARK: - JSON validity

--- a/Tests/WhatCableCoreTests/PortSummaryTests.swift
+++ b/Tests/WhatCableCoreTests/PortSummaryTests.swift
@@ -170,11 +170,50 @@ final class PortSummaryTests: XCTestCase {
     }
 
     func testNoEmarkerCableProducesBasicCableBullet() {
-        let port = makePort(active: ["USB2"], emarker: false)
+        // PD-capable port (CC present) with no e-marker: existing wording.
+        let port = makePort(active: ["USB2"], supported: ["CC", "USB2"], emarker: false)
         let summary = PortSummary(port: port)
         XCTAssertTrue(
             summary.bullets.contains(where: { $0.contains("does not advertise") }),
             "expected a basic-cable bullet, got: \(summary.bullets)"
+        )
+    }
+
+    func testNoPDPortDoesNotClaimBasicCable() {
+        // USB-only port (no CC = no PD = no SOP' query possible). Don't blame
+        // the cable for a missing e-marker the OS could never have read. This
+        // is the M4 Mac Mini front-port case from issue #50.
+        let port = makePort(active: ["USB3"], supported: ["USB2", "USB3"], superSpeed: true)
+        let summary = PortSummary(port: port)
+        XCTAssertFalse(
+            summary.bullets.contains(where: { $0.contains("does not advertise") }),
+            "no-PD port should not claim 'basic cable', got: \(summary.bullets)"
+        )
+        XCTAssertTrue(
+            summary.bullets.contains(where: { $0.contains("can't read cable details") }),
+            "expected the 'port can't read cable details' bullet, got: \(summary.bullets)"
+        )
+    }
+
+    func testPDPortWithEmarkerStillShowsEmarker() {
+        // Sanity: presence of an e-marker means PD must have fired, regardless
+        // of whether the test fixture happens to set CC explicitly. We don't
+        // want the new gate to suppress legitimate e-marker bullets.
+        let port = makePort(
+            active: ["USB3"],
+            supported: ["CC", "USB2", "USB3"],
+            superSpeed: true
+        )
+        let cable = PDIdentity(
+            id: 99, endpoint: .sopPrime,
+            parentPortType: 0, parentPortNumber: 0,
+            vendorID: 0, productID: 0, bcdDevice: 0,
+            vdos: [], specRevision: 0
+        )
+        let summary = PortSummary(port: port, identities: [cable])
+        XCTAssertTrue(
+            summary.bullets.contains(where: { $0.contains("e-marker") && $0.contains("advertises") }),
+            "expected e-marker bullet on PD-capable port, got: \(summary.bullets)"
         )
     }
 


### PR DESCRIPTION
## Summary

- Stop saying "Cable does not advertise an e-marker (basic cable)" on ports that physically can't run USB-PD.
- Gate the wording on `transportsSupported.contains("CC")`. No Configuration Channel = no Power Delivery = no SOP' query possible, so any inference about the cable's e-marker is meaningless.
- New wording for those ports: *"This port can't read cable details (USB-only port, no Power Delivery)"*.
- Surface `pdCapable: Bool` in the JSON port DTO for tooling.

Closes #50.

## Why

The reporter found that two cables which read fine on the M4 Mac Mini's rear (Thunderbolt 4) ports came back as "basic cable" on the front USB-C ports. The cables are not at fault. M4 Mac Mini front ports hang off a plain xHCI controller (`AppleT8132USBXHCI`), not the AppleHPM PD controller. Without PD, macOS doesn't query SOP', so there is nothing to read.

Mapping verified against the JSON in #50:

| Port | IOClass | TransportsSupported | Physical |
|---|---|---|---|
| @1, @2, @4 | AppleHPMInterfaceType10 | CC, USB2, USB3, CIO, DisplayPort | rear TB4 |
| @5, @6 | IOPort | USB2, USB3 | **front** |

The CC pin is the spec-anchored signal; checking for `IOClass == "IOPort"` would also work but leans on a Darwin-internals string.

## Note on the secondary finding in #50

The reporter's second JSON dump shows the rear ports @2/@4 also reading "basic cable", which this PR does not change. Those ports do have CC, so the existing wording is operating on a PD-capable port. ConnectionCount and Plug Event Count between the two captures suggest the cables had been re-plugged and macOS hadn't re-queried SOP' yet, which is a separate re-enumeration race worth a follow-up issue if it reproduces.

## Test plan

- [x] `swift test` (119 tests, 0 failures)
- [x] New `PortSummaryTests.testNoPDPortDoesNotClaimBasicCable` covers the no-CC case
- [x] New `PortSummaryTests.testPDPortWithEmarkerStillShowsEmarker` guards the e-marker bullet
- [x] New `JSONFormatterTests.testPDCapableFalseWhenCCAbsent` mimics the M4 Mini front port shape
- [x] Existing PD-capable basic-cable test fixture updated to include CC, so it still pins the existing wording

Generated with [Claude Code](https://claude.com/claude-code)
