### PR TITLE
Show modal alert when 'Check for Updates' finds a new version

### DIFF
--- a/Sources/WhatCable/UpdateChecker.swift
+++ b/Sources/WhatCable/UpdateChecker.swift
@@ -98,6 +98,13 @@ final class UpdateChecker: ObservableObject {
                         self.notifiedVersion = remote
                         self.postNotification(update)
                     }
+                    if visible {
+                        // Manual "Check for Updates" click: surface a modal
+                        // alert so the user gets the same feedback they get
+                        // when already up-to-date, with a button to open the
+                        // release page directly.
+                        self.showUpdateAlert(update)
+                    }
                 } else {
                     self.available = nil
                     if visible {
@@ -136,6 +143,26 @@ final class UpdateChecker: ObservableObject {
         alert.runModal()
 
         NSApp.setActivationPolicy(originalPolicy)
+    }
+
+    private func showUpdateAlert(_ update: AvailableUpdate) {
+        let originalPolicy = NSApp.activationPolicy()
+        NSApp.setActivationPolicy(.regular)
+        NSApp.activate(ignoringOtherApps: true)
+
+        let alert = NSAlert()
+        alert.messageText = "WhatCable \(update.version) is available"
+        alert.informativeText = "You're on \(AppInfo.version). Open the release page to read the notes and download."
+        alert.window.level = .floating
+        alert.addButton(withTitle: "View Release")
+        alert.addButton(withTitle: "Later")
+        let response = alert.runModal()
+
+        NSApp.setActivationPolicy(originalPolicy)
+
+        if response == .alertFirstButtonReturn {
+            NSWorkspace.shared.open(update.url)
+        }
     }
 
     /// Compare dot-separated numeric versions. Non-numeric segments compare lexically.


### PR DESCRIPTION
## Summary

The manual "Check for Updates…" menu item showed a modal alert when no update was available, but when an update *was* available it only set internal state for the popover banner and posted a system notification (which is per-version dedup'd and can be suppressed in Notification Center). Users clicking the menu item with a real update waiting got no immediate feedback.

This PR adds a parallel modal alert for the update-available case with two buttons: **View Release** opens the GitHub release page, **Later** dismisses. The menu item now gives predictable feedback either way.

## Test plan

- [x] `swift build` succeeds
- [ ] Manual: launch the app on an older version, click "Check for Updates…", expect the new alert with both buttons. Click "View Release" and confirm the release page opens.
- [ ] Manual: with the latest version installed, click "Check for Updates…" and confirm the existing "You're up to date" alert still appears.

No automated test: this is GUI-only modal code; the existing UpdateChecker has no unit-test surface.
