### PR TITLE
Include raw VDOs in cable-report markdown

### DIFF
--- a/Sources/WhatCableCore/CableReport.swift
+++ b/Sources/WhatCableCore/CableReport.swift
@@ -32,6 +32,11 @@ public enum CableReport {
         public let maxWatts: Int?
         public let type: String?
         public let hasEmarker: Bool
+        /// Raw 32-bit VDOs as the cable returned them. Included in reports
+        /// so we can later distinguish "macOS dropped the field" from "the
+        /// cable genuinely sent zero" when calibrating heuristics like the
+        /// zero-PID flag.
+        public let vdos: [UInt32]
 
         public init(identity: PDIdentity) {
             self.vendorID = identity.vendorID
@@ -39,6 +44,7 @@ public enum CableReport {
             self.vendorIDHex = String(format: "0x%04X", identity.vendorID)
             self.productIDHex = String(format: "0x%04X", identity.productID)
             self.vendorName = VendorDB.name(for: identity.vendorID) ?? "Unregistered / unknown"
+            self.vdos = identity.vdos
             if let cv = identity.cableVDO {
                 self.speed = cv.speed.label
                 self.currentRating = cv.current.label
@@ -103,6 +109,19 @@ public enum CableReport {
 
     /// Issue endpoint the report is filed against.
     public static let issueBaseURL = URL(string: "https://github.com/darrylmorley/whatcable/issues/new")!
+
+    /// Map a VDO array index to its role per the USB-PD spec layout for a
+    /// passive / active cable Discover Identity response. Anything past the
+    /// known indices is "Other" so we still surface the raw value.
+    static func vdoRoleLabel(at index: Int) -> String {
+        switch index {
+        case 0: return "ID Header"
+        case 1: return "Cert Stat"
+        case 2: return "Product"
+        case 3: return "Cable"
+        default: return "Other"
+        }
+    }
 }
 
 extension CableReport.Payload {
@@ -128,6 +147,18 @@ extension CableReport.Payload {
         }
         lines.append("| Has e-marker | \(cable.hasEmarker ? "Yes" : "No") |")
         lines.append("")
+        if !cable.vdos.isEmpty {
+            lines.append("### Raw VDOs")
+            lines.append("")
+            lines.append("| Index | Role | Value |")
+            lines.append("|---|---|---|")
+            for (i, vdo) in cable.vdos.enumerated() {
+                let role = CableReport.vdoRoleLabel(at: i)
+                let hex = String(format: "0x%08X", vdo)
+                lines.append("| \(i) | \(role) | `\(hex)` |")
+            }
+            lines.append("")
+        }
         lines.append("### Environment")
         lines.append("")
         lines.append("- WhatCable: `\(appVersion)`")

--- a/Tests/WhatCableCoreTests/CableReportTests.swift
+++ b/Tests/WhatCableCoreTests/CableReportTests.swift
@@ -91,4 +91,73 @@ final class CableReportTests: XCTestCase {
         XCTAssertTrue(payload.issueTitle.contains("Apple"))
         XCTAssertTrue(payload.issueTitle.contains("USB4"))
     }
+
+    func testFingerprintCarriesRawVDOs() {
+        let payload = CableReport.payload(for: cableIdentity())!
+        // Fixture has 4 VDOs: ID Header, Cert Stat, Product, Cable.
+        XCTAssertEqual(payload.cable.vdos.count, 4)
+        // VDO[0] = passive cable header (3 << 27) | 0x05AC.
+        XCTAssertEqual(payload.cable.vdos[0], (3 << 27) | UInt32(0x05AC))
+    }
+
+    func testMarkdownIncludesRawVDOSection() {
+        let payload = CableReport.payload(for: cableIdentity())!
+        let md = payload.markdown
+        XCTAssertTrue(md.contains("### Raw VDOs"))
+        // ID Header VDO from the fixture: (3 << 27) | 0x05AC = 0x180005AC.
+        XCTAssertTrue(md.contains("`0x180005AC`"))
+        // Role labels appear so future readers can tell which is which
+        // without having to know the spec layout.
+        XCTAssertTrue(md.contains("ID Header"))
+        XCTAssertTrue(md.contains("Cable"))
+        XCTAssertTrue(md.contains("Product"))
+    }
+
+    func testMarkdownOmitsRawVDOSectionWhenAbsent() {
+        // Identity with no VDOs (e.g. a cable that didn't respond to
+        // Discover Identity at all) shouldn't render an empty Raw VDOs table.
+        let id = PDIdentity(
+            id: 1,
+            endpoint: .sopPrime,
+            parentPortType: 0,
+            parentPortNumber: 0,
+            vendorID: 0x05AC,
+            productID: 0,
+            bcdDevice: 0,
+            vdos: [],
+            specRevision: 3
+        )
+        let payload = CableReport.payload(for: id)!
+        let md = payload.markdown
+        XCTAssertFalse(md.contains("### Raw VDOs"))
+    }
+
+    func testMarkdownLabelsExtraVDOsAsOther() {
+        // PD response can include up to 7 VDOs (ID Header + Cert Stat +
+        // Product + up to 4 Product Type VDOs). Anything past index 3 we
+        // label "Other" rather than guessing.
+        let id = PDIdentity(
+            id: 1,
+            endpoint: .sopPrime,
+            parentPortType: 0,
+            parentPortNumber: 0,
+            vendorID: 0x05AC,
+            productID: 0x1234,
+            bcdDevice: 0,
+            vdos: [
+                (3 << 27) | UInt32(0x05AC),
+                0,
+                0,
+                (0b10 << 5) | 0b011,
+                0xDEADBEEF,
+                0xCAFEBABE
+            ],
+            specRevision: 3
+        )
+        let payload = CableReport.payload(for: id)!
+        let md = payload.markdown
+        XCTAssertTrue(md.contains("`0xDEADBEEF`"))
+        XCTAssertTrue(md.contains("`0xCAFEBABE`"))
+        XCTAssertTrue(md.contains("Other"))
+    }
 }


### PR DESCRIPTION
## Summary

- Cable reports filed via the "Report this cable" button now include a "Raw VDOs" section listing each 32-bit VDO the cable returned, in hex, labelled by USB-PD spec role.
- Lets future reports tell us whether a `productID: 0x0000` is genuine (the cable's Product VDO has zero in its PID bits) or an extraction gap (macOS didn't surface the field).
- Section is omitted entirely when the cable didn't return any VDOs, so reports for non-e-marker cables stay clean.

## Why

Two of three existing cable reports (#45 Acasis enclosure cable, #49 Dbilida 240W TB4) show `productID: 0x0000` on cables the reporters describe as functional. The current report can't distinguish those cases from cables where the Product VDO was simply missing.

Per the USB-PD spec the Product VDO is `vdos[2]` and its high 16 bits are the PID. With the raw VDOs in the report we can answer "is this a real zero or an extraction gap?" definitively for each future report. That dataset is the missing input before we can ship the deferred zero-PID trust flag (planning doc H1b) without false-positives on legitimate cables.

## Test plan

- [x] `swift test` (123 tests, all green; +4 new in `CableReportTests`)
- [ ] Hit "Report this cable" against a real cable, check the pre-filled GitHub issue body shows the new "Raw VDOs" table

🤖 Generated with [Claude Code](https://claude.com/claude-code)
