### PR TITLE
Don't treat stale power sources as a live port signal

### DIFF
--- a/Sources/WhatCable/ContentView.swift
+++ b/Sources/WhatCable/ContentView.swift
@@ -218,20 +218,15 @@ struct ContentView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
-    /// Live-signal check that bypasses the unreliable `port.connectionActive`
-    /// flag. A port is considered live if any of the three IOKit watchers
-    /// (devices, power sources, PD identities) has at least one entry tied
-    /// to it. Each watcher tracks add/terminate via real notifications, so
-    /// their union reflects the current physical state.
+    /// Live-signal check delegating to the pure helper in `WhatCableCore`,
+    /// so the same rules apply to both the GUI and any test harness.
     private func isPortLive(_ port: USBCPort) -> Bool {
-        if !powerWatcher.sources(for: port).isEmpty { return true }
-        if !pdWatcher.identities(for: port).isEmpty { return true }
-        if !matchingDevices(for: port).isEmpty { return true }
-        // MagSafe holds connectionActive=true for several seconds after unplug,
-        // so we only fall back to it for regular USB-C ports where it is reliable.
-        let isMagSafe = port.portTypeDescription?.hasPrefix("MagSafe") == true
-        if !isMagSafe && port.connectionActive == true { return true }
-        return false
+        WhatCableCore.isPortLive(
+            port: port,
+            powerSources: powerWatcher.sources(for: port),
+            identities: pdWatcher.identities(for: port),
+            matchingDevices: matchingDevices(for: port)
+        )
     }
 
     /// Match USB devices to their physical port. The IOKit relationship

--- a/Sources/WhatCableCore/PortLiveness.swift
+++ b/Sources/WhatCableCore/PortLiveness.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// Decide whether a port is physically live based on the union of IOKit
+/// watcher state (devices, power sources, PD identities) and the port-level
+/// `ConnectionActive` flag.
+///
+/// Why this helper exists:
+///
+/// - `USBCPort.connectionActive` lingers `true` for several seconds after
+///   unplug on MagSafe (`AppleHPMInterfaceType11`), so we can't trust it
+///   alone there.
+/// - The power source watcher caches the last negotiated PDO, so a port
+///   with nothing plugged in can still expose a USB-PD source long after
+///   the cable was removed (issue #47).
+///
+/// So we treat each signal differently. Devices and PD identities are
+/// strong: their watchers terminate on real IOKit notifications, no
+/// caching. The port-level `connectionActive` flag is trusted on
+/// non-MagSafe. Power sources need corroboration before they count.
+public func isPortLive(
+    port: USBCPort,
+    powerSources: [PowerSource],
+    identities: [PDIdentity],
+    matchingDevices: [USBDevice]
+) -> Bool {
+    if !matchingDevices.isEmpty { return true }
+    if !identities.isEmpty { return true }
+
+    let isMagSafe = port.portTypeDescription?.hasPrefix("MagSafe") == true
+    if !isMagSafe && port.connectionActive == true { return true }
+
+    // Power sources alone aren't enough: the watcher's cached PDO can
+    // outlive the physical connection. Only count them when the port
+    // itself agrees something is connected.
+    if !powerSources.isEmpty && port.connectionActive == true { return true }
+
+    return false
+}

