### PR TITLE
Don't fabricate per-port wattage from system adapter

### DIFF
--- a/Sources/WhatCableCore/ChargingDiagnostic.swift
+++ b/Sources/WhatCableCore/ChargingDiagnostic.swift
@@ -53,8 +53,10 @@ extension ChargingDiagnostic {
         let negotiatedW = source.winning.map { Int((Double($0.maxPowerMW) / 1000).rounded()) }
 
         // No real per-port wattage to report. Don't fabricate one from
-        // system-wide signals; the charging block simply doesn't render.
-        if chargerMaxW <= 0 && negotiatedW == nil {
+        // system-wide signals, and don't render "Charging well at 0W" if a
+        // winning PDO rounds to zero. The charging block simply doesn't
+        // appear for this port.
+        if chargerMaxW <= 0 && (negotiatedW ?? 0) <= 0 {
             return nil
         }
 

--- a/Sources/WhatCableCore/ChargingDiagnostic.swift
+++ b/Sources/WhatCableCore/ChargingDiagnostic.swift
@@ -30,6 +30,15 @@ extension ChargingDiagnostic {
         identities: [PDIdentity],
         adapter: AdapterInfo? = nil
     ) {
+        // `adapter` is retained for API compatibility but intentionally unused.
+        // Earlier versions used `IOPSCopyExternalPowerAdapterDetails().Watts`
+        // as a fallback when the per-port USB-PD source had no winning PDO.
+        // That value is system-wide, so on a Mac with two ports each carrying
+        // a different charger (e.g. an 87W adapter on @1 and a 30W power bank
+        // on @2), the adapter watts for @1 leaked into @2's diagnostic and
+        // claimed "Charging well at 87W" on the 30W port. See issue #46.
+        _ = adapter
+
         guard let source = PowerSource.preferredChargingSource(in: sources) else {
             return nil // No USB-PD or MagSafe Brick ID source on this port.
         }
@@ -40,16 +49,13 @@ extension ChargingDiagnostic {
         // the PowerSource node alone.
         guard port.connectionActive == true else { return nil }
 
-        var chargerMaxW = Int((Double(source.maxPowerMW) / 1000).rounded())
-        var negotiatedW = source.winning.map { Int((Double($0.maxPowerMW) / 1000).rounded()) }
+        let chargerMaxW = Int((Double(source.maxPowerMW) / 1000).rounded())
+        let negotiatedW = source.winning.map { Int((Double($0.maxPowerMW) / 1000).rounded()) }
 
-        if negotiatedW.map({ $0 <= 0 }) ?? true,
-           let watts = adapter?.watts,
-           watts > 0 {
-            negotiatedW = watts
-            if chargerMaxW <= 0 {
-                chargerMaxW = watts
-            }
+        // No real per-port wattage to report. Don't fabricate one from
+        // system-wide signals; the charging block simply doesn't render.
+        if chargerMaxW <= 0 && negotiatedW == nil {
+            return nil
         }
 
         let cableMaxW: Int? = identities

--- a/Tests/WhatCableCoreTests/ChargingDiagnosticTests.swift
+++ b/Tests/WhatCableCoreTests/ChargingDiagnosticTests.swift
@@ -211,6 +211,18 @@ final class ChargingDiagnosticTests: XCTestCase {
         XCTAssertNil(diag)
     }
 
+    func testZeroWattWinningPDOSuppressesDiagnostic() {
+        // A winning PDO with maxPowerMW rounding to 0 is just as useless as
+        // a missing one. Don't render "Charging well at 0W".
+        let zeroWinning = PowerSource(
+            id: 1, name: "USB-PD", parentPortType: 2, parentPortNumber: 1,
+            options: [],
+            winning: PowerOption(voltageMV: 0, maxCurrentMA: 0, maxPowerMW: 0)
+        )
+        let diag = ChargingDiagnostic(port: port, sources: [zeroWinning], identities: [])
+        XCTAssertNil(diag)
+    }
+
     func testTwoPortsWithDifferentChargersDoNotCrossContaminate() {
         // Issue #46: M1 MBA with an 87W adapter on @1 and a 30W power bank on
         // @2 that briefly reports a USB-PD source without a winning PDO.

--- a/Tests/WhatCableCoreTests/ChargingDiagnosticTests.swift
+++ b/Tests/WhatCableCoreTests/ChargingDiagnosticTests.swift
@@ -197,17 +197,46 @@ final class ChargingDiagnosticTests: XCTestCase {
         XCTAssertEqual(n, 96)
     }
 
-    func testSystemPowerAdapterWattsFallbackCanSupplyNegotiatedWattage() {
+    func testSystemAdapterWattsAreNotUsedAsPerPortFallback() {
+        // Regression for issue #46. Per-port USB-PD source has no winning PDO
+        // and no options, so we have nothing real to report. The system-wide
+        // adapter wattage must NOT be substituted, because on a Mac with two
+        // chargers attached it belongs to a different port.
         let diag = ChargingDiagnostic(
             port: port,
             sources: [brickIDWithoutPDOs()],
             identities: [],
             adapter: AdapterInfo(watts: 140, isCharging: nil, source: "AC")
         )
-        guard case .fine(let n) = diag?.bottleneck else {
-            return XCTFail("expected .fine from system adapter wattage, got \(String(describing: diag?.bottleneck))")
-        }
-        XCTAssertEqual(n, 140)
+        XCTAssertNil(diag)
+    }
+
+    func testTwoPortsWithDifferentChargersDoNotCrossContaminate() {
+        // Issue #46: M1 MBA with an 87W adapter on @1 and a 30W power bank on
+        // @2 that briefly reports a USB-PD source without a winning PDO.
+        // The diagnostic for @2 must not borrow the 87W system adapter watts.
+        let port2 = USBCPort(
+            id: 2, serviceName: "Port-USB-C@2", className: "AppleHPMInterfaceType10",
+            portDescription: nil, portTypeDescription: "USB-C", portNumber: 2,
+            connectionActive: true,
+            activeCable: nil, opticalCable: nil, usbActive: nil, superSpeedActive: nil,
+            usbModeType: nil, usbConnectString: nil,
+            transportsSupported: [], transportsActive: [], transportsProvisioned: [],
+            plugOrientation: nil, plugEventCount: nil, connectionCount: nil,
+            overcurrentCount: nil, pinConfiguration: [:], powerCurrentLimits: [],
+            firmwareVersion: nil, bootFlagsHex: nil, rawProperties: [:]
+        )
+        let bareUSBPDOnPort2 = PowerSource(
+            id: 99, name: "USB-PD", parentPortType: 2, parentPortNumber: 2,
+            options: [], winning: nil
+        )
+        let diag = ChargingDiagnostic(
+            port: port2,
+            sources: [bareUSBPDOnPort2],
+            identities: [],
+            adapter: AdapterInfo(watts: 87, isCharging: nil, source: "AC")
+        )
+        XCTAssertNil(diag, "port @2 must not inherit port @1's adapter wattage")
     }
 
     // MARK: - Edge cases (#15)


### PR DESCRIPTION
## Summary

`ChargingDiagnostic` used to fall back to `IOPSCopyExternalPowerAdapterDetails().Watts` whenever a per-port USB-PD source lacked a winning PDO. That value is system-wide, so on a Mac with two chargers attached (an 87W adapter on one port, a 30W power bank on the other), the adapter watts from one port could leak into the other port's diagnostic and claim "Charging well at 87W" on the 30W port.

The fix drops the fallback. If a per-port source has neither a winning PDO nor any options, the charging block now returns nil and renders nothing for that port rather than guessing.

The `adapter:` parameter on the public init is kept for API compatibility but ignored, with a comment explaining why.

## Test plan

- [x] `swift test` (124 tests pass)
- [x] Updated `testSystemPowerAdapterWattsFallbackCanSupplyNegotiatedWattage` to assert the new "no fallback" behaviour and renamed it.
- [x] Added `testTwoPortsWithDifferentChargersDoNotCrossContaminate` mirroring the issue #46 setup: two ports, port @2 has a USB-PD source with no winning PDO, the global system adapter is 87W. Asserts port @2's diagnostic returns nil.

Closes #46
