### PR TITLE
Add Thunderbolt fabric: report negotiated link state and topology

### DIFF
--- a/Sources/WhatCable/ContentView.swift
+++ b/Sources/WhatCable/ContentView.swift
@@ -7,6 +7,7 @@ struct ContentView: View {
     @StateObject private var deviceWatcher = USBWatcher()
     @StateObject private var powerWatcher = PowerSourceWatcher()
     @StateObject private var pdWatcher = PDIdentityWatcher()
+    @StateObject private var tbWatcher = ThunderboltWatcher()
     @EnvironmentObject private var refresh: RefreshSignal
     @ObservedObject private var settings = AppSettings.shared
     @ObservedObject private var updates = UpdateChecker.shared
@@ -30,6 +31,7 @@ struct ContentView: View {
             deviceWatcher.start()
             powerWatcher.start()
             pdWatcher.start()
+            tbWatcher.start()
             startPortPoll()
         }
         .onDisappear {
@@ -41,11 +43,13 @@ struct ContentView: View {
             deviceWatcher.stop()
             powerWatcher.stop()
             pdWatcher.stop()
+            tbWatcher.stop()
         }
         .onChange(of: refresh.tick) { _, _ in
             portWatcher.refresh()
             powerWatcher.refresh()
             pdWatcher.refresh()
+            tbWatcher.refresh()
         }
         // Port controller services don't fire IOKit match notifications when
         // their connection state flips, so we re-poll the port watcher
@@ -116,6 +120,7 @@ struct ContentView: View {
                                 devices: matchingDevices(for: port),
                                 powerSources: powerWatcher.sources(for: port),
                                 identities: pdWatcher.identities(for: port),
+                                thunderboltSwitches: tbWatcher.switches,
                                 isLive: isPortLive(port),
                                 showAdvanced: showAdvanced
                             )
@@ -322,6 +327,7 @@ struct PortCard: View {
     let devices: [USBDevice]
     let powerSources: [PowerSource]
     let identities: [PDIdentity]
+    let thunderboltSwitches: [ThunderboltSwitch]
     /// Authoritative connection state derived from the live IOKit watchers,
     /// passed in from the parent so we don't have to consult them from here
     /// and so PortSummary doesn't fall back to the unreliable
@@ -337,8 +343,19 @@ struct PortCard: View {
             sources: powerSources,
             identities: identities,
             devices: devices,
+            thunderboltSwitches: thunderboltSwitches,
             isConnectedOverride: isLive
         )
+    }
+
+    /// Switches in the chain from this port's host root to the deepest
+    /// connected device. Empty if the port doesn't map to any TB switch.
+    var thunderboltChain: [ThunderboltSwitch] {
+        guard let socketID = ThunderboltTopology.socketID(fromServiceName: port.serviceName),
+              let root = ThunderboltTopology.hostRoot(forSocketID: socketID, in: thunderboltSwitches) else {
+            return []
+        }
+        return ThunderboltTopology.chain(from: root, in: thunderboltSwitches)
     }
 
     private var cableEmarker: PDIdentity? {
@@ -423,7 +440,7 @@ struct PortCard: View {
 
             if showAdvanced {
                 Divider()
-                AdvancedPortDetails(port: port)
+                AdvancedPortDetails(port: port, thunderboltChain: thunderboltChain)
             }
         }
         .padding(14)
@@ -492,6 +509,7 @@ struct PowerSourceList: View {
 
 struct AdvancedPortDetails: View {
     let port: USBCPort
+    let thunderboltChain: [ThunderboltSwitch]
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -507,6 +525,9 @@ struct AdvancedPortDetails: View {
                 row("Supported", port.transportsSupported.joined(separator: ", "))
                 row("Provisioned", port.transportsProvisioned.joined(separator: ", "))
                 row("Active", port.transportsActive.isEmpty ? "—" : port.transportsActive.joined(separator: ", "))
+            }
+            if !thunderboltChain.isEmpty {
+                ThunderboltFabricSection(chain: thunderboltChain)
             }
             DisclosureGroup("All raw IOKit properties (\(port.rawProperties.count))") {
                 VStack(alignment: .leading, spacing: 2) {
@@ -545,6 +566,42 @@ struct AdvancedPortDetails: View {
     private func bool(_ v: Bool?) -> String {
         guard let v else { return "—" }
         return v ? "Yes" : "No"
+    }
+}
+
+/// Compact tree view of the Thunderbolt fabric for one port. Shows the
+/// host root, every downstream switch in the chain, and the active
+/// downstream lane port's link state for each hop. Hidden behind the
+/// existing "show technical details" toggle.
+struct ThunderboltFabricSection: View {
+    let chain: [ThunderboltSwitch]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("Thunderbolt fabric")
+                .font(.caption).bold().foregroundStyle(.secondary)
+            ForEach(Array(chain.enumerated()), id: \.element.id) { index, sw in
+                hopRow(sw, index: index)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func hopRow(_ sw: ThunderboltSwitch, index: Int) -> some View {
+        let indent = String(repeating: "  ", count: index)
+        let arrow = index == 0 ? "" : "↳ "
+        let name = sw.isHostRoot ? "Host (\(sw.className))" : ThunderboltLabels.deviceName(for: sw)
+        let port = ThunderboltTopology.activeDownstreamLanePort(sw)
+        let linkLabel = port.flatMap { ThunderboltLabels.linkLabel(for: $0) } ?? "no active link"
+
+        HStack(alignment: .top) {
+            Text("\(indent)\(arrow)\(name)")
+                .font(.system(.caption, design: .monospaced))
+            Spacer()
+            Text(linkLabel)
+                .font(.system(.caption, design: .monospaced))
+                .foregroundStyle(.secondary)
+        }
     }
 }
 

--- a/Sources/WhatCableCLI/WhatCableCLI.swift
+++ b/Sources/WhatCableCLI/WhatCableCLI.swift
@@ -140,7 +140,8 @@ private func consumeWatchStream(provider: any CableSnapshotProvider, asJSON: Boo
                         sources: snapshot.powerSources,
                         identities: snapshot.identities,
                         showRaw: showRaw,
-                        adapter: snapshot.adapter
+                        adapter: snapshot.adapter,
+                        thunderboltSwitches: snapshot.thunderboltSwitches
                     )
                 } catch {
                     FileHandle.standardError.write(Data("whatcable: json encoding failed: \(error)\n".utf8))
@@ -152,7 +153,8 @@ private func consumeWatchStream(provider: any CableSnapshotProvider, asJSON: Boo
                     sources: snapshot.powerSources,
                     identities: snapshot.identities,
                     showRaw: showRaw,
-                    adapter: snapshot.adapter
+                    adapter: snapshot.adapter,
+                    thunderboltSwitches: snapshot.thunderboltSwitches
                 )
             }
 

--- a/Sources/WhatCableCLI/WhatCableCLI.swift
+++ b/Sources/WhatCableCLI/WhatCableCLI.swift
@@ -83,7 +83,8 @@ private func printSnapshot(_ snapshot: CableSnapshot, asJSON: Bool, showRaw: Boo
             sources: snapshot.powerSources,
             identities: snapshot.identities,
             showRaw: showRaw,
-            adapter: snapshot.adapter
+            adapter: snapshot.adapter,
+            thunderboltSwitches: snapshot.thunderboltSwitches
         )
         print(json)
     } else {
@@ -92,7 +93,8 @@ private func printSnapshot(_ snapshot: CableSnapshot, asJSON: Bool, showRaw: Boo
             sources: snapshot.powerSources,
             identities: snapshot.identities,
             showRaw: showRaw,
-            adapter: snapshot.adapter
+            adapter: snapshot.adapter,
+            thunderboltSwitches: snapshot.thunderboltSwitches
         )
         print(output, terminator: "")
     }

--- a/Sources/WhatCableCore/CableSnapshot.swift
+++ b/Sources/WhatCableCore/CableSnapshot.swift
@@ -22,19 +22,26 @@ public struct CableSnapshot: Equatable {
     public let identities: [PDIdentity]
     public let usbDevices: [USBDevice]
     public let adapter: AdapterInfo?
+    /// Top-level array of every Thunderbolt switch the host can see. Empty
+    /// on machines without a Thunderbolt controller, or when IOKit returns
+    /// nothing (the JSON shape adds the key but with an empty array, so
+    /// downstream consumers can rely on the field always being present).
+    public let thunderboltSwitches: [ThunderboltSwitch]
 
     public init(
         ports: [USBCPort],
         powerSources: [PowerSource],
         identities: [PDIdentity],
         usbDevices: [USBDevice],
-        adapter: AdapterInfo?
+        adapter: AdapterInfo?,
+        thunderboltSwitches: [ThunderboltSwitch] = []
     ) {
         self.ports = ports
         self.powerSources = powerSources
         self.identities = identities
         self.usbDevices = usbDevices
         self.adapter = adapter
+        self.thunderboltSwitches = thunderboltSwitches
     }
 }
 

--- a/Sources/WhatCableCore/JSONFormatter.swift
+++ b/Sources/WhatCableCore/JSONFormatter.swift
@@ -6,7 +6,8 @@ public enum JSONFormatter {
         sources: [PowerSource],
         identities: [PDIdentity],
         showRaw: Bool,
-        adapter: AdapterInfo? = nil
+        adapter: AdapterInfo? = nil,
+        thunderboltSwitches: [ThunderboltSwitch] = []
     ) throws -> String {
         let output = Output(
             version: AppInfo.version,
@@ -15,10 +16,12 @@ public enum JSONFormatter {
                     port: port,
                     sources: sources.filter { $0.portKey == port.portKey },
                     identities: identities.filter { $0.portKey == port.portKey },
+                    thunderboltSwitches: thunderboltSwitches,
                     showRaw: showRaw,
                     adapter: adapter
                 )
-            }
+            },
+            thunderboltSwitches: thunderboltSwitches.map { ThunderboltSwitchDTO(sw: $0) }
         )
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
@@ -30,6 +33,11 @@ public enum JSONFormatter {
 private struct Output: Codable {
     let version: String
     let ports: [PortDTO]
+    /// Top-level Thunderbolt fabric. Always present (empty array on
+    /// machines without a TB controller, or before the watcher has data).
+    /// Per-port `thunderboltSwitchUID` references this graph by UID rather
+    /// than nesting the whole switch under each port.
+    let thunderboltSwitches: [ThunderboltSwitchDTO]
 }
 
 private struct PortDTO: Codable {
@@ -47,20 +55,46 @@ private struct PortDTO: Codable {
     let cable: CableDTO?
     let device: DeviceDTO?
     let charging: ChargingDTO?
+    /// UID of the host root Thunderbolt switch this port maps to, if any.
+    /// Resolved via the `Socket ID` <-> `@N` join key. Encoded as Int64
+    /// (signed, matching IOKit's representation; some vendors use the
+    /// sign bit). nil for ports that aren't TB-protocol or for which the
+    /// watcher hasn't found a match.
+    let thunderboltSwitchUID: Int64?
     let rawProperties: [String: String]?
 
-    init(port: USBCPort, sources: [PowerSource], identities: [PDIdentity], showRaw: Bool, adapter: AdapterInfo?) {
+    init(
+        port: USBCPort,
+        sources: [PowerSource],
+        identities: [PDIdentity],
+        thunderboltSwitches: [ThunderboltSwitch],
+        showRaw: Bool,
+        adapter: AdapterInfo?
+    ) {
         self.name = port.portDescription ?? port.serviceName
         self.type = port.portTypeDescription
         self.className = port.className
         self.connectionActive = port.connectionActive ?? false
         self.pdCapable = port.transportsSupported.contains("CC")
 
-        let summary = PortSummary(port: port, sources: sources, identities: identities)
+        let summary = PortSummary(
+            port: port,
+            sources: sources,
+            identities: identities,
+            thunderboltSwitches: thunderboltSwitches
+        )
         self.status = String(describing: summary.status)
         self.headline = summary.headline
         self.subtitle = summary.subtitle
         self.bullets = summary.bullets
+
+        // Resolve the host-root switch UID via Socket ID matching.
+        if let socketID = ThunderboltTopology.socketID(fromServiceName: port.serviceName),
+           let root = ThunderboltTopology.hostRoot(forSocketID: socketID, in: thunderboltSwitches) {
+            self.thunderboltSwitchUID = root.id
+        } else {
+            self.thunderboltSwitchUID = nil
+        }
 
         self.transports = TransportsDTO(
             supported: port.transportsSupported,
@@ -177,6 +211,108 @@ private struct DeviceDTO: Codable {
         self.vendorID = identity.vendorID
         self.vendorName = VendorDB.name(for: identity.vendorID)
         self.productID = identity.productID
+    }
+}
+
+// MARK: - Thunderbolt fabric DTOs
+
+/// One Thunderbolt switch in JSON form. Encoded once at the top level of
+/// the snapshot; per-port references use `thunderboltSwitchUID`. Avoids
+/// duplicating the whole graph under every port.
+private struct ThunderboltSwitchDTO: Codable {
+    let uid: Int64
+    let className: String
+    let vendorID: Int
+    let vendorName: String
+    let modelName: String
+    let depth: Int
+    let routerID: Int
+    let routeString: Int64
+    let upstreamPortNumber: Int
+    let maxPortNumber: Int
+    let supportedSpeedMask: Int
+    let parentSwitchUID: Int64?
+    let ports: [ThunderboltPortDTO]
+
+    init(sw: ThunderboltSwitch) {
+        self.uid = sw.id
+        self.className = sw.className
+        self.vendorID = sw.vendorID
+        self.vendorName = sw.vendorName
+        self.modelName = sw.modelName
+        self.depth = sw.depth
+        self.routerID = sw.routerID
+        self.routeString = sw.routeString
+        self.upstreamPortNumber = sw.upstreamPortNumber
+        self.maxPortNumber = sw.maxPortNumber
+        self.supportedSpeedMask = Int(sw.supportedSpeed.rawValue)
+        self.parentSwitchUID = sw.parentSwitchUID
+        self.ports = sw.ports.map { ThunderboltPortDTO(port: $0) }
+    }
+}
+
+private struct ThunderboltPortDTO: Codable {
+    let portNumber: Int
+    let socketID: String?
+    let adapterType: String
+    let linkActive: Bool
+    let linkLabel: String?
+    let generation: String?
+    let perLaneGbps: Int?
+    let txLanes: Int?
+    let rxLanes: Int?
+    let rawSpeedCode: Int?
+    let rawWidthCode: Int?
+    let rawTargetSpeed: Int?
+    let linkBandwidthRaw: Int?
+
+    init(port: ThunderboltPort) {
+        self.portNumber = port.portNumber
+        self.socketID = port.socketID
+        self.adapterType = Self.adapterTypeLabel(port.adapterType)
+        self.linkActive = port.hasActiveLink
+        self.linkLabel = ThunderboltLabels.linkLabel(for: port)
+        self.generation = port.currentSpeed.map { Self.generationLabel($0) }
+        self.perLaneGbps = port.perLaneGbps
+        self.txLanes = port.txLanes
+        self.rxLanes = port.rxLanes
+        self.rawSpeedCode = port.currentSpeed.map { Self.rawSpeedCode($0) }
+        self.rawWidthCode = port.currentWidth.map { Int($0.rawValue) }
+        self.rawTargetSpeed = port.rawTargetSpeed.map { Int($0) }
+        self.linkBandwidthRaw = port.linkBandwidthRaw
+    }
+
+    private static func adapterTypeLabel(_ type: AdapterType) -> String {
+        switch type {
+        case .inactive: return "inactive"
+        case .lane: return "lane"
+        case .nhi: return "nhi"
+        case .dpIn: return "dpIn"
+        case .dpOut: return "dpOut"
+        case .pcieDown: return "pcieDown"
+        case .pcieUp: return "pcieUp"
+        case .usb3Down: return "usb3Down"
+        case .usb3Up: return "usb3Up"
+        case .other(let raw): return "other(0x\(String(raw, radix: 16)))"
+        }
+    }
+
+    private static func generationLabel(_ gen: LinkGeneration) -> String {
+        switch gen {
+        case .tb3: return "tb3"
+        case .usb4Tb4: return "usb4Tb4"
+        case .tb5: return "tb5"
+        case .unknown(let raw): return "unknown(0x\(String(raw, radix: 16)))"
+        }
+    }
+
+    private static func rawSpeedCode(_ gen: LinkGeneration) -> Int {
+        switch gen {
+        case .tb3: return 0x8
+        case .usb4Tb4: return 0x4
+        case .tb5: return 0x2
+        case .unknown(let raw): return Int(raw)
+        }
     }
 }
 

--- a/Sources/WhatCableCore/JSONFormatter.swift
+++ b/Sources/WhatCableCore/JSONFormatter.swift
@@ -301,7 +301,13 @@ private struct ThunderboltPortDTO: Codable {
         switch gen {
         case .tb3: return "tb3"
         case .usb4Tb4: return "usb4Tb4"
-        case .tb5: return "tb5"
+        // TB5 stays hedged in JSON for the same reason as the text
+        // renderer: the 0x2 -> TB5 mapping is inferred from Linux
+        // register definitions but not yet verified against an Apple
+        // Silicon TB5 paste-back. Machine consumers that want the raw
+        // code can read `rawSpeedCode` directly. The label flips to
+        // `"tb5"` once verified.
+        case .tb5: return "unknown(0x2_inferredTb5)"
         case .unknown(let raw): return "unknown(0x\(String(raw, radix: 16)))"
         }
     }

--- a/Sources/WhatCableCore/PortSummary.swift
+++ b/Sources/WhatCableCore/PortSummary.swift
@@ -38,6 +38,7 @@ extension PortSummary {
         sources: [PowerSource] = [],
         identities: [PDIdentity] = [],
         devices: [USBDevice] = [],
+        thunderboltSwitches: [ThunderboltSwitch] = [],
         isConnectedOverride: Bool? = nil
     ) {
         let connected = isConnectedOverride ?? (port.connectionActive == true)
@@ -76,7 +77,16 @@ extension PortSummary {
 
         // Speed
         if hasTB {
-            bullets.append("Thunderbolt / USB4 link active")
+            // If we have a matching Thunderbolt switch graph for this port,
+            // emit specific link-state bullets (negotiated speed, lane
+            // count, daisy-chain info). Otherwise fall back to the generic
+            // "active" line so older paths still work.
+            let tbBullets = thunderboltBullets(for: port, switches: thunderboltSwitches)
+            if tbBullets.isEmpty {
+                bullets.append("Thunderbolt / USB4 link active")
+            } else {
+                bullets.append(contentsOf: tbBullets)
+            }
         } else if hasUSB3 {
             bullets.append("SuperSpeed USB (5 Gbps or faster)")
         } else if hasUSB2 {
@@ -191,6 +201,73 @@ extension PortSummary {
 
         self.bullets = bullets
     }
+}
+
+/// Build the TB-specific bullets for a port whose `transportsActive`
+/// includes `"CIO"`. Returns an empty array if we can't find a matching
+/// switch (e.g. the port doesn't have an `@N` suffix, or the Thunderbolt
+/// watcher hasn't populated yet). Caller falls back to a generic bullet
+/// in that case.
+private func thunderboltBullets(
+    for port: USBCPort,
+    switches: [ThunderboltSwitch]
+) -> [String] {
+    guard !switches.isEmpty,
+          let socketID = ThunderboltTopology.socketID(fromServiceName: port.serviceName),
+          let root = ThunderboltTopology.hostRoot(forSocketID: socketID, in: switches) else {
+        return []
+    }
+
+    let chain = ThunderboltTopology.chain(from: root, in: switches)
+    var bullets: [String] = []
+
+    // First-hop link state: the host root's downstream lane port describes
+    // the cable's negotiated speed.
+    if let hostPort = ThunderboltTopology.activeDownstreamLanePort(root),
+       let label = ThunderboltLabels.linkLabel(for: hostPort) {
+        // label is e.g. "Up to 20 Gb/s × 2" — replace the leading "Up"
+        // with "up" for the bullet phrasing without lowercasing units.
+        bullets.append("Linked at " + label.replacingOccurrences(of: "Up to", with: "up to"))
+    }
+
+    // Connected-device line. Only meaningful when there's at least one
+    // downstream switch.
+    let downstream = chain.dropFirst()
+    if !downstream.isEmpty {
+        let names = downstream.map { ThunderboltLabels.deviceName(for: $0) }
+        let hops = downstream.count
+        let path = names.joined(separator: " → ")
+        let prefix = hops == 1 ? "Connected to" : "Connected via \(hops) hops:"
+        bullets.append("\(prefix) \(path)")
+    }
+
+    // Step-down detection: compare the last leg's link to the host port's
+    // link. If the per-lane Gbps or lane count drops, surface it so the
+    // user knows the slowest leg.
+    if downstream.count >= 1,
+       let hostPort = ThunderboltTopology.activeDownstreamLanePort(root),
+       let last = downstream.last,
+       let lastLeg = ThunderboltTopology.activeDownstreamLanePort(last)
+            ?? last.ports.first(where: { $0.adapterType.isLane && $0.hasActiveLink }),
+       let stepLabel = stepDownLabel(host: hostPort, lastLeg: lastLeg) {
+        bullets.append(stepLabel)
+    }
+
+    return bullets
+}
+
+/// If the last-leg link is slower than the host link (per-lane Gbps drop
+/// or lane count drop), describe the change. Returns nil for symmetric
+/// chains where every leg matches.
+private func stepDownLabel(host: ThunderboltPort, lastLeg: ThunderboltPort) -> String? {
+    guard let hostLabel = ThunderboltLabels.linkLabel(for: host),
+          let lastLabel = ThunderboltLabels.linkLabel(for: lastLeg) else {
+        return nil
+    }
+    if hostLabel == lastLabel { return nil }
+    let h = hostLabel.replacingOccurrences(of: "Up to", with: "up to")
+    let l = lastLabel.replacingOccurrences(of: "Up to", with: "up to")
+    return "Last leg drops from \(h) to \(l)"
 }
 
 private func subtitleForCapabilities(usb3: Bool, dp: Bool, emarker: Bool) -> String {

--- a/Sources/WhatCableCore/PortSummary.swift
+++ b/Sources/WhatCableCore/PortSummary.swift
@@ -241,10 +241,16 @@ private func thunderboltBullets(
         bullets.append("\(prefix) \(path)")
     }
 
-    // Step-down detection: compare the last leg's link to the host port's
-    // link. If the per-lane Gbps or lane count drops, surface it so the
-    // user knows the slowest leg.
-    if downstream.count >= 1,
+    // Step-down detection: only meaningful on real daisy-chains
+    // (two or more downstream switches). On a single-hop link, the
+    // host's downstream port and the device's upstream port describe
+    // the SAME physical cable from opposite ends; the two readings can
+    // disagree on lane count (the controller-side view aggregates lanes
+    // that the device-side view doesn't), and that disagreement is not
+    // a real step-down. With two or more hops, comparing the first link
+    // (host -> device 1) to the last link (device N-1 -> device N)
+    // genuinely contrasts two distinct cables.
+    if downstream.count >= 2,
        let hostPort = ThunderboltTopology.activeDownstreamLanePort(root),
        let last = downstream.last,
        let lastLeg = ThunderboltTopology.activeDownstreamLanePort(last)

--- a/Sources/WhatCableCore/TextFormatter.swift
+++ b/Sources/WhatCableCore/TextFormatter.swift
@@ -6,7 +6,8 @@ public enum TextFormatter {
         sources: [PowerSource],
         identities: [PDIdentity],
         showRaw: Bool,
-        adapter: AdapterInfo? = nil
+        adapter: AdapterInfo? = nil,
+        thunderboltSwitches: [ThunderboltSwitch] = []
     ) -> String {
         if ports.isEmpty {
             return "No USB-C / MagSafe ports were found on this Mac.\n"
@@ -20,7 +21,8 @@ public enum TextFormatter {
                 sources: filterSources(port, all: sources),
                 identities: filterIdentities(port, all: identities),
                 showRaw: showRaw,
-                adapter: adapter
+                adapter: adapter,
+                thunderboltSwitches: thunderboltSwitches
             )
         }
         return out
@@ -31,9 +33,15 @@ public enum TextFormatter {
         sources: [PowerSource],
         identities: [PDIdentity],
         showRaw: Bool,
-        adapter: AdapterInfo?
+        adapter: AdapterInfo?,
+        thunderboltSwitches: [ThunderboltSwitch]
     ) -> String {
-        let summary = PortSummary(port: port, sources: sources, identities: identities)
+        let summary = PortSummary(
+            port: port,
+            sources: sources,
+            identities: identities,
+            thunderboltSwitches: thunderboltSwitches
+        )
         let label = port.portDescription ?? port.serviceName
         let typeSuffix = port.portTypeDescription.map { " (\($0))" } ?? ""
 

--- a/Sources/WhatCableCore/ThunderboltLabels.swift
+++ b/Sources/WhatCableCore/ThunderboltLabels.swift
@@ -1,0 +1,132 @@
+import Foundation
+
+/// Pure helpers that turn `ThunderboltSwitch` / `ThunderboltPort` model
+/// values into user-facing labels. Convention: per-lane Gb/s × lane count,
+/// matching Apple's `system_profiler SPThunderboltDataType` output so the
+/// labels line up with what users see in About This Mac → System Information.
+///
+/// Conservative on TB5: even though the model decodes raw speed code `0x2`
+/// to `LinkGeneration.tb5`, the renderer treats that as unverified and emits
+/// a hedge label until we have a real Apple Silicon TB5 paste-back. See
+/// planning/thunderbolt-fabric.md for the reasoning.
+public enum ThunderboltLabels {
+    /// Compact human label for an active TB link.
+    /// Returns nil if the port has no active link.
+    /// Examples:
+    /// - `"Up to 20 Gb/s × 2"` (USB4 / TB4 dual-lane)
+    /// - `"Up to 10 Gb/s × 1"` (TB3 single-lane)
+    /// - `"Unknown generation (raw speed code 0x2)"` (TB5 inferred but not verified)
+    public static func linkLabel(for port: ThunderboltPort) -> String? {
+        guard port.hasActiveLink,
+              let gen = port.currentSpeed,
+              let width = port.currentWidth else {
+            return nil
+        }
+
+        // Hedge wording when we don't have a verified label. TB5 is in
+        // this bucket until a real Apple Silicon TB5 sample lands.
+        switch gen {
+        case .tb3, .usb4Tb4:
+            guard let perLane = gen.perLaneGbps else { return nil }
+            let lanes = describeLanes(width)
+            return "Up to \(perLane) Gb/s \(lanes)"
+        case .tb5:
+            // Don't emit a "TB5" or "40 Gb/s" label yet — encoding inferred,
+            // not yet verified against real hardware.
+            return "Unknown generation (raw speed code 0x2, inferred TB5)"
+        case .unknown(let raw):
+            return "Unknown generation (raw speed code 0x\(String(raw, radix: 16)))"
+        }
+    }
+
+    /// Lane-count suffix. Symmetric links read `× N`; asymmetric links
+    /// (TB5 3+1 configurations) read `(N TX / M RX)`.
+    private static func describeLanes(_ width: LinkWidth) -> String {
+        if width.asymmetricTx || width.asymmetricRx {
+            return "(\(width.txLanes) TX / \(width.rxLanes) RX)"
+        }
+        // Symmetric: just lane count.
+        let lanes = max(width.txLanes, 1)
+        return "× \(lanes)"
+    }
+
+    /// Human-readable name for a downstream switch ("ASUS PA32QCV",
+    /// "CalDigit, Inc. TS3 Plus"). Falls back to "Unknown device" if the
+    /// DROM didn't decode (rare but possible).
+    public static func deviceName(for sw: ThunderboltSwitch) -> String {
+        let vendor = sw.vendorName.trimmingCharacters(in: .whitespaces)
+        let model = sw.modelName.trimmingCharacters(in: .whitespaces)
+        switch (vendor.isEmpty, model.isEmpty) {
+        case (false, false): return "\(vendor) \(model)"
+        case (false, true): return vendor
+        case (true, false): return model
+        case (true, true): return "Unknown device"
+        }
+    }
+}
+
+/// Topology helpers: walk the switch graph to find the chain rooted at a
+/// host port. Pure logic; no IOKit. Used by `PortSummary` and the GUI.
+public enum ThunderboltTopology {
+    /// Find the host root switch whose lane port has `Socket ID == "N"`,
+    /// where N is parsed from a USB-C port's serviceName suffix
+    /// (e.g. `Port-USB-C@1` → `1`).
+    public static func hostRoot(
+        forSocketID socketID: String,
+        in switches: [ThunderboltSwitch]
+    ) -> ThunderboltSwitch? {
+        switches.first { sw in
+            sw.isHostRoot && sw.ports.contains {
+                $0.adapterType.isLane && $0.socketID == socketID
+            }
+        }
+    }
+
+    /// Parse the trailing `@N` suffix from a port serviceName, or nil if
+    /// it doesn't have one. `Port-USB-C@1` → `"1"`.
+    public static func socketID(fromServiceName name: String) -> String? {
+        guard let at = name.lastIndex(of: "@") else { return nil }
+        let suffix = name[name.index(after: at)...]
+        return suffix.isEmpty ? nil : String(suffix)
+    }
+
+    /// Return the chain of downstream switches reachable from a host root,
+    /// in depth order (root → device). Walks the `parentSwitchUID` graph.
+    /// Returns just the root if there's nothing downstream.
+    public static func chain(
+        from root: ThunderboltSwitch,
+        in switches: [ThunderboltSwitch]
+    ) -> [ThunderboltSwitch] {
+        var byParent: [Int64: [ThunderboltSwitch]] = [:]
+        for sw in switches {
+            guard let parentUID = sw.parentSwitchUID else { continue }
+            byParent[parentUID, default: []].append(sw)
+        }
+
+        var chain: [ThunderboltSwitch] = [root]
+        var current = root
+        // Follow first-child only. Daisy-chains are linear in the common
+        // case; if the user has a true tree (dock with two TB devices),
+        // the chain follows the first downstream branch and the GUI tree
+        // can render the full topology separately.
+        while let children = byParent[current.id], let next = children.first {
+            chain.append(next)
+            current = next
+        }
+        return chain
+    }
+
+    /// Find the active downstream lane port on a switch (the one going
+    /// toward the next-hop device, not the upstream link to the host).
+    /// Useful for picking which port's link state describes the next leg.
+    public static func activeDownstreamLanePort(_ sw: ThunderboltSwitch) -> ThunderboltPort? {
+        // Host root: any active lane port is downstream by definition.
+        // Downstream switch: skip the lane port matching upstreamPortNumber,
+        // pick the first active one of the rest.
+        let candidates = sw.ports.filter { $0.adapterType.isLane && $0.hasActiveLink }
+        if sw.isHostRoot {
+            return candidates.first
+        }
+        return candidates.first { $0.portNumber != sw.upstreamPortNumber }
+    }
+}

--- a/Sources/WhatCableCore/ThunderboltLink.swift
+++ b/Sources/WhatCableCore/ThunderboltLink.swift
@@ -1,0 +1,366 @@
+import Foundation
+
+// MARK: - Generation / width / adapter enums
+//
+// These decode the raw IOKit field values into Swift cases. Encoding is
+// anchored against Linux's `drivers/thunderbolt/tb_regs.h`, which describes
+// the same USB4 lane-adapter registers Apple's IOThunderbolt fields appear
+// to mirror. See planning/thunderbolt-fabric.md for the field-by-field
+// reasoning and the contributor samples that confirmed the mapping for
+// TB3 and TB4 / USB4. TB5 (raw speed code 0x2) is supported in the model
+// but the renderer should not produce a TB5 label until we have a real
+// sample — the `LinkGeneration.unknown(rawSpeedCode:)` escape hatch
+// exists for exactly that.
+
+/// Negotiated lane-rate generation for a Thunderbolt link.
+/// Decoded from `Current Link Speed` on a TB-protocol port (Adapter Type = 1).
+public enum LinkGeneration: Hashable {
+    /// Speed code `0x8`. 10 Gb/s per lane.
+    case tb3
+    /// Speed code `0x4`. 20 Gb/s per lane. Used by both USB4 v1 and TB4.
+    /// IOKit doesn't (as far as we've seen) distinguish the two; the
+    /// renderer treats them as one bucket.
+    case usb4Tb4
+    /// Speed code `0x2`. 40 Gb/s per lane. USB4 v2 / TB5.
+    /// Inferred from Linux register definitions; not yet verified against
+    /// an Apple Silicon TB5 hardware sample.
+    case tb5
+    /// Speed code we don't have a mapping for. Forward-compat: future
+    /// generations or unexpected encodings won't break the model.
+    case unknown(rawSpeedCode: UInt8)
+
+    /// Per-lane Gb/s for the known cases. `nil` for `.unknown`.
+    public var perLaneGbps: Int? {
+        switch self {
+        case .tb3: return 10
+        case .usb4Tb4: return 20
+        case .tb5: return 40
+        case .unknown: return nil
+        }
+    }
+
+    /// Build from a raw `Current Link Speed` register value.
+    /// `0` (idle) returns `nil`; the caller treats that as "no link".
+    public static func from(rawSpeedCode: UInt8) -> LinkGeneration? {
+        switch rawSpeedCode {
+        case 0x0: return nil
+        case 0x8: return .tb3
+        case 0x4: return .usb4Tb4
+        case 0x2: return .tb5
+        default: return .unknown(rawSpeedCode: rawSpeedCode)
+        }
+    }
+}
+
+/// Bitmask decoding of `Current Link Speed` (a single value) for use as
+/// a bitmask on `Supported Link Speed`. Each bit set indicates the
+/// controller can negotiate that generation. We keep this as a raw struct
+/// so future generations are representable without a model change.
+public struct SupportedSpeedMask: Hashable {
+    public let supportsTb3: Bool      // bit 0x8
+    public let supportsUsb4Tb4: Bool  // bit 0x4
+    public let supportsTb5: Bool      // bit 0x2
+    public let rawValue: UInt8
+
+    public init(rawValue: UInt8) {
+        self.rawValue = rawValue
+        self.supportsTb3 = (rawValue & 0x8) != 0
+        self.supportsUsb4Tb4 = (rawValue & 0x4) != 0
+        self.supportsTb5 = (rawValue & 0x2) != 0
+    }
+}
+
+/// Decode of `Current Link Width`. This is a bitmask in the Linux model
+/// (`enum tb_link_width`); preserve it as separate flags so a future TB5
+/// asymmetric link is representable without refactoring.
+public struct LinkWidth: Hashable {
+    public let single: Bool        // bit 0x1
+    public let dual: Bool          // bit 0x2
+    public let asymmetricTx: Bool  // bit 0x4 (3 TX / 1 RX)
+    public let asymmetricRx: Bool  // bit 0x8 (1 TX / 3 RX)
+    public let rawValue: UInt8
+
+    public init(rawValue: UInt8) {
+        self.rawValue = rawValue
+        self.single = (rawValue & 0x1) != 0
+        self.dual = (rawValue & 0x2) != 0
+        self.asymmetricTx = (rawValue & 0x4) != 0
+        self.asymmetricRx = (rawValue & 0x8) != 0
+    }
+
+    /// Number of active TX lanes.
+    /// `1` for single, `2` for dual, `3` for asymmetric TX, `1` for asymmetric RX.
+    public var txLanes: Int {
+        if asymmetricTx { return 3 }
+        if asymmetricRx { return 1 }
+        if dual { return 2 }
+        if single { return 1 }
+        return 0
+    }
+
+    /// Number of active RX lanes.
+    public var rxLanes: Int {
+        if asymmetricRx { return 3 }
+        if asymmetricTx { return 1 }
+        if dual { return 2 }
+        if single { return 1 }
+        return 0
+    }
+
+    /// Whether any lane is active.
+    public var isActive: Bool { rawValue != 0 }
+}
+
+/// Decode of `Target Link Width`. Different encoding to Current Link Width:
+/// Linux defines `LANE_ADP_CS_1_TARGET_WIDTH_SINGLE = 0x1` and
+/// `LANE_ADP_CS_1_TARGET_WIDTH_DUAL = 0x3`. So `0x3` here means "negotiated
+/// dual lane", NOT "asymmetric". This was a footgun in the planning phase.
+public enum TargetLinkWidth: Hashable {
+    case single
+    case dual
+    case unknown(rawValue: UInt8)
+
+    public static func from(rawValue: UInt8) -> TargetLinkWidth? {
+        switch rawValue {
+        case 0: return nil
+        case 0x1: return .single
+        case 0x3: return .dual
+        default: return .unknown(rawValue: rawValue)
+        }
+    }
+}
+
+/// Type of adapter on a Thunderbolt port. Each switch has lane adapters
+/// (the actual TB ports) plus protocol adapters that tunnel DP, PCIe, and
+/// USB3 over the fabric. Encoding 1:1 with Linux `tb_regs.h` adapter types.
+///
+/// The `down` / `up` distinction is the adapter's role relative to its
+/// **local** router, not a global host-side / device-side label. In a
+/// daisy-chain, a middle switch has both.
+public enum AdapterType: Hashable {
+    case inactive       // 0x000000
+    case lane           // 0x000001 — physical TB port
+    case nhi            // 0x000002 — host interface (only on root switches)
+    case dpIn           // 0x0e0101
+    case dpOut          // 0x0e0102
+    case pcieDown       // 0x100101
+    case pcieUp         // 0x100102
+    case usb3Down       // 0x200101
+    case usb3Up         // 0x200102
+    case other(UInt32)
+
+    public static func from(rawValue: UInt32) -> AdapterType {
+        switch rawValue {
+        case 0x000000: return .inactive
+        case 0x000001: return .lane
+        case 0x000002: return .nhi
+        case 0x0e0101: return .dpIn
+        case 0x0e0102: return .dpOut
+        case 0x100101: return .pcieDown
+        case 0x100102: return .pcieUp
+        case 0x200101: return .usb3Down
+        case 0x200102: return .usb3Up
+        default: return .other(rawValue)
+        }
+    }
+
+    /// True for the lane (physical TB) adapter. Used to select ports that
+    /// actually carry a Thunderbolt link, as opposed to the protocol
+    /// tunnels above.
+    public var isLane: Bool {
+        if case .lane = self { return true }
+        return false
+    }
+}
+
+// MARK: - Switch and port models
+
+/// One Thunderbolt switch in the fabric. Could be a host root (Depth=0)
+/// or a downstream device's internal switch (Depth>0).
+public struct ThunderboltSwitch: Identifiable, Hashable {
+    public let id: Int64                    // UID (signed Int64; can be negative)
+    public let className: String            // raw IOKit class
+    public let vendorID: Int
+    public let vendorName: String
+    public let modelName: String
+    public let routerID: Int                // 0 on the first host root
+    public let depth: Int                   // hops from host (0 = root)
+    public let routeString: Int64           // path encoding (one byte per hop)
+    public let upstreamPortNumber: Int
+    public let maxPortNumber: Int
+    public let supportedSpeed: SupportedSpeedMask
+    public let ports: [ThunderboltPort]
+    /// Parent switch UID, populated by the watcher via the IOKit parent
+    /// chain. `nil` on host roots. Phase 3 (rendering) uses this to walk
+    /// the topology without re-parsing Route String / Hop Table.
+    public let parentSwitchUID: Int64?
+
+    public init(
+        id: Int64,
+        className: String,
+        vendorID: Int,
+        vendorName: String,
+        modelName: String,
+        routerID: Int,
+        depth: Int,
+        routeString: Int64,
+        upstreamPortNumber: Int,
+        maxPortNumber: Int,
+        supportedSpeed: SupportedSpeedMask,
+        ports: [ThunderboltPort],
+        parentSwitchUID: Int64?
+    ) {
+        self.id = id
+        self.className = className
+        self.vendorID = vendorID
+        self.vendorName = vendorName
+        self.modelName = modelName
+        self.routerID = routerID
+        self.depth = depth
+        self.routeString = routeString
+        self.upstreamPortNumber = upstreamPortNumber
+        self.maxPortNumber = maxPortNumber
+        self.supportedSpeed = supportedSpeed
+        self.ports = ports
+        self.parentSwitchUID = parentSwitchUID
+    }
+
+    /// Build a `ThunderboltSwitch` from a raw IOKit property dictionary
+    /// plus a list of already-parsed child ports. Returns `nil` if the
+    /// dictionary is missing the minimum identifying fields (UID + Vendor ID).
+    /// Lives here in `WhatCableCore` so it can be exercised against fixture
+    /// data without IOKit, mirroring the `USBCPort.from(...)` pattern.
+    public static func from(
+        properties: [String: Any],
+        className: String,
+        ports: [ThunderboltPort],
+        parentSwitchUID: Int64? = nil
+    ) -> ThunderboltSwitch? {
+        guard let uidNum = properties["UID"] as? NSNumber else { return nil }
+        guard let vendorIDNum = properties["Vendor ID"] as? NSNumber else { return nil }
+
+        let speedMaskRaw = (properties["Supported Link Speed"] as? NSNumber)?.uint8Value ?? 0
+        return ThunderboltSwitch(
+            id: uidNum.int64Value,
+            className: className,
+            vendorID: vendorIDNum.intValue,
+            vendorName: (properties["Device Vendor Name"] as? String) ?? "",
+            modelName: (properties["Device Model Name"] as? String) ?? "",
+            routerID: (properties["Router ID"] as? NSNumber)?.intValue ?? 0,
+            depth: (properties["Depth"] as? NSNumber)?.intValue ?? 0,
+            routeString: (properties["Route String"] as? NSNumber)?.int64Value ?? 0,
+            upstreamPortNumber: (properties["Upstream Port Number"] as? NSNumber)?.intValue ?? 0,
+            maxPortNumber: (properties["Max Port Number"] as? NSNumber)?.intValue ?? 0,
+            supportedSpeed: SupportedSpeedMask(rawValue: speedMaskRaw),
+            ports: ports,
+            parentSwitchUID: parentSwitchUID
+        )
+    }
+
+    /// True for switches the host owns directly (Depth=0).
+    public var isHostRoot: Bool { depth == 0 }
+}
+
+/// One adapter on a Thunderbolt switch. Could be a physical TB lane port
+/// (with link-state fields) or a protocol-tunnel adapter (DP, PCIe, USB3).
+public struct ThunderboltPort: Hashable {
+    public let portNumber: Int
+    /// String form of `Socket ID`, present on TB-protocol ports.
+    /// Matches the `@N` suffix on a root host's USB-C port for the
+    /// host-port-to-switch correlation key.
+    public let socketID: String?
+    public let adapterType: AdapterType
+    /// Decoded `Current Link Speed`. `nil` on idle ports or non-lane adapters.
+    public let currentSpeed: LinkGeneration?
+    /// Decoded `Current Link Width`. `nil` on non-lane adapters; on idle
+    /// lane ports, `LinkWidth.isActive` will be false.
+    public let currentWidth: LinkWidth?
+    public let targetWidth: TargetLinkWidth?
+    /// Per-lane Gb/s if we have a known generation, else `nil`. Convenience
+    /// derived from `currentSpeed` so renderers don't need to switch on it.
+    public let perLaneGbps: Int?
+    public let txLanes: Int?
+    public let rxLanes: Int?
+    /// Raw `Target Link Speed`. Don't interpret this as a bitmask in the
+    /// renderer; Linux defines it as a single named value
+    /// (e.g. `LANE_ADP_CS_1_TARGET_SPEED_GEN3 = 0xc`). Kept raw for
+    /// diagnostics.
+    public let rawTargetSpeed: UInt8?
+    /// Raw `Link Bandwidth`. Unitless aggregate that scales with active
+    /// lanes; useful for diagnostics, not for user-facing labels.
+    public let linkBandwidthRaw: Int?
+
+    public init(
+        portNumber: Int,
+        socketID: String?,
+        adapterType: AdapterType,
+        currentSpeed: LinkGeneration?,
+        currentWidth: LinkWidth?,
+        targetWidth: TargetLinkWidth?,
+        rawTargetSpeed: UInt8?,
+        linkBandwidthRaw: Int?
+    ) {
+        self.portNumber = portNumber
+        self.socketID = socketID
+        self.adapterType = adapterType
+        self.currentSpeed = currentSpeed
+        self.currentWidth = currentWidth
+        self.targetWidth = targetWidth
+        self.perLaneGbps = currentSpeed?.perLaneGbps
+        self.txLanes = currentWidth?.txLanes
+        self.rxLanes = currentWidth?.rxLanes
+        self.rawTargetSpeed = rawTargetSpeed
+        self.linkBandwidthRaw = linkBandwidthRaw
+    }
+
+    /// Build a port from a raw IOKit property dictionary.
+    public static func from(properties: [String: Any]) -> ThunderboltPort? {
+        guard let portNumNum = properties["Port Number"] as? NSNumber else { return nil }
+        let adapterRaw = (properties["Adapter Type"] as? NSNumber)?.uint32Value ?? 0
+        let adapter = AdapterType.from(rawValue: adapterRaw)
+
+        // Socket ID is stored as a string in IOKit (e.g. "1", "2"). It
+        // appears on TB-protocol ports only.
+        let socketID = properties["Socket ID"] as? String
+
+        let speedRaw = (properties["Current Link Speed"] as? NSNumber)?.uint8Value ?? 0
+        let widthRaw = (properties["Current Link Width"] as? NSNumber)?.uint8Value ?? 0
+        let targetWidthRaw = (properties["Target Link Width"] as? NSNumber)?.uint8Value ?? 0
+        let targetSpeedRaw = (properties["Target Link Speed"] as? NSNumber)?.uint8Value
+
+        // Only populate link state on actual lane ports. Protocol
+        // adapters (DP, PCIe, USB3) don't carry link generation; their
+        // tunnel state is exposed via Hop Table, which we ignore in v1.
+        let currentSpeed: LinkGeneration?
+        let currentWidth: LinkWidth?
+        let targetWidth: TargetLinkWidth?
+        if adapter.isLane {
+            currentSpeed = LinkGeneration.from(rawSpeedCode: speedRaw)
+            currentWidth = LinkWidth(rawValue: widthRaw)
+            targetWidth = TargetLinkWidth.from(rawValue: targetWidthRaw)
+        } else {
+            currentSpeed = nil
+            currentWidth = nil
+            targetWidth = nil
+        }
+
+        return ThunderboltPort(
+            portNumber: portNumNum.intValue,
+            socketID: socketID,
+            adapterType: adapter,
+            currentSpeed: currentSpeed,
+            currentWidth: currentWidth,
+            targetWidth: targetWidth,
+            rawTargetSpeed: targetSpeedRaw,
+            linkBandwidthRaw: (properties["Link Bandwidth"] as? NSNumber)?.intValue
+        )
+    }
+
+    /// True for a TB lane port that has actually negotiated a link.
+    /// Useful for the renderer when picking which port to label.
+    public var hasActiveLink: Bool {
+        guard adapterType.isLane else { return false }
+        guard let currentWidth, currentWidth.isActive else { return false }
+        return currentSpeed != nil
+    }
+}

--- a/Sources/WhatCableDarwinBackend/DarwinSnapshotProvider.swift
+++ b/Sources/WhatCableDarwinBackend/DarwinSnapshotProvider.swift
@@ -18,6 +18,7 @@ public final class DarwinSnapshotProvider: CableSnapshotProvider, @unchecked Sen
         let powerWatcher = PowerSourceWatcher()
         let pdWatcher = PDIdentityWatcher()
         let usbWatcher = USBWatcher()
+        let tbWatcher = ThunderboltWatcher()
         var started = false
 
         func ensureStarted() {
@@ -26,6 +27,7 @@ public final class DarwinSnapshotProvider: CableSnapshotProvider, @unchecked Sen
             powerWatcher.start()
             pdWatcher.start()
             usbWatcher.start()
+            tbWatcher.start()
             started = true
         }
 
@@ -36,12 +38,14 @@ public final class DarwinSnapshotProvider: CableSnapshotProvider, @unchecked Sen
             portWatcher.refresh()
             powerWatcher.refresh()
             pdWatcher.refresh()
+            tbWatcher.refresh()
             return CableSnapshot(
                 ports: portWatcher.ports,
                 powerSources: powerWatcher.sources,
                 identities: pdWatcher.identities,
                 usbDevices: usbWatcher.devices,
-                adapter: SystemPower.currentAdapter()
+                adapter: SystemPower.currentAdapter(),
+                thunderboltSwitches: tbWatcher.switches
             )
         }
     }

--- a/Sources/WhatCableDarwinBackend/ThunderboltWatcher.swift
+++ b/Sources/WhatCableDarwinBackend/ThunderboltWatcher.swift
@@ -95,22 +95,28 @@ public final class ThunderboltWatcher: ObservableObject {
         }
         defer { IOObjectRelease(iter) }
 
-        // First pass: build a list of (service, props, parentService) so
+        // First pass: build a list of (service, props, parent entry ID) so
         // we can resolve parent UIDs in a second pass once every switch has
         // been parsed.
+        //
+        // The parent linkage is keyed by registry entry ID (the stable
+        // 64-bit identifier IOKit assigns per registry object), not by the
+        // raw `io_service_t` mach-port value. Different IOKit calls can
+        // hand back different mach-port handles for the same registry
+        // object, so a port-handle keyed lookup would silently miss and
+        // collapse the topology to "host only".
         struct RawEntry {
             let service: io_service_t
             let className: String
             let properties: [String: Any]
-            let parentService: io_service_t  // 0 if no IOThunderboltSwitch parent
             let entryID: UInt64
+            let parentEntryID: UInt64  // 0 if no IOThunderboltSwitch parent
         }
 
         var raw: [RawEntry] = []
         defer {
             for entry in raw {
                 IOObjectRelease(entry.service)
-                if entry.parentService != 0 { IOObjectRelease(entry.parentService) }
             }
         }
 
@@ -135,23 +141,26 @@ public final class ThunderboltWatcher: ObservableObject {
             // Walk up to the nearest IOThunderboltSwitch ancestor (skipping
             // adapter / port intermediaries). On Apple Silicon, downstream
             // switches sit below their parent switch in the IOService plane,
-            // so this gives us the parent linkage for free.
-            let parentService = nearestThunderboltSwitchAncestor(of: service)
+            // so this gives us the parent linkage for free. We resolve the
+            // parent's registry entry ID immediately and release the
+            // ancestor handle so we don't have to track its lifetime.
+            let parentEntryID = parentSwitchEntryID(of: service)
 
             raw.append(RawEntry(
                 service: service,
                 className: className,
                 properties: dict,
-                parentService: parentService,
-                entryID: entryID
+                entryID: entryID,
+                parentEntryID: parentEntryID
             ))
         }
 
-        // Build a UID lookup keyed by service so we can resolve parent UIDs.
-        var uidByService: [io_service_t: Int64] = [:]
+        // Build a UID lookup keyed by registry entry ID. Stable across
+        // separate IOKit calls, unlike the raw mach-port handle.
+        var uidByEntryID: [UInt64: Int64] = [:]
         for entry in raw {
             if let uidNum = entry.properties["UID"] as? NSNumber {
-                uidByService[entry.service] = uidNum.int64Value
+                uidByEntryID[entry.entryID] = uidNum.int64Value
             }
         }
 
@@ -160,8 +169,8 @@ public final class ThunderboltWatcher: ObservableObject {
 
         for entry in raw {
             let ports = parsePorts(of: entry.service)
-            let parentUID: Int64? = entry.parentService != 0
-                ? uidByService[entry.parentService]
+            let parentUID: Int64? = entry.parentEntryID != 0
+                ? uidByEntryID[entry.parentEntryID]
                 : nil
 
             if let model = ThunderboltSwitch.from(
@@ -221,32 +230,44 @@ public final class ThunderboltWatcher: ObservableObject {
         return ports
     }
 
-    /// Walk up the IOService plane and return the nearest ancestor whose
-    /// class is an IOThunderboltSwitch. Caller takes ownership of the
-    /// returned service and must `IOObjectRelease` it (returns 0 if none).
-    private func nearestThunderboltSwitchAncestor(of service: io_service_t) -> io_service_t {
+    /// Walk up the IOService plane and return the registry entry ID of the
+    /// nearest ancestor whose class is an IOThunderboltSwitch. Returns `0`
+    /// if no such ancestor is found. The walker manages all IOKit handle
+    /// lifetimes internally so callers don't have to track ownership.
+    ///
+    /// Returning the entry ID (a stable 64-bit identifier per registry
+    /// object) rather than the raw service handle avoids a class of bug
+    /// where two `io_service_t` values for the same registry object
+    /// compare unequal because IOKit can hand back distinct mach-port
+    /// handles for the same underlying entry.
+    private func parentSwitchEntryID(of service: io_service_t) -> UInt64 {
         var current = service
         IOObjectRetain(current)
+        defer { IOObjectRelease(current) }
+
         for _ in 0..<32 {
             var parent: io_service_t = 0
             guard IORegistryEntryGetParentEntry(current, kIOServicePlane, &parent) == KERN_SUCCESS else {
-                IOObjectRelease(current)
                 return 0
             }
+            // Move ownership into `current` for the next iteration / cleanup.
             IOObjectRelease(current)
+            current = parent
 
             var classBuf = [CChar](repeating: 0, count: 128)
-            if IOObjectGetClass(parent, &classBuf) == KERN_SUCCESS {
+            if IOObjectGetClass(current, &classBuf) == KERN_SUCCESS {
                 let name = String(cString: classBuf)
                 // Match the abstract prefix; covers Type3 / Type5 / Type7 /
                 // IntelJHL8440 / future variants.
                 if name.hasPrefix("IOThunderboltSwitch") {
-                    return parent  // caller releases
+                    var entryID: UInt64 = 0
+                    if IORegistryEntryGetRegistryEntryID(current, &entryID) == KERN_SUCCESS {
+                        return entryID
+                    }
+                    return 0
                 }
             }
-            current = parent
         }
-        IOObjectRelease(current)
         return 0
     }
 

--- a/Sources/WhatCableDarwinBackend/ThunderboltWatcher.swift
+++ b/Sources/WhatCableDarwinBackend/ThunderboltWatcher.swift
@@ -1,0 +1,278 @@
+import Foundation
+import IOKit
+import WhatCableCore
+
+/// Watches `IOThunderboltSwitch` services and assembles them into a normalised
+/// list of `ThunderboltSwitch` models. Modelled on `USBCPortWatcher`:
+///
+/// - Match notification on the abstract parent class so all subclass variants
+///   come in (we've seen `Type3`, `Type5`, `Type7`, `IntelJHL8440` so far,
+///   and there will be more once TB5 silicon ships).
+/// - Per-service interest notifications for property changes (link state
+///   moves, dock plug/unplug). Mirrors the USB-C watcher's pattern.
+/// - `refresh()` re-walks the registry; `read()`-style consumers can call it
+///   on every snapshot read.
+/// - The factory in `WhatCableCore.ThunderboltSwitch.from(...)` does the
+///   actual property decoding so unit tests can run on hand-built dictionaries.
+@MainActor
+public final class ThunderboltWatcher: ObservableObject {
+    @Published public private(set) var switches: [ThunderboltSwitch] = []
+
+    private var notifyPort: IONotificationPortRef?
+    private var matchIterator: io_iterator_t = 0
+    private var interestNotifications: [UInt64: io_object_t] = [:]
+
+    public init() {}
+
+    public func start() {
+        guard notifyPort == nil else { return }
+        let port = IONotificationPortCreate(kIOMainPortDefault)
+        IONotificationPortSetDispatchQueue(port, DispatchQueue.main)
+        notifyPort = port
+
+        // C callback bridge: capture self via Unmanaged so the IOKit
+        // notification machinery can call us back. Same pattern as
+        // USBCPortWatcher and PDIdentityWatcher.
+        let selfPtr = Unmanaged.passUnretained(self).toOpaque()
+        let cb: IOServiceMatchingCallback = { refcon, iterator in
+            guard let refcon else { return }
+            let watcher = Unmanaged<ThunderboltWatcher>.fromOpaque(refcon).takeUnretainedValue()
+            Task { @MainActor in
+                // Drain the iterator so the kernel re-arms the notification,
+                // then do a full re-walk so we pick up parent linkage and
+                // sort consistently.
+                while case let s = IOIteratorNext(iterator), s != 0 {
+                    IOObjectRelease(s)
+                }
+                watcher.refresh()
+            }
+        }
+
+        let matching = IOServiceMatching("IOThunderboltSwitch")
+        var iter: io_iterator_t = 0
+        if IOServiceAddMatchingNotification(
+            port,
+            kIOMatchedNotification,
+            matching,
+            cb,
+            selfPtr,
+            &iter
+        ) == KERN_SUCCESS {
+            matchIterator = iter
+            // Drain the initial set the kernel hands back so the notification
+            // re-arms. The actual model build happens in refresh().
+            while case let s = IOIteratorNext(iter), s != 0 {
+                IOObjectRelease(s)
+            }
+            refresh()
+        }
+    }
+
+    public func stop() {
+        if matchIterator != 0 {
+            IOObjectRelease(matchIterator)
+            matchIterator = 0
+        }
+        for (_, n) in interestNotifications { IOObjectRelease(n) }
+        interestNotifications.removeAll()
+        if let port = notifyPort {
+            IONotificationPortDestroy(port)
+            notifyPort = nil
+        }
+        switches.removeAll()
+    }
+
+    /// Re-walk every `IOThunderboltSwitch` service. Cheap to call on every
+    /// snapshot read, mirroring `USBCPortWatcher.refresh()`. Property
+    /// changes (link-state moves) tend to arrive via interest notifications
+    /// but we don't rely on them for correctness.
+    public func refresh() {
+        let matching = IOServiceMatching("IOThunderboltSwitch")
+        var iter: io_iterator_t = 0
+        guard IOServiceGetMatchingServices(kIOMainPortDefault, matching, &iter) == KERN_SUCCESS else {
+            if !switches.isEmpty { switches = [] }
+            return
+        }
+        defer { IOObjectRelease(iter) }
+
+        // First pass: build a list of (service, props, parentService) so
+        // we can resolve parent UIDs in a second pass once every switch has
+        // been parsed.
+        struct RawEntry {
+            let service: io_service_t
+            let className: String
+            let properties: [String: Any]
+            let parentService: io_service_t  // 0 if no IOThunderboltSwitch parent
+            let entryID: UInt64
+        }
+
+        var raw: [RawEntry] = []
+        defer {
+            for entry in raw {
+                IOObjectRelease(entry.service)
+                if entry.parentService != 0 { IOObjectRelease(entry.parentService) }
+            }
+        }
+
+        while case let service = IOIteratorNext(iter), service != 0 {
+            // Read everything we need before deciding to keep or release.
+            var className = "<unknown>"
+            var nameBuf = [CChar](repeating: 0, count: 128)
+            if IOObjectGetClass(service, &nameBuf) == KERN_SUCCESS {
+                className = String(cString: nameBuf)
+            }
+
+            var props: Unmanaged<CFMutableDictionary>?
+            guard IORegistryEntryCreateCFProperties(service, &props, kCFAllocatorDefault, 0) == KERN_SUCCESS,
+                  let dict = props?.takeRetainedValue() as? [String: Any] else {
+                IOObjectRelease(service)
+                continue
+            }
+
+            var entryID: UInt64 = 0
+            IORegistryEntryGetRegistryEntryID(service, &entryID)
+
+            // Walk up to the nearest IOThunderboltSwitch ancestor (skipping
+            // adapter / port intermediaries). On Apple Silicon, downstream
+            // switches sit below their parent switch in the IOService plane,
+            // so this gives us the parent linkage for free.
+            let parentService = nearestThunderboltSwitchAncestor(of: service)
+
+            raw.append(RawEntry(
+                service: service,
+                className: className,
+                properties: dict,
+                parentService: parentService,
+                entryID: entryID
+            ))
+        }
+
+        // Build a UID lookup keyed by service so we can resolve parent UIDs.
+        var uidByService: [io_service_t: Int64] = [:]
+        for entry in raw {
+            if let uidNum = entry.properties["UID"] as? NSNumber {
+                uidByService[entry.service] = uidNum.int64Value
+            }
+        }
+
+        var rebuilt: [ThunderboltSwitch] = []
+        rebuilt.reserveCapacity(raw.count)
+
+        for entry in raw {
+            let ports = parsePorts(of: entry.service)
+            let parentUID: Int64? = entry.parentService != 0
+                ? uidByService[entry.parentService]
+                : nil
+
+            if let model = ThunderboltSwitch.from(
+                properties: entry.properties,
+                className: entry.className,
+                ports: ports,
+                parentSwitchUID: parentUID
+            ) {
+                rebuilt.append(model)
+                registerInterest(for: entry.service, entryID: entry.entryID)
+            }
+        }
+
+        // Stable order: host roots first (Depth=0), then by Route String, then UID.
+        rebuilt.sort { lhs, rhs in
+            if lhs.depth != rhs.depth { return lhs.depth < rhs.depth }
+            if lhs.routeString != rhs.routeString { return lhs.routeString < rhs.routeString }
+            return lhs.id < rhs.id
+        }
+
+        if rebuilt != switches { switches = rebuilt }
+    }
+
+    /// Walk port children of a switch service. Returns the parsed ports
+    /// in registry order. Skips non-port children (driver shims sometimes
+    /// hang off a switch service).
+    private func parsePorts(of switchService: io_service_t) -> [ThunderboltPort] {
+        var ports: [ThunderboltPort] = []
+        var childIter: io_iterator_t = 0
+        guard IORegistryEntryGetChildIterator(switchService, kIOServicePlane, &childIter) == KERN_SUCCESS else {
+            return ports
+        }
+        defer { IOObjectRelease(childIter) }
+
+        while case let child = IOIteratorNext(childIter), child != 0 {
+            defer { IOObjectRelease(child) }
+
+            // Class name must contain "Port" to qualify; this filters out
+            // the adapter shims (AppleThunderboltUSBDownAdapter etc.) which
+            // are driver matches rather than registry-backed ports.
+            var classBuf = [CChar](repeating: 0, count: 128)
+            guard IOObjectGetClass(child, &classBuf) == KERN_SUCCESS else { continue }
+            let className = String(cString: classBuf)
+            guard className.contains("Port") else { continue }
+
+            var props: Unmanaged<CFMutableDictionary>?
+            guard IORegistryEntryCreateCFProperties(child, &props, kCFAllocatorDefault, 0) == KERN_SUCCESS,
+                  let dict = props?.takeRetainedValue() as? [String: Any] else {
+                continue
+            }
+
+            if let port = ThunderboltPort.from(properties: dict) {
+                ports.append(port)
+            }
+        }
+        ports.sort { $0.portNumber < $1.portNumber }
+        return ports
+    }
+
+    /// Walk up the IOService plane and return the nearest ancestor whose
+    /// class is an IOThunderboltSwitch. Caller takes ownership of the
+    /// returned service and must `IOObjectRelease` it (returns 0 if none).
+    private func nearestThunderboltSwitchAncestor(of service: io_service_t) -> io_service_t {
+        var current = service
+        IOObjectRetain(current)
+        for _ in 0..<32 {
+            var parent: io_service_t = 0
+            guard IORegistryEntryGetParentEntry(current, kIOServicePlane, &parent) == KERN_SUCCESS else {
+                IOObjectRelease(current)
+                return 0
+            }
+            IOObjectRelease(current)
+
+            var classBuf = [CChar](repeating: 0, count: 128)
+            if IOObjectGetClass(parent, &classBuf) == KERN_SUCCESS {
+                let name = String(cString: classBuf)
+                // Match the abstract prefix; covers Type3 / Type5 / Type7 /
+                // IntelJHL8440 / future variants.
+                if name.hasPrefix("IOThunderboltSwitch") {
+                    return parent  // caller releases
+                }
+            }
+            current = parent
+        }
+        IOObjectRelease(current)
+        return 0
+    }
+
+    /// Subscribe to property changes on a switch service. Apple's IOKit
+    /// fires `kIOMessageServicePropertyChange` when link state moves
+    /// (e.g. dock cable plugged), so this gives us a refresh trigger
+    /// without polling. Same pattern as `USBCPortWatcher.registerInterest`.
+    private func registerInterest(for service: io_service_t, entryID: UInt64) {
+        guard let notifyPort, interestNotifications[entryID] == nil else { return }
+        let selfPtr = Unmanaged.passUnretained(self).toOpaque()
+        let cb: IOServiceInterestCallback = { refcon, _, _, _ in
+            guard let refcon else { return }
+            let watcher = Unmanaged<ThunderboltWatcher>.fromOpaque(refcon).takeUnretainedValue()
+            Task { @MainActor in watcher.refresh() }
+        }
+        var notification: io_object_t = 0
+        let result = IOServiceAddInterestNotification(
+            notifyPort,
+            service,
+            kIOGeneralInterest,
+            cb,
+            selfPtr,
+            &notification
+        )
+        if result == KERN_SUCCESS {
+            interestNotifications[entryID] = notification
+        }
+    }
+}

--- a/Tests/WhatCableCoreTests/JSONFormatterTests.swift
+++ b/Tests/WhatCableCoreTests/JSONFormatterTests.swift
@@ -373,6 +373,43 @@ final class JSONFormatterTests: XCTestCase {
         XCTAssertEqual(port["txLanes"] as? Int, 2)
     }
 
+    /// Regression: TB5 must stay hedged in JSON the same way it's hedged
+    /// in the text renderer. Otherwise a `--json` consumer that parses
+    /// `generation == "tb5"` would treat the inferred mapping as verified.
+    func testTb5JsonGenerationLabelStaysHedged() throws {
+        let host = ThunderboltSwitch(
+            id: 1, className: "IOThunderboltSwitchType9",
+            vendorID: 1452, vendorName: "Apple Inc.", modelName: "iOS",
+            routerID: 0, depth: 0, routeString: 0,
+            upstreamPortNumber: 7, maxPortNumber: 8,
+            supportedSpeed: SupportedSpeedMask(rawValue: 14),
+            ports: [
+                ThunderboltPort(
+                    portNumber: 1, socketID: "1", adapterType: .lane,
+                    currentSpeed: .tb5,
+                    currentWidth: LinkWidth(rawValue: 0x2),
+                    targetWidth: .dual,
+                    rawTargetSpeed: nil, linkBandwidthRaw: 800
+                )
+            ],
+            parentSwitchUID: nil
+        )
+        let json = try JSONFormatter.render(
+            ports: [makePort()], sources: [], identities: [], showRaw: false,
+            thunderboltSwitches: [host]
+        )
+        let obj = parse(json)
+        let port = ((obj["thunderboltSwitches"] as? [[String: Any]])?.first?["ports"] as? [[String: Any]])?.first ?? [:]
+        let gen = port["generation"] as? String ?? ""
+        XCTAssertTrue(
+            gen.contains("inferredTb5") || gen.hasPrefix("unknown"),
+            "TB5 must stay hedged in JSON; got generation = \(gen)"
+        )
+        XCTAssertNotEqual(gen, "tb5", "must not promise verified TB5 yet")
+        // Raw speed code is still exposed for diagnostics consumers.
+        XCTAssertEqual(port["rawSpeedCode"] as? Int, 0x2)
+    }
+
     func testPortDtoCarriesThunderboltSwitchUidReference() throws {
         let host = ThunderboltSwitch(
             id: 12345,

--- a/Tests/WhatCableCoreTests/JSONFormatterTests.swift
+++ b/Tests/WhatCableCoreTests/JSONFormatterTests.swift
@@ -306,4 +306,100 @@ final class JSONFormatterTests: XCTestCase {
         XCTAssertEqual(port["status"] as? String, "empty")
         XCTAssertEqual(port["headline"] as? String, "Nothing connected")
     }
+
+    // MARK: - Thunderbolt fabric
+
+    /// The `thunderboltSwitches` key must always be present at the top
+    /// level, even when the host has no Thunderbolt controller. The
+    /// docstring on `CableSnapshot.thunderboltSwitches` advertises this
+    /// to downstream consumers.
+    func testThunderboltSwitchesKeyPresentEvenWhenEmpty() throws {
+        let json = try JSONFormatter.render(
+            ports: [makePort(connected: false)], sources: [], identities: [], showRaw: false
+        )
+        let obj = parse(json)
+        XCTAssertNotNil(obj["thunderboltSwitches"], "top-level key must always exist")
+        XCTAssertEqual((obj["thunderboltSwitches"] as? [Any])?.count, 0)
+    }
+
+    func testThunderboltSwitchesEncodedAtTopLevel() throws {
+        let host = ThunderboltSwitch(
+            id: 408750268121704800,
+            className: "IOThunderboltSwitchType5",
+            vendorID: 1452,
+            vendorName: "Apple Inc.",
+            modelName: "iOS",
+            routerID: 0,
+            depth: 0,
+            routeString: 0,
+            upstreamPortNumber: 7,
+            maxPortNumber: 8,
+            supportedSpeed: SupportedSpeedMask(rawValue: 12),
+            ports: [
+                ThunderboltPort(
+                    portNumber: 1,
+                    socketID: "1",
+                    adapterType: .lane,
+                    currentSpeed: .usb4Tb4,
+                    currentWidth: LinkWidth(rawValue: 0x2),
+                    targetWidth: .dual,
+                    rawTargetSpeed: 12,
+                    linkBandwidthRaw: 400
+                )
+            ],
+            parentSwitchUID: nil
+        )
+
+        let json = try JSONFormatter.render(
+            ports: [makePort()], sources: [], identities: [], showRaw: false,
+            thunderboltSwitches: [host]
+        )
+        let obj = parse(json)
+        let switches = obj["thunderboltSwitches"] as? [[String: Any]] ?? []
+        XCTAssertEqual(switches.count, 1)
+
+        let sw = switches[0]
+        XCTAssertEqual(sw["uid"] as? Int64, 408750268121704800)
+        XCTAssertEqual(sw["depth"] as? Int, 0)
+        XCTAssertEqual(sw["modelName"] as? String, "iOS")
+
+        let ports = sw["ports"] as? [[String: Any]] ?? []
+        let port = ports.first ?? [:]
+        XCTAssertEqual(port["adapterType"] as? String, "lane")
+        XCTAssertEqual(port["linkActive"] as? Bool, true)
+        XCTAssertEqual(port["linkLabel"] as? String, "Up to 20 Gb/s × 2")
+        XCTAssertEqual(port["generation"] as? String, "usb4Tb4")
+        XCTAssertEqual(port["perLaneGbps"] as? Int, 20)
+        XCTAssertEqual(port["txLanes"] as? Int, 2)
+    }
+
+    func testPortDtoCarriesThunderboltSwitchUidReference() throws {
+        let host = ThunderboltSwitch(
+            id: 12345,
+            className: "IOThunderboltSwitchType5",
+            vendorID: 1452, vendorName: "Apple Inc.", modelName: "iOS",
+            routerID: 0, depth: 0, routeString: 0,
+            upstreamPortNumber: 7, maxPortNumber: 8,
+            supportedSpeed: SupportedSpeedMask(rawValue: 12),
+            ports: [
+                ThunderboltPort(
+                    portNumber: 1, socketID: "1", adapterType: .lane,
+                    currentSpeed: .usb4Tb4,
+                    currentWidth: LinkWidth(rawValue: 0x2),
+                    targetWidth: .dual,
+                    rawTargetSpeed: 12, linkBandwidthRaw: 400
+                )
+            ],
+            parentSwitchUID: nil
+        )
+
+        let json = try JSONFormatter.render(
+            ports: [makePort()], sources: [], identities: [], showRaw: false,
+            thunderboltSwitches: [host]
+        )
+        let obj = parse(json)
+        let port = (obj["ports"] as? [[String: Any]])?.first ?? [:]
+        // Port-USB-C@1 should resolve via Socket ID "1" → host switch UID.
+        XCTAssertEqual(port["thunderboltSwitchUID"] as? Int64, 12345)
+    }
 }

--- a/Tests/WhatCableCoreTests/PortSummaryThunderboltTests.swift
+++ b/Tests/WhatCableCoreTests/PortSummaryThunderboltTests.swift
@@ -1,0 +1,205 @@
+import XCTest
+@testable import WhatCableCore
+
+/// Phase 3 integration: PortSummary should pull TB fabric data through and
+/// emit specific link-state bullets when a port has a matching switch graph.
+/// Anchored against Joe's M2 Pro + ASUS PA32QCV (USB4) + CalDigit TS3 Plus
+/// daisy-chain from issue #52.
+final class PortSummaryThunderboltTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    private func tbPort(socket: String) -> USBCPort {
+        USBCPort(
+            id: 1,
+            serviceName: "Port-USB-C@\(socket)",
+            className: "AppleHPMInterfaceType10",
+            portDescription: "Port-USB-C@\(socket)",
+            portTypeDescription: "USB-C",
+            portNumber: Int(socket),
+            connectionActive: true,
+            activeCable: nil,
+            opticalCable: nil,
+            usbActive: nil,
+            superSpeedActive: nil,
+            usbModeType: nil,
+            usbConnectString: nil,
+            transportsSupported: ["CC", "USB2", "USB3", "CIO", "DisplayPort"],
+            transportsActive: ["CIO"],
+            transportsProvisioned: ["CC"],
+            plugOrientation: nil,
+            plugEventCount: nil,
+            connectionCount: nil,
+            overcurrentCount: nil,
+            pinConfiguration: [:],
+            powerCurrentLimits: [],
+            firmwareVersion: nil,
+            bootFlagsHex: nil,
+            rawProperties: [:]
+        )
+    }
+
+    private func lanePort(
+        portNumber: Int,
+        socketID: String?,
+        speed: LinkGeneration?,
+        widthRaw: UInt8
+    ) -> ThunderboltPort {
+        ThunderboltPort(
+            portNumber: portNumber,
+            socketID: socketID,
+            adapterType: .lane,
+            currentSpeed: speed,
+            currentWidth: LinkWidth(rawValue: widthRaw),
+            targetWidth: nil,
+            rawTargetSpeed: nil,
+            linkBandwidthRaw: nil
+        )
+    }
+
+    private func sw(
+        uid: Int64,
+        depth: Int,
+        parent: Int64?,
+        upstreamPort: Int = 0,
+        vendor: String,
+        model: String,
+        ports: [ThunderboltPort]
+    ) -> ThunderboltSwitch {
+        ThunderboltSwitch(
+            id: uid,
+            className: "IOThunderboltSwitchType5",
+            vendorID: 1452,
+            vendorName: vendor,
+            modelName: model,
+            routerID: 0,
+            depth: depth,
+            routeString: 0,
+            upstreamPortNumber: upstreamPort,
+            maxPortNumber: 8,
+            supportedSpeed: SupportedSpeedMask(rawValue: 12),
+            ports: ports,
+            parentSwitchUID: parent
+        )
+    }
+
+    // MARK: - Single-hop (host + one device)
+
+    func testHostUsb4LinkProducesSpecificBullet() {
+        let port = tbPort(socket: "1")
+        let host = sw(
+            uid: 100, depth: 0, parent: nil,
+            vendor: "Apple Inc.", model: "iOS",
+            ports: [lanePort(portNumber: 1, socketID: "1", speed: .usb4Tb4, widthRaw: 0x2)]
+        )
+        let device = sw(
+            uid: 200, depth: 1, parent: 100, upstreamPort: 1,
+            vendor: "ASUS-Display", model: "PA32QCV",
+            ports: [lanePort(portNumber: 1, socketID: nil, speed: .usb4Tb4, widthRaw: 0x2)]
+        )
+
+        let summary = PortSummary(
+            port: port,
+            thunderboltSwitches: [host, device]
+        )
+
+        XCTAssertTrue(
+            summary.bullets.contains("Linked at up to 20 Gb/s × 2"),
+            "expected USB4 link label, got: \(summary.bullets)"
+        )
+        XCTAssertTrue(
+            summary.bullets.contains("Connected to ASUS-Display PA32QCV"),
+            "expected single-hop device label, got: \(summary.bullets)"
+        )
+    }
+
+    func testTb3LinkProducesTb3Bullet() {
+        let port = tbPort(socket: "1")
+        let host = sw(
+            uid: 100, depth: 0, parent: nil,
+            vendor: "Apple Inc.", model: "iOS",
+            ports: [lanePort(portNumber: 1, socketID: "1", speed: .tb3, widthRaw: 0x2)]
+        )
+
+        let summary = PortSummary(port: port, thunderboltSwitches: [host])
+        XCTAssertTrue(summary.bullets.contains("Linked at up to 10 Gb/s × 2"))
+    }
+
+    // MARK: - Daisy-chain step-down (the headline UX)
+
+    func testDaisyChainStepDownIsSurfaced() {
+        // Joe's topology: USB4 to ASUS, TS3 Plus daisy-chained off the
+        // ASUS at TB3 single-lane.
+        let port = tbPort(socket: "1")
+        let host = sw(
+            uid: 100, depth: 0, parent: nil,
+            vendor: "Apple Inc.", model: "iOS",
+            ports: [lanePort(portNumber: 1, socketID: "1", speed: .usb4Tb4, widthRaw: 0x2)]
+        )
+        let asus = sw(
+            uid: 200, depth: 1, parent: 100, upstreamPort: 1,
+            vendor: "ASUS-Display", model: "PA32QCV",
+            ports: [
+                lanePort(portNumber: 1, socketID: nil, speed: .usb4Tb4, widthRaw: 0x2),
+                lanePort(portNumber: 4, socketID: nil, speed: .tb3, widthRaw: 0x1)
+            ]
+        )
+        let ts3 = sw(
+            uid: 300, depth: 2, parent: 200, upstreamPort: 1,
+            vendor: "CalDigit, Inc.", model: "TS3 Plus",
+            ports: [lanePort(portNumber: 1, socketID: nil, speed: .tb3, widthRaw: 0x1)]
+        )
+
+        let summary = PortSummary(
+            port: port,
+            thunderboltSwitches: [host, asus, ts3]
+        )
+
+        XCTAssertTrue(
+            summary.bullets.contains("Linked at up to 20 Gb/s × 2"),
+            "host link bullet missing; got: \(summary.bullets)"
+        )
+        XCTAssertTrue(
+            summary.bullets.contains("Connected via 2 hops: ASUS-Display PA32QCV → CalDigit, Inc. TS3 Plus"),
+            "daisy-chain device list missing; got: \(summary.bullets)"
+        )
+        XCTAssertTrue(
+            summary.bullets.contains { $0.contains("Last leg drops from up to 20 Gb/s × 2 to up to 10 Gb/s × 1") },
+            "step-down bullet missing; got: \(summary.bullets)"
+        )
+    }
+
+    // MARK: - Fallback when no matching switch is found
+
+    func testFallsBackToGenericLabelWhenNoMatchingSwitch() {
+        let port = tbPort(socket: "1")
+        // Switch list is empty: PortSummary should fall back to the
+        // pre-Phase-3 generic line so we don't regress on machines without
+        // the watcher data.
+        let summary = PortSummary(port: port, thunderboltSwitches: [])
+        XCTAssertTrue(
+            summary.bullets.contains("Thunderbolt / USB4 link active"),
+            "expected fallback bullet when no switch data; got: \(summary.bullets)"
+        )
+    }
+
+    // MARK: - TB5 hedging — must NOT promise "TB5"
+
+    func testTb5LinkRendersAsHedgedLabel() {
+        let port = tbPort(socket: "1")
+        let host = sw(
+            uid: 100, depth: 0, parent: nil,
+            vendor: "Apple Inc.", model: "iOS",
+            ports: [lanePort(portNumber: 1, socketID: "1", speed: .tb5, widthRaw: 0x2)]
+        )
+        let summary = PortSummary(port: port, thunderboltSwitches: [host])
+        XCTAssertTrue(
+            summary.bullets.contains { $0.contains("Unknown generation (raw speed code 0x2") },
+            "TB5 must stay hedged until verified; got: \(summary.bullets)"
+        )
+        XCTAssertFalse(
+            summary.bullets.contains { $0.contains("40 Gb/s") },
+            "must not promise 40 Gb/s yet"
+        )
+    }
+}

--- a/Tests/WhatCableCoreTests/PortSummaryThunderboltTests.swift
+++ b/Tests/WhatCableCoreTests/PortSummaryThunderboltTests.swift
@@ -169,6 +169,41 @@ final class PortSummaryThunderboltTests: XCTestCase {
         )
     }
 
+    // MARK: - Single-hop must NOT trigger step-down
+
+    /// Regression: in Steve's TB3 sample, the host port reports
+    /// `Current Link Width = 2` while the Samsung's upstream port reports
+    /// `Current Link Width = 1` for the same physical cable. That's just
+    /// the controller-side view aggregating lanes the device-side view
+    /// doesn't; it's not a real step-down. Step-down only fires for
+    /// daisy-chains with two or more downstream switches.
+    func testSingleHopDoesNotEmitStepDown() {
+        let port = tbPort(socket: "1")
+        let host = sw(
+            uid: 100, depth: 0, parent: nil,
+            vendor: "Apple Inc.", model: "iOS",
+            ports: [lanePort(portNumber: 1, socketID: "1", speed: .tb3, widthRaw: 0x2)]
+        )
+        // Samsung-style single device: upstream port reports the same
+        // link from the device side with a different width value.
+        let samsung = sw(
+            uid: 200, depth: 1, parent: 100, upstreamPort: 1,
+            vendor: "SAMSUNG ELECTRONICS CO.,LTD", model: "C34J79x",
+            ports: [lanePort(portNumber: 1, socketID: nil, speed: .tb3, widthRaw: 0x1)]
+        )
+
+        let summary = PortSummary(port: port, thunderboltSwitches: [host, samsung])
+        XCTAssertFalse(
+            summary.bullets.contains { $0.contains("Last leg drops") },
+            "single-hop must not emit step-down warning; got: \(summary.bullets)"
+        )
+        // Sanity: the single-hop bullets we DO want should still be there.
+        XCTAssertTrue(
+            summary.bullets.contains("Connected to SAMSUNG ELECTRONICS CO.,LTD C34J79x"),
+            "device label still required"
+        )
+    }
+
     // MARK: - Fallback when no matching switch is found
 
     func testFallsBackToGenericLabelWhenNoMatchingSwitch() {

--- a/Tests/WhatCableCoreTests/ThunderboltLabelsTests.swift
+++ b/Tests/WhatCableCoreTests/ThunderboltLabelsTests.swift
@@ -1,0 +1,180 @@
+import XCTest
+@testable import WhatCableCore
+
+/// Tests for the user-facing label helpers and topology walker.
+/// These cover the rendering convention chosen for Phase 3:
+///   - per-lane Gb/s × lane count, matching Apple's `system_profiler`
+///   - hedge wording for unknown / TB5 (TB5 stays hedged until verified)
+///   - daisy-chain detection by `parentSwitchUID`
+final class ThunderboltLabelsTests: XCTestCase {
+
+    // MARK: - linkLabel
+
+    func testLabelForTb3DualLane() {
+        let port = makeLanePort(speed: .tb3, widthRaw: 0x2)
+        XCTAssertEqual(ThunderboltLabels.linkLabel(for: port), "Up to 10 Gb/s × 2")
+    }
+
+    func testLabelForTb3SingleLane() {
+        let port = makeLanePort(speed: .tb3, widthRaw: 0x1)
+        XCTAssertEqual(ThunderboltLabels.linkLabel(for: port), "Up to 10 Gb/s × 1")
+    }
+
+    func testLabelForUsb4DualLane() {
+        let port = makeLanePort(speed: .usb4Tb4, widthRaw: 0x2)
+        XCTAssertEqual(ThunderboltLabels.linkLabel(for: port), "Up to 20 Gb/s × 2")
+    }
+
+    /// TB5 stays hedged until verified against real hardware. Even though
+    /// the model decodes raw 0x2 to .tb5, the renderer must not promise
+    /// "TB5" or "40 Gb/s" yet.
+    func testLabelForTb5IsHedged() {
+        let port = makeLanePort(speed: .tb5, widthRaw: 0x2)
+        let label = ThunderboltLabels.linkLabel(for: port)
+        XCTAssertEqual(label, "Unknown generation (raw speed code 0x2, inferred TB5)")
+    }
+
+    func testLabelForUnknownGenerationIsHedged() {
+        let port = makeLanePort(speed: .unknown(rawSpeedCode: 0x1), widthRaw: 0x2)
+        XCTAssertEqual(ThunderboltLabels.linkLabel(for: port), "Unknown generation (raw speed code 0x1)")
+    }
+
+    func testLabelNilForIdlePort() {
+        let port = makeLanePort(speed: nil, widthRaw: 0)
+        XCTAssertNil(ThunderboltLabels.linkLabel(for: port))
+    }
+
+    func testLabelForAsymmetricLink() {
+        // 3 TX / 1 RX. We have no real TB5 sample, but the model must
+        // produce a sensible label if one ever lands.
+        let port = makeLanePort(speed: .usb4Tb4, widthRaw: 0x4)
+        XCTAssertEqual(ThunderboltLabels.linkLabel(for: port), "Up to 20 Gb/s (3 TX / 1 RX)")
+    }
+
+    // MARK: - deviceName
+
+    func testDeviceNameAsus() {
+        let sw = makeSwitch(uid: 1, vendor: "ASUS-Display", model: "PA32QCV")
+        XCTAssertEqual(ThunderboltLabels.deviceName(for: sw), "ASUS-Display PA32QCV")
+    }
+
+    func testDeviceNameMissingFieldsFallsBack() {
+        let sw = makeSwitch(uid: 1, vendor: "", model: "")
+        XCTAssertEqual(ThunderboltLabels.deviceName(for: sw), "Unknown device")
+    }
+
+    // MARK: - Topology socket-ID parsing
+
+    func testSocketIDExtractedFromAtSuffix() {
+        XCTAssertEqual(ThunderboltTopology.socketID(fromServiceName: "Port-USB-C@1"), "1")
+        XCTAssertEqual(ThunderboltTopology.socketID(fromServiceName: "Port-USB-C@3"), "3")
+    }
+
+    func testSocketIDNilWhenNoAtSuffix() {
+        XCTAssertNil(ThunderboltTopology.socketID(fromServiceName: "Port-USB-C"))
+    }
+
+    // MARK: - Topology chain walking
+
+    func testChainSingleHop() {
+        let host = makeSwitch(uid: 100, depth: 0, parent: nil, ports: [
+            makeLanePort(portNumber: 1, socketID: "1", speed: .usb4Tb4, widthRaw: 0x2)
+        ])
+        let device = makeSwitch(uid: 200, depth: 1, parent: 100, vendor: "ASUS-Display", model: "PA32QCV")
+        let chain = ThunderboltTopology.chain(from: host, in: [host, device])
+        XCTAssertEqual(chain.count, 2)
+        XCTAssertEqual(chain.first?.id, 100)
+        XCTAssertEqual(chain.last?.id, 200)
+    }
+
+    func testChainDaisyTwoHops() {
+        let host = makeSwitch(uid: 100, depth: 0, parent: nil, ports: [])
+        let asus = makeSwitch(uid: 200, depth: 1, parent: 100, vendor: "ASUS-Display", model: "PA32QCV")
+        let ts3 = makeSwitch(uid: 300, depth: 2, parent: 200, vendor: "CalDigit, Inc.", model: "TS3 Plus")
+        let chain = ThunderboltTopology.chain(from: host, in: [host, asus, ts3])
+        XCTAssertEqual(chain.map(\.id), [100, 200, 300])
+    }
+
+    // MARK: - hostRoot lookup by Socket ID
+
+    func testHostRootMatchesBySocketID() {
+        let portA = makeLanePort(portNumber: 1, socketID: "1", speed: .usb4Tb4, widthRaw: 0x2)
+        let portB = makeLanePort(portNumber: 2, socketID: "2", speed: nil, widthRaw: 0)
+        let root1 = makeSwitch(uid: 100, depth: 0, parent: nil, ports: [portA])
+        let root2 = makeSwitch(uid: 200, depth: 0, parent: nil, ports: [portB])
+        let device = makeSwitch(uid: 999, depth: 1, parent: 100)
+        let switches = [root1, root2, device]
+
+        XCTAssertEqual(ThunderboltTopology.hostRoot(forSocketID: "1", in: switches)?.id, 100)
+        XCTAssertEqual(ThunderboltTopology.hostRoot(forSocketID: "2", in: switches)?.id, 200)
+        XCTAssertNil(ThunderboltTopology.hostRoot(forSocketID: "3", in: switches))
+    }
+
+    // MARK: - activeDownstreamLanePort
+
+    func testActiveDownstreamLanePortOnHostRoot() {
+        let port1 = makeLanePort(portNumber: 1, socketID: "1", speed: .usb4Tb4, widthRaw: 0x2)
+        let root = makeSwitch(uid: 100, depth: 0, parent: nil, ports: [port1])
+        XCTAssertEqual(ThunderboltTopology.activeDownstreamLanePort(root)?.portNumber, 1)
+    }
+
+    /// On a downstream switch, the upstream lane port (matching
+    /// `upstreamPortNumber`) faces the host. The downstream port is the
+    /// one that goes toward the next-hop device.
+    func testActiveDownstreamLanePortSkipsUpstreamOnDeepSwitch() {
+        let upPort = makeLanePort(portNumber: 1, socketID: nil, speed: .usb4Tb4, widthRaw: 0x2)
+        let downPort = makeLanePort(portNumber: 4, socketID: nil, speed: .tb3, widthRaw: 0x1)
+        let dock = makeSwitch(
+            uid: 200, depth: 1, parent: 100,
+            upstreamPortNumber: 1,
+            ports: [upPort, downPort]
+        )
+        XCTAssertEqual(ThunderboltTopology.activeDownstreamLanePort(dock)?.portNumber, 4)
+    }
+}
+
+// MARK: - Test helpers
+
+private func makeLanePort(
+    portNumber: Int = 1,
+    socketID: String? = nil,
+    speed: LinkGeneration?,
+    widthRaw: UInt8
+) -> ThunderboltPort {
+    ThunderboltPort(
+        portNumber: portNumber,
+        socketID: socketID,
+        adapterType: .lane,
+        currentSpeed: speed,
+        currentWidth: LinkWidth(rawValue: widthRaw),
+        targetWidth: nil,
+        rawTargetSpeed: nil,
+        linkBandwidthRaw: nil
+    )
+}
+
+private func makeSwitch(
+    uid: Int64,
+    depth: Int = 0,
+    parent: Int64? = nil,
+    upstreamPortNumber: Int = 0,
+    vendor: String = "Apple Inc.",
+    model: String = "iOS",
+    ports: [ThunderboltPort] = []
+) -> ThunderboltSwitch {
+    ThunderboltSwitch(
+        id: uid,
+        className: "IOThunderboltSwitchType7",
+        vendorID: 1452,
+        vendorName: vendor,
+        modelName: model,
+        routerID: 0,
+        depth: depth,
+        routeString: 0,
+        upstreamPortNumber: upstreamPortNumber,
+        maxPortNumber: 8,
+        supportedSpeed: SupportedSpeedMask(rawValue: 12),
+        ports: ports,
+        parentSwitchUID: parent
+    )
+}

--- a/Tests/WhatCableCoreTests/ThunderboltLinkFromTests.swift
+++ b/Tests/WhatCableCoreTests/ThunderboltLinkFromTests.swift
@@ -1,0 +1,368 @@
+import XCTest
+@testable import WhatCableCore
+
+/// Covers `ThunderboltSwitch.from(...)` and `ThunderboltPort.from(...)` —
+/// the pure factories the watcher uses to turn raw IOKit property
+/// dictionaries into model values. Fixture dictionaries are transcribed
+/// from real `whatcable --tb-debug` paste-backs on issue #52, so the keys
+/// and shapes match what live machines actually report.
+///
+/// Two real topologies anchor the tests:
+/// - Steve's M3 Air + Samsung C34J79x via TB3 (one downstream switch)
+/// - Joe's M2 Pro + ASUS PA32QCV (USB4) + CalDigit TS3 Plus daisy-chain
+///   (downstream + sub-downstream)
+final class ThunderboltLinkFromTests: XCTestCase {
+
+    // MARK: - LinkGeneration enum
+
+    func testLinkGenerationKnownCodes() {
+        XCTAssertEqual(LinkGeneration.from(rawSpeedCode: 0x8), .tb3)
+        XCTAssertEqual(LinkGeneration.from(rawSpeedCode: 0x4), .usb4Tb4)
+        XCTAssertEqual(LinkGeneration.from(rawSpeedCode: 0x2), .tb5)
+    }
+
+    func testLinkGenerationIdleReturnsNil() {
+        XCTAssertNil(LinkGeneration.from(rawSpeedCode: 0))
+    }
+
+    func testLinkGenerationUnknownCode() {
+        // Forward-compat: a future generation should not crash the parser.
+        XCTAssertEqual(LinkGeneration.from(rawSpeedCode: 0x1), .unknown(rawSpeedCode: 0x1))
+    }
+
+    func testLinkGenerationPerLaneGbps() {
+        XCTAssertEqual(LinkGeneration.tb3.perLaneGbps, 10)
+        XCTAssertEqual(LinkGeneration.usb4Tb4.perLaneGbps, 20)
+        XCTAssertEqual(LinkGeneration.tb5.perLaneGbps, 40)
+        XCTAssertNil(LinkGeneration.unknown(rawSpeedCode: 0x1).perLaneGbps)
+    }
+
+    // MARK: - LinkWidth bitmask
+
+    func testLinkWidthSingle() {
+        let w = LinkWidth(rawValue: 0x1)
+        XCTAssertTrue(w.single)
+        XCTAssertFalse(w.dual)
+        XCTAssertEqual(w.txLanes, 1)
+        XCTAssertEqual(w.rxLanes, 1)
+        XCTAssertTrue(w.isActive)
+    }
+
+    func testLinkWidthDual() {
+        let w = LinkWidth(rawValue: 0x2)
+        XCTAssertFalse(w.single)
+        XCTAssertTrue(w.dual)
+        XCTAssertEqual(w.txLanes, 2)
+        XCTAssertEqual(w.rxLanes, 2)
+    }
+
+    func testLinkWidthAsymmetricTx() {
+        // 3 TX / 1 RX. TB5 only; we have no real sample yet but the
+        // model has to handle it without breaking.
+        let w = LinkWidth(rawValue: 0x4)
+        XCTAssertTrue(w.asymmetricTx)
+        XCTAssertEqual(w.txLanes, 3)
+        XCTAssertEqual(w.rxLanes, 1)
+    }
+
+    func testLinkWidthAsymmetricRx() {
+        let w = LinkWidth(rawValue: 0x8)
+        XCTAssertTrue(w.asymmetricRx)
+        XCTAssertEqual(w.txLanes, 1)
+        XCTAssertEqual(w.rxLanes, 3)
+    }
+
+    func testLinkWidthIdle() {
+        let w = LinkWidth(rawValue: 0)
+        XCTAssertFalse(w.isActive)
+        XCTAssertEqual(w.txLanes, 0)
+    }
+
+    // MARK: - TargetLinkWidth (different encoding from current width)
+
+    func testTargetLinkWidthSingle() {
+        XCTAssertEqual(TargetLinkWidth.from(rawValue: 0x1), .single)
+    }
+
+    /// `Target Link Width = 3` is the named DUAL register value, NOT
+    /// asymmetric. This was a footgun the planning doc nearly baked in.
+    func testTargetLinkWidthThreeMeansDual() {
+        XCTAssertEqual(TargetLinkWidth.from(rawValue: 0x3), .dual)
+    }
+
+    func testTargetLinkWidthUnknown() {
+        XCTAssertEqual(TargetLinkWidth.from(rawValue: 0x7), .unknown(rawValue: 0x7))
+    }
+
+    // MARK: - SupportedSpeedMask
+
+    /// Apple TB4-class controllers report 12 (0x4 | 0x8) on every host root
+    /// we've seen so far.
+    func testSupportedSpeedMaskTb4Class() {
+        let m = SupportedSpeedMask(rawValue: 12)
+        XCTAssertTrue(m.supportsTb3)
+        XCTAssertTrue(m.supportsUsb4Tb4)
+        XCTAssertFalse(m.supportsTb5)
+    }
+
+    /// A future TB5 controller should report 14 (0x2 | 0x4 | 0x8). Verified
+    /// by inference only; no real sample yet.
+    func testSupportedSpeedMaskTb5Class() {
+        let m = SupportedSpeedMask(rawValue: 14)
+        XCTAssertTrue(m.supportsTb5)
+        XCTAssertTrue(m.supportsUsb4Tb4)
+        XCTAssertTrue(m.supportsTb3)
+    }
+
+    // MARK: - AdapterType decoding
+
+    func testAdapterTypeDecoding() {
+        XCTAssertEqual(AdapterType.from(rawValue: 0), .inactive)
+        XCTAssertEqual(AdapterType.from(rawValue: 1), .lane)
+        XCTAssertEqual(AdapterType.from(rawValue: 2), .nhi)
+        XCTAssertEqual(AdapterType.from(rawValue: 0x0e0101), .dpIn)
+        XCTAssertEqual(AdapterType.from(rawValue: 0x0e0102), .dpOut)
+        XCTAssertEqual(AdapterType.from(rawValue: 0x100101), .pcieDown)
+        XCTAssertEqual(AdapterType.from(rawValue: 0x100102), .pcieUp)
+        XCTAssertEqual(AdapterType.from(rawValue: 0x200101), .usb3Down)
+        XCTAssertEqual(AdapterType.from(rawValue: 0x200102), .usb3Up)
+        XCTAssertEqual(AdapterType.from(rawValue: 0xdeadbe), .other(0xdeadbe))
+    }
+
+    func testAdapterTypeDecimalValuesFromIokit() {
+        // The IOKit dumps print these as decimals; sanity-check the
+        // hex-to-decimal conversions.
+        XCTAssertEqual(AdapterType.from(rawValue: 917761), .dpIn)
+        XCTAssertEqual(AdapterType.from(rawValue: 917762), .dpOut)
+        XCTAssertEqual(AdapterType.from(rawValue: 1048833), .pcieDown)
+        XCTAssertEqual(AdapterType.from(rawValue: 1048834), .pcieUp)
+        XCTAssertEqual(AdapterType.from(rawValue: 2097409), .usb3Down)
+        XCTAssertEqual(AdapterType.from(rawValue: 2097410), .usb3Up)
+    }
+
+    // MARK: - Steve's Samsung C34J79x downstream switch (TB3)
+
+    /// Switch #3 from issue #52 comment 1: Samsung C34J79x at Depth=1.
+    private var samsungSwitch: [String: Any] {
+        [
+            "UID": NSNumber(value: Int64(105094508797638400)),
+            "Vendor ID": NSNumber(value: 32902),
+            "Device Vendor ID": NSNumber(value: 373),
+            "Device Vendor Name": "SAMSUNG ELECTRONICS CO.,LTD",
+            "Device Model Name": "C34J79x",
+            "Router ID": NSNumber(value: 0),
+            "Depth": NSNumber(value: 1),
+            "Route String": NSNumber(value: 1),
+            "Upstream Port Number": NSNumber(value: 3),
+            "Max Port Number": NSNumber(value: 13),
+            "Supported Link Speed": NSNumber(value: 12)
+        ]
+    }
+
+    /// Active TB3 link from the same dump: host port @1 (Lane 1) with
+    /// `Current Link Speed = 8`, `Width = 2`, `Link Bandwidth = 200`.
+    private var hostTb3Port: [String: Any] {
+        [
+            "Adapter Type": NSNumber(value: 1),
+            "Port Number": NSNumber(value: 1),
+            "Socket ID": "1",
+            "Current Link Speed": NSNumber(value: 8),
+            "Current Link Width": NSNumber(value: 2),
+            "Target Link Speed": NSNumber(value: 12),
+            "Target Link Width": NSNumber(value: 3),
+            "Supported Link Speed": NSNumber(value: 12),
+            "Supported Link Width": NSNumber(value: 2),
+            "Link Bandwidth": NSNumber(value: 200)
+        ]
+    }
+
+    func testSamsungSwitchParses() {
+        let model = ThunderboltSwitch.from(
+            properties: samsungSwitch,
+            className: "IOThunderboltSwitchType3",
+            ports: []
+        )
+        XCTAssertNotNil(model)
+        XCTAssertEqual(model?.id, 105094508797638400)
+        XCTAssertEqual(model?.depth, 1)
+        XCTAssertEqual(model?.routeString, 1)
+        XCTAssertEqual(model?.modelName, "C34J79x")
+        XCTAssertEqual(model?.vendorName, "SAMSUNG ELECTRONICS CO.,LTD")
+        XCTAssertEqual(model?.upstreamPortNumber, 3)
+        XCTAssertFalse(model?.isHostRoot ?? true)
+    }
+
+    func testHostTb3PortParsesAsActiveTb3Link() {
+        let port = ThunderboltPort.from(properties: hostTb3Port)
+        XCTAssertNotNil(port)
+        XCTAssertEqual(port?.adapterType, .lane)
+        XCTAssertEqual(port?.socketID, "1")
+        XCTAssertEqual(port?.currentSpeed, .tb3)
+        XCTAssertEqual(port?.perLaneGbps, 10)
+        XCTAssertEqual(port?.currentWidth?.dual, true)
+        XCTAssertEqual(port?.txLanes, 2)
+        XCTAssertEqual(port?.targetWidth, .dual)
+        XCTAssertEqual(port?.linkBandwidthRaw, 200)
+        XCTAssertTrue(port?.hasActiveLink ?? false)
+    }
+
+    // MARK: - Joe's daisy-chain (USB4 + TB3 step-down)
+
+    /// ASUS PA32QCV at Depth=1 via Intel JHL8440 controller.
+    private var asusSwitch: [String: Any] {
+        [
+            // ASUS UID is negative in IOKit (Int64 sign bit set). This is
+            // exactly why the model uses Int64 rather than UInt64.
+            "UID": NSNumber(value: Int64(-9185256489162756864)),
+            "Vendor ID": NSNumber(value: 32903),
+            "Device Vendor ID": NSNumber(value: 2821),
+            "Device Vendor Name": "ASUS-Display",
+            "Device Model Name": "PA32QCV",
+            "Router ID": NSNumber(value: 0),
+            "Depth": NSNumber(value: 1),
+            "Route String": NSNumber(value: 1),
+            "Upstream Port Number": NSNumber(value: 1),
+            "Max Port Number": NSNumber(value: 19),
+            "Supported Link Speed": NSNumber(value: 12)
+        ]
+    }
+
+    /// Host port @1 on Joe's M2 Pro: USB4 link to the ASUS, speed=4, width=2.
+    private var hostUsb4Port: [String: Any] {
+        [
+            "Adapter Type": NSNumber(value: 1),
+            "Port Number": NSNumber(value: 1),
+            "Socket ID": "1",
+            "Current Link Speed": NSNumber(value: 4),
+            "Current Link Width": NSNumber(value: 2),
+            "Target Link Speed": NSNumber(value: 12),
+            "Target Link Width": NSNumber(value: 3),
+            "Link Bandwidth": NSNumber(value: 400)
+        ]
+    }
+
+    /// CalDigit TS3 Plus at Depth=2, Route String=769 (= 0x301: entered
+    /// ASUS port 3, then host port 1).
+    private var ts3PlusSwitch: [String: Any] {
+        [
+            "UID": NSNumber(value: Int64(17188550068006400)),
+            "Vendor ID": NSNumber(value: 32902),
+            "Device Vendor ID": NSNumber(value: 61),
+            "Device Vendor Name": "CalDigit, Inc.",
+            "Device Model Name": "TS3 Plus",
+            "Router ID": NSNumber(value: 0),
+            "Depth": NSNumber(value: 2),
+            "Route String": NSNumber(value: 769),
+            "Upstream Port Number": NSNumber(value: 1),
+            "Max Port Number": NSNumber(value: 11),
+            "Supported Link Speed": NSNumber(value: 12)
+        ]
+    }
+
+    /// TS3 Plus upstream lane port: TB3 single-lane (the step-down).
+    private var ts3PlusUpstreamPort: [String: Any] {
+        [
+            "Adapter Type": NSNumber(value: 1),
+            "Port Number": NSNumber(value: 3),
+            "Current Link Speed": NSNumber(value: 8),
+            "Current Link Width": NSNumber(value: 1),
+            "Target Link Speed": NSNumber(value: 12),
+            "Target Link Width": NSNumber(value: 1),
+            "Link Bandwidth": NSNumber(value: 100)
+        ]
+    }
+
+    func testHostUsb4PortDetectedAsTb4Class() {
+        let port = ThunderboltPort.from(properties: hostUsb4Port)
+        XCTAssertEqual(port?.currentSpeed, .usb4Tb4)
+        XCTAssertEqual(port?.perLaneGbps, 20)
+        XCTAssertEqual(port?.txLanes, 2)
+        XCTAssertEqual(port?.linkBandwidthRaw, 400)
+    }
+
+    func testDaisyChainStepDownDetected() {
+        // The interesting UX bullet for this topology is "USB4 to ASUS,
+        // step-down to TB3 single-lane on the next leg". This test
+        // confirms the model exposes everything a renderer needs to
+        // produce that label. The renderer itself is Phase 3.
+        let usb4 = ThunderboltPort.from(properties: hostUsb4Port)
+        let tb3 = ThunderboltPort.from(properties: ts3PlusUpstreamPort)
+        XCTAssertEqual(usb4?.currentSpeed, .usb4Tb4)
+        XCTAssertEqual(tb3?.currentSpeed, .tb3)
+        // Per-lane Gbps drops on the second hop. Lane count also drops.
+        XCTAssertGreaterThan(usb4?.perLaneGbps ?? 0, tb3?.perLaneGbps ?? 0)
+        XCTAssertGreaterThan(usb4?.txLanes ?? 0, tb3?.txLanes ?? 0)
+    }
+
+    func testTs3PlusSwitchAtDepth2() {
+        let model = ThunderboltSwitch.from(
+            properties: ts3PlusSwitch,
+            className: "IOThunderboltSwitchType3",
+            ports: []
+        )
+        XCTAssertEqual(model?.depth, 2)
+        XCTAssertEqual(model?.routeString, 769)
+        XCTAssertEqual(model?.modelName, "TS3 Plus")
+    }
+
+    func testAsusSwitchHandlesNegativeUid() {
+        // Regression guard: IOKit reports some UIDs as signed Int64 with
+        // the sign bit set. The model must store these without truncation.
+        let model = ThunderboltSwitch.from(
+            properties: asusSwitch,
+            className: "IOThunderboltSwitchIntelJHL8440",
+            ports: []
+        )
+        XCTAssertEqual(model?.id, -9185256489162756864)
+        XCTAssertEqual(model?.modelName, "PA32QCV")
+    }
+
+    // MARK: - Idle / non-lane ports
+
+    func testIdleHostPortHasNoLinkState() {
+        // From the M5 Pro idle probe: lane port with everything zeroed.
+        let dict: [String: Any] = [
+            "Adapter Type": NSNumber(value: 1),
+            "Port Number": NSNumber(value: 1),
+            "Socket ID": "1",
+            "Current Link Speed": NSNumber(value: 0),
+            "Current Link Width": NSNumber(value: 0)
+        ]
+        let port = ThunderboltPort.from(properties: dict)
+        XCTAssertNil(port?.currentSpeed)
+        XCTAssertEqual(port?.currentWidth?.isActive, false)
+        XCTAssertFalse(port?.hasActiveLink ?? true)
+    }
+
+    func testProtocolAdapterPortHasNoLinkState() {
+        // PCIe adapter ports report Adapter Type but not link generation.
+        // The factory should not invent a generation just because the
+        // dictionary happens to contain a Link Bandwidth value.
+        let dict: [String: Any] = [
+            "Adapter Type": NSNumber(value: 1048833),  // PCIe down
+            "Port Number": NSNumber(value: 3),
+            "Link Bandwidth": NSNumber(value: 60)
+        ]
+        let port = ThunderboltPort.from(properties: dict)
+        XCTAssertEqual(port?.adapterType, .pcieDown)
+        XCTAssertNil(port?.currentSpeed)
+        XCTAssertNil(port?.currentWidth)
+        XCTAssertFalse(port?.hasActiveLink ?? true)
+    }
+
+    // MARK: - Missing fields
+
+    func testSwitchWithoutUidReturnsNil() {
+        let model = ThunderboltSwitch.from(
+            properties: ["Vendor ID": NSNumber(value: 1)],
+            className: "IOThunderboltSwitchType7",
+            ports: []
+        )
+        XCTAssertNil(model)
+    }
+
+    func testPortWithoutPortNumberReturnsNil() {
+        let port = ThunderboltPort.from(properties: ["Adapter Type": NSNumber(value: 1)])
+        XCTAssertNil(port)
+    }
+}


### PR DESCRIPTION
## Summary

Adds the Thunderbolt fabric feature: WhatCable now reads `IOThunderboltSwitch` and reports negotiated link state (per-lane Gb/s, lane count, daisy-chain topology, connected device identity) instead of just the cable's e-marker capability. Closes the gap with `USB Connection Information` on the same surface.

Built across three phases (one commit each), plus two follow-up commits that resolve Codex review findings.

* **Phase 1+2** (`95e85a9`): typed model in `WhatCableCore` (`ThunderboltSwitch`, `ThunderboltPort`, `LinkGeneration`, `LinkWidth`, `TargetLinkWidth`, `AdapterType`, `SupportedSpeedMask`) + IOKit watcher in `WhatCableDarwinBackend`. Encoding anchored against Linux's `drivers/thunderbolt/tb_regs.h`.
* **Phase 3** (`1529612`): rendering layer. PortSummary emits new bullets (`"Linked at up to 20 Gb/s × 2"`, `"Connected via 2 hops: ..."`, `"Last leg drops from ..."`). JSON gets a top-level `thunderboltSwitches` array and per-port `thunderboltSwitchUID` reference. GUI gets a `ThunderboltFabricSection` behind the existing technical-details toggle.
* **Fixes** (`a67bef9`, `be7569c`): watch-mode now passes the new field to the formatters, parent-switch lookup uses stable registry entry IDs instead of mach-port handles, single-hop links no longer trigger the step-down warning, JSON TB5 generation label stays hedged.

## Anchored against real samples

Issue #52 paste-backs from contributors:

* Steve's M3 Air + Samsung C34J79x via TB3 (single hop)
* Joe's M2 Pro + ASUS PA32QCV (USB4) + CalDigit TS3 Plus daisy-chain (two hops, with TB3 step-down)
* Dev-machine M5 Pro idle probe

Encoding (speed code, width bits, adapter type bytes) cross-referenced with Linux's USB4 lane-adapter register definitions.

## TB5 conservatism

The model decodes raw speed code `0x2` to `LinkGeneration.tb5`, but the renderer (text, JSON, GUI) treats it as unverified and emits `"Unknown generation (raw speed code 0x2, inferred TB5)"` until a real Apple Silicon TB5 paste-back lands. Tests pin both the text and JSON labels so we can't accidentally promise TB5 too early. Issue #52 has been updated to specifically ask for TB5-host samples and `system_profiler SPThunderboltDataType` output for cross-reference.

## Test plan

- [x] `swift build` clean
- [x] `swift test` 186 / 186 passing (+52 new tests across model, labels, PortSummary integration, JSON shape)
- [x] Live `whatcable-cli --json` emits `thunderboltSwitches` (3 host switches on dev machine)
- [x] Live `whatcable-cli --watch --json` also emits the field (regression check on the watch-mode fix)
- [x] Existing TextFormatter / JSONFormatter golden tests still pass (no regression on non-TB output)
- [ ] Live test with a real TB device plugged in (none on dev machine; will validate post-merge as more contributor data lands)
- [ ] GUI smoke test in built `.app` (planned via `scripts/smoke-test.sh` before release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