--- a/Tests/WhatCableCoreTests/PortLivenessTests.swift
+++ b/Tests/WhatCableCoreTests/PortLivenessTests.swift
@@ -1,0 +1,150 @@
+import XCTest
+@testable import WhatCableCore
+
+final class PortLivenessTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    private func usbCPort(
+        connectionActive: Bool = false
+    ) -> USBCPort {
+        USBCPort(
+            id: 1, serviceName: "Port-USB-C@1", className: "AppleHPMInterfaceType10",
+            portDescription: nil, portTypeDescription: "USB-C", portNumber: 1,
+            connectionActive: connectionActive,
+            activeCable: nil, opticalCable: nil, usbActive: nil, superSpeedActive: nil,
+            usbModeType: nil, usbConnectString: nil,
+            transportsSupported: [], transportsActive: [], transportsProvisioned: [],
+            plugOrientation: nil, plugEventCount: nil, connectionCount: nil,
+            overcurrentCount: nil, pinConfiguration: [:], powerCurrentLimits: [],
+            firmwareVersion: nil, bootFlagsHex: nil, rawProperties: [:]
+        )
+    }
+
+    private func magSafePort(
+        connectionActive: Bool = false
+    ) -> USBCPort {
+        USBCPort(
+            id: 1, serviceName: "Port-MagSafe 3@1", className: "AppleHPMInterfaceType11",
+            portDescription: nil, portTypeDescription: "MagSafe 3", portNumber: 1,
+            connectionActive: connectionActive,
+            activeCable: nil, opticalCable: nil, usbActive: nil, superSpeedActive: nil,
+            usbModeType: nil, usbConnectString: nil,
+            transportsSupported: [], transportsActive: [], transportsProvisioned: [],
+            plugOrientation: nil, plugEventCount: nil, connectionCount: nil,
+            overcurrentCount: nil, pinConfiguration: [:], powerCurrentLimits: [],
+            firmwareVersion: nil, bootFlagsHex: nil, rawProperties: [:]
+        )
+    }
+
+    private func staleUSBPDSource() -> PowerSource {
+        PowerSource(
+            id: 1, name: "USB-PD", parentPortType: 2, parentPortNumber: 1,
+            options: [],
+            winning: PowerOption(voltageMV: 20_000, maxCurrentMA: 1490, maxPowerMW: 29_800)
+        )
+    }
+
+    private func partnerIdentity() -> PDIdentity {
+        PDIdentity(
+            id: 99, endpoint: .sop,
+            parentPortType: 0, parentPortNumber: 0,
+            vendorID: 0, productID: 0, bcdDevice: 0,
+            vdos: [], specRevision: 0
+        )
+    }
+
+    private func usbDevice() -> USBDevice {
+        USBDevice(
+            id: 42, locationID: 0, vendorID: 0, productID: 0,
+            vendorName: nil, productName: nil, serialNumber: nil,
+            usbVersion: nil, speedRaw: nil, busPowerMA: nil, currentMA: nil,
+            rawProperties: [:]
+        )
+    }
+
+    // MARK: - Cases
+
+    func testNothingPresentIsNotLive() {
+        XCTAssertFalse(isPortLive(
+            port: usbCPort(connectionActive: false),
+            powerSources: [], identities: [], matchingDevices: []
+        ))
+    }
+
+    func testUSBDeviceMakesPortLive() {
+        XCTAssertTrue(isPortLive(
+            port: usbCPort(connectionActive: false),
+            powerSources: [], identities: [], matchingDevices: [usbDevice()]
+        ))
+    }
+
+    func testPDIdentityMakesPortLive() {
+        XCTAssertTrue(isPortLive(
+            port: usbCPort(connectionActive: false),
+            powerSources: [], identities: [partnerIdentity()], matchingDevices: []
+        ))
+    }
+
+    func testNonMagSafeConnectionActiveMakesPortLive() {
+        XCTAssertTrue(isPortLive(
+            port: usbCPort(connectionActive: true),
+            powerSources: [], identities: [], matchingDevices: []
+        ))
+    }
+
+    // MARK: - Issue #47 regressions
+
+    func testStalePowerSourceAloneDoesNotMakePortLive() {
+        // Issue #47: M2 MBA showed disconnected ports as connected because the
+        // PowerSourceWatcher held a stale negotiated PDO. The port itself
+        // correctly reports connectionActive=false, so the union must not
+        // light up purely on the cached source.
+        XCTAssertFalse(isPortLive(
+            port: usbCPort(connectionActive: false),
+            powerSources: [staleUSBPDSource()],
+            identities: [],
+            matchingDevices: []
+        ))
+    }
+
+    func testStalePowerSourceOnDisconnectedMagSafeIsNotLive() {
+        // The MagSafe port from issue #47's JSON dump: connectionActive=false,
+        // but the watcher still exposes a 30W winning PDO from the previous
+        // session. Must not be treated as live.
+        XCTAssertFalse(isPortLive(
+            port: magSafePort(connectionActive: false),
+            powerSources: [staleUSBPDSource()],
+            identities: [],
+            matchingDevices: []
+        ))
+    }
+
+    func testPowerSourceWithActiveConnectionIsLive() {
+        // Charger genuinely plugged in: power source plus an active
+        // connection. This is the case we still want to count as live, on
+        // both USB-C and MagSafe.
+        XCTAssertTrue(isPortLive(
+            port: usbCPort(connectionActive: true),
+            powerSources: [staleUSBPDSource()],
+            identities: [],
+            matchingDevices: []
+        ))
+        XCTAssertTrue(isPortLive(
+            port: magSafePort(connectionActive: true),
+            powerSources: [staleUSBPDSource()],
+            identities: [],
+            matchingDevices: []
+        ))
+    }
+
+    func testMagSafeConnectionActiveAloneIsNotLive() {
+        // The original MagSafe quirk: connectionActive=true lingers for
+        // several seconds after unplug. Without any other live signal, we
+        // shouldn't trust it.
+        XCTAssertFalse(isPortLive(
+            port: magSafePort(connectionActive: true),
+            powerSources: [], identities: [], matchingDevices: []
+        ))
+    }
+}


### PR DESCRIPTION
## Summary

The popover's live-state union counted any non-empty `powerWatcher.sources(for: port)` as proof a port was live. The PowerSourceWatcher caches the last negotiated PDO, so a port with nothing physically connected can still expose a USB-PD source. On affected machines this lit up empty ports as "connected and charging" with stale wattage, even though the port itself reported `connectionActive: false` (which the CLI/JSON path honoured correctly).

The fix moves the live-state rule into a pure helper in `WhatCableCore` and requires power sources to be corroborated by `port.connectionActive` before they count. Devices and PD identities still light up the port on their own, since their watchers terminate on real IOKit notifications without caching.

Extracting the helper also makes the live-state rules unit-testable for the first time.

## Test plan

- [x] `swift test` (133 tests pass, 8 new ones in `PortLivenessTests`)
- [x] Regression test for the issue #47 scenario: disconnected port with a stale USB-PD source asserts `isPortLive` returns false, on both USB-C and MagSafe shapes.
- [x] Coverage for the cases that should still be live: USB device match, PD identity, non-MagSafe `connectionActive`, and power source paired with `connectionActive=true`.
- [x] Coverage for the original MagSafe quirk: `connectionActive=true` alone on MagSafe is no longer enough.

Closes #47
