### PR TITLE
Don't claim 'no Power Delivery' on MagSafe ports

### DIFF
--- a/Sources/WhatCableCore/PortSummary.swift
+++ b/Sources/WhatCableCore/PortSummary.swift
@@ -87,10 +87,16 @@ extension PortSummary {
             bullets.append("Carrying DisplayPort video")
         }
 
-        // E-marker
+        // E-marker. The whole cable-details bullet only makes sense on
+        // USB-C, where the user can swap cables and might wonder why
+        // details are missing. On MagSafe the cable is part of the brick
+        // (and MagSafe absolutely does negotiate Power Delivery, just over
+        // its own pins, not the CC line we test for `pdCapable`), so don't
+        // emit any "no e-marker" wording there.
+        let isMagSafe = port.portTypeDescription?.hasPrefix("MagSafe") == true
         if hasEmarker {
             bullets.append("Cable has an e-marker chip (advertises its capabilities)")
-        } else if !active.isEmpty {
+        } else if !active.isEmpty && !isMagSafe {
             if pdCapable {
                 bullets.append("Cable does not advertise an e-marker (basic cable)")
             } else {

--- a/Tests/WhatCableCoreTests/PortSummaryTests.swift
+++ b/Tests/WhatCableCoreTests/PortSummaryTests.swift
@@ -195,6 +195,48 @@ final class PortSummaryTests: XCTestCase {
         )
     }
 
+    func testMagSafePortDoesNotClaimNoPowerDelivery() {
+        // Regression: a charging MagSafe port reports an empty
+        // TransportsSupported (MagSafe negotiates PD over its own pins,
+        // not the CC line). The previous logic tripped the "no Power
+        // Delivery" branch because `pdCapable` is gated on CC. MagSafe
+        // ports must not get any "can't read cable details" bullet at
+        // all, since the cable is built into the brick.
+        let magSafePort = USBCPort(
+            id: 1,
+            serviceName: "Port-MagSafe 3@1",
+            className: "AppleHPMInterfaceType11",
+            portDescription: "Port-MagSafe 3@1",
+            portTypeDescription: "MagSafe 3",
+            portNumber: 1,
+            connectionActive: true,
+            activeCable: nil, opticalCable: nil, usbActive: nil, superSpeedActive: nil,
+            usbModeType: nil, usbConnectString: nil,
+            transportsSupported: [],
+            transportsActive: ["CC"],
+            transportsProvisioned: ["CC"],
+            plugOrientation: nil, plugEventCount: nil, connectionCount: nil,
+            overcurrentCount: nil, pinConfiguration: [:], powerCurrentLimits: [],
+            firmwareVersion: nil, bootFlagsHex: nil, rawProperties: [:]
+        )
+        let summary = PortSummary(
+            port: magSafePort,
+            sources: [usbPD(maxW: 100, winningW: 100)]
+        )
+        XCTAssertFalse(
+            summary.bullets.contains(where: { $0.contains("no Power Delivery") }),
+            "MagSafe must not claim 'no Power Delivery', got: \(summary.bullets)"
+        )
+        XCTAssertFalse(
+            summary.bullets.contains(where: { $0.contains("can't read cable details") }),
+            "MagSafe must not show the 'can't read cable details' bullet, got: \(summary.bullets)"
+        )
+        XCTAssertFalse(
+            summary.bullets.contains(where: { $0.contains("does not advertise") }),
+            "MagSafe must not show the 'basic cable' bullet, got: \(summary.bullets)"
+        )
+    }
+
     func testPDPortWithEmarkerStillShowsEmarker() {
         // Sanity: presence of an e-marker means PD must have fired, regardless
         // of whether the test fixture happens to set CC explicitly. We don't


### PR DESCRIPTION
## Summary

The "This port can't read cable details (USB-only port, no Power Delivery)" bullet added in v0.7.0 (PR #54) was firing on MagSafe ports while they were actively negotiating PD. MagSafe carries Power Delivery over its own pins, not the CC line that `pdCapable` is gated on, so its empty `TransportsSupported` made the gate think there's no PD. A charging MagSafe port could show "no Power Delivery" right next to "Charging well at 100W", which is plainly wrong.

The fix suppresses the entire cable-details bullet group (e-marker / basic cable / no-PD) on MagSafe. The bullet only makes sense on USB-C where the user can swap the cable; on MagSafe the cable is part of the brick.

## Test plan

- [x] `swift test` (134 tests pass, 1 new)
- [x] Added `testMagSafePortDoesNotClaimNoPowerDelivery` covering the reported scenario: charging MagSafe port with empty `TransportsSupported`, asserts none of the three cable-details wordings appear.
