### PR TITLE
Add H3 trust flag: VID not in USB-IF's published list

### DIFF
--- a/Sources/WhatCableCore/CableTrustReport.swift
+++ b/Sources/WhatCableCore/CableTrustReport.swift
@@ -25,6 +25,11 @@ public struct CableTrustReport: Hashable {
 
         if identity.vendorID == 0 {
             collected.append(.zeroVendorID)
+        } else if !VendorDB.isRegistered(identity.vendorID) {
+            // Only flag non-zero unregistered VIDs. The zeroed-VID case
+            // is already covered by .zeroVendorID with stronger wording;
+            // we don't want to double-flag.
+            collected.append(.vidNotInUSBIFList(identity.vendorID))
         }
 
         if let cv = identity.cableVDO {
@@ -54,12 +59,19 @@ public enum TrustFlag: Hashable {
     /// Cable VDO current field uses the reserved bit pattern (3).
     case reservedCurrentEncoding(Int)
 
+    /// E-marker reports a non-zero vendor ID that isn't in any of our
+    /// known sources (the curated VendorDB or the bundled USB-IF list).
+    /// Could be a post-bundle assignment, a copied number, or a typo
+    /// from a knock-off chip programmer. Hedged accordingly.
+    case vidNotInUSBIFList(Int)
+
     /// Short identifier suitable for JSON output. Stable across releases.
     public var code: String {
         switch self {
         case .zeroVendorID: return "zeroVendorID"
         case .reservedSpeedEncoding: return "reservedSpeedEncoding"
         case .reservedCurrentEncoding: return "reservedCurrentEncoding"
+        case .vidNotInUSBIFList: return "vidNotInUSBIFList"
         }
     }
 
@@ -72,6 +84,8 @@ public enum TrustFlag: Hashable {
             return "E-marker uses a reserved data-speed value"
         case .reservedCurrentEncoding:
             return "E-marker uses a reserved current-rating value"
+        case .vidNotInUSBIFList:
+            return "Vendor ID isn't in USB-IF's published list"
         }
     }
 
@@ -84,6 +98,9 @@ public enum TrustFlag: Hashable {
             return "The cable's e-marker reports speed value \(bits), which is reserved by the USB-PD spec. Real e-marker chips should not emit reserved values."
         case .reservedCurrentEncoding(let bits):
             return "The cable's e-marker reports current value \(bits), which is reserved by the USB-PD spec. Real e-marker chips should not emit reserved values."
+        case .vidNotInUSBIFList(let vid):
+            let hex = String(format: "0x%04X", vid)
+            return "The cable's e-marker reports vendor \(hex), which isn't in our bundled USB-IF list. The number could be unassigned, copied, or assigned after the bundled list was generated. On its own this isn't proof of a problem, but on a clone cable it often appears alongside other inconsistencies."
         }
     }
 }

--- a/Sources/WhatCableCore/VendorDB.swift
+++ b/Sources/WhatCableCore/VendorDB.swift
@@ -108,6 +108,15 @@ public enum VendorDB {
         return USBIFVendors.name(for: vendorID)
     }
 
+    /// True if the VID is present in either the curated map or the
+    /// bundled USB-IF list. Distinct from `name(for:) != nil` only for
+    /// VID 0, which the bundled lookup hides for display purposes but
+    /// is still considered "registered" (USB-IF assigns 0 to itself).
+    public static func isRegistered(_ vendorID: Int) -> Bool {
+        if names[vendorID] != nil { return true }
+        return USBIFVendors.isRegistered(vendorID)
+    }
+
     /// Returns "Realtek (0x0BDA)" if known, else "0x0BDA".
     public static func label(for vendorID: Int) -> String {
         if let n = name(for: vendorID) {

--- a/Tests/WhatCableCoreTests/CableTrustReportTests.swift
+++ b/Tests/WhatCableCoreTests/CableTrustReportTests.swift
@@ -69,10 +69,66 @@ final class CableTrustReportTests: XCTestCase {
         ])
     }
 
+    // MARK: - H3: VID not in USB-IF list
+
+    func testRegisteredVendorDoesNotFireH3() {
+        // 0x05AC (Apple) is in both the curated map and the bundled list.
+        let report = CableTrustReport(identity: cableIdentity(vendorID: 0x05AC))
+        XCTAssertTrue(report.isEmpty)
+    }
+
+    func testCableEmarkerChipVendorsDoNotFireH3() {
+        // The six chip vendors observed in real cable reports
+        // (#44, #45, #48, #49, #60, #62). All registered with USB-IF
+        // per the bundled March 2026 list, so H3 must not fire.
+        for vid in [0x20C2, 0x315C, 0x2095, 0x2E99, 0x201C, 0x2B1D] {
+            let report = CableTrustReport(identity: cableIdentity(vendorID: vid))
+            XCTAssertTrue(
+                report.isEmpty,
+                "H3 should not fire on registered VID \(String(format: "0x%04X", vid))"
+            )
+        }
+    }
+
+    func testUnregisteredVIDFiresH3() {
+        // 0xDEAD is not a USB-IF assignment in any source we carry.
+        let report = CableTrustReport(identity: cableIdentity(vendorID: 0xDEAD))
+        XCTAssertEqual(report.flags, [.vidNotInUSBIFList(0xDEAD)])
+    }
+
+    func testZeroVendorIDDoesNotDoubleFire() {
+        // VID 0 fires zeroVendorID (stronger signal); we don't also
+        // want H3 firing as a noisier "0x0000 not registered" message.
+        let report = CableTrustReport(identity: cableIdentity(vendorID: 0))
+        XCTAssertEqual(report.flags, [.zeroVendorID])
+        XCTAssertFalse(report.flags.contains { flag in
+            if case .vidNotInUSBIFList = flag { return true }
+            return false
+        })
+    }
+
+    func testH3CombinesWithReservedEncodings() {
+        // Unregistered VID + reserved speed bits = both flags.
+        let vdo = UInt32(0b111) | UInt32(2 << 5)
+        let report = CableTrustReport(identity: cableIdentity(vendorID: 0xDEAD, cableVDO: vdo))
+        XCTAssertEqual(report.flags, [
+            .vidNotInUSBIFList(0xDEAD),
+            .reservedSpeedEncoding(7)
+        ])
+    }
+
+    // MARK: - JSON contract
+
     func testFlagCodesAreStable() {
         // Codes are part of the JSON contract; pin them.
         XCTAssertEqual(TrustFlag.zeroVendorID.code, "zeroVendorID")
         XCTAssertEqual(TrustFlag.reservedSpeedEncoding(5).code, "reservedSpeedEncoding")
         XCTAssertEqual(TrustFlag.reservedCurrentEncoding(3).code, "reservedCurrentEncoding")
+        XCTAssertEqual(TrustFlag.vidNotInUSBIFList(0xDEAD).code, "vidNotInUSBIFList")
+    }
+
+    func testH3DetailIncludesVIDInHex() {
+        let detail = TrustFlag.vidNotInUSBIFList(0xABCD).detail
+        XCTAssertTrue(detail.contains("0xABCD"))
     }
 }

--- a/Tests/WhatCableCoreTests/JSONFormatterTests.swift
+++ b/Tests/WhatCableCoreTests/JSONFormatterTests.swift
@@ -230,6 +230,24 @@ final class JSONFormatterTests: XCTestCase {
         }
     }
 
+    func testTrustFlagsEmitsH3ForUnregisteredVID() throws {
+        let port = makePort()
+        // 0xDEAD isn't in the curated map or the bundled USB-IF list.
+        let id = cableIdentity(vendorID: 0xDEAD, cableVDO: (0b10 << 5) | 0b011)
+        let json = try JSONFormatter.render(
+            ports: [port], sources: [], identities: [id], showRaw: false
+        )
+        let obj = parse(json)
+        let portObj = (obj["ports"] as? [[String: Any]])?.first ?? [:]
+        let cable = try XCTUnwrap(portObj["cable"] as? [String: Any])
+        let flags = try XCTUnwrap(cable["trustFlags"] as? [[String: Any]])
+        XCTAssertEqual(flags.count, 1)
+        XCTAssertEqual(flags.first?["code"] as? String, "vidNotInUSBIFList")
+        // Detail should reference the VID in hex so users can grep / search.
+        let detail = flags.first?["detail"] as? String ?? ""
+        XCTAssertTrue(detail.contains("0xDEAD"), "detail should include hex VID, got: \(detail)")
+    }
+
     // MARK: - Raw properties gating
 
     func testRawPropertiesOmittedByDefault() throws {


### PR DESCRIPTION
## Summary

New trust flag `vidNotInUSBIFList(Int)` fires when a cable's e-marker reports a non-zero vendor ID that's missing from both layers of vendor lookup (the curated `VendorDB.names` overrides and the bundled USB-IF March 2026 list shipped in v0.8.1).

This is the H3 heuristic from `planning/cable-trust-signals.md`. It was deferred until the bundled list landed because flagging "VID not in our small hand-curated set" produced too many false positives. With ~13,652 USB-IF entries now in hand, "VID in neither layer" is a much rarer and more informative signal.

## What this flags (and what it doesn't)

- **Fires** on a non-zero VID absent from both layers — could be a post-bundle assignment, a copied number, or a typo from a knock-off chip programmer.
- **Doesn't fire** when the VID is present in either layer. All seven cable-report sample VIDs (Caldigit, Anker, Monoprice, Delock, Acasis, Dbilida chip vendors plus Apple) are registered, so none of those reports would false-positive.
- **Doesn't fire** when the VID is zero — that case fires `zeroVendorID` (stronger wording). Explicit no-double-flag check.

## Wording

> "The cable's e-marker reports vendor 0xABCD, which isn't in our bundled USB-IF list. The number could be unassigned, copied, or assigned after the bundled list was generated. On its own this isn't proof of a problem, but on a clone cable it often appears alongside other inconsistencies."

Stays in the hedged "looks unusual / common counterfeit pattern, never 'this cable is fake'" register the rest of the trust flags use.

## Test plan

- [x] `swift test` — 205 tests green (+7 new).
- [x] Confirmed registered VIDs (0x05AC, 0x20C2, 0x315C, 0x2095, 0x2E99, 0x201C, 0x2B1D) do not fire H3.
- [x] Confirmed `0xDEAD` (unregistered) does fire H3, and JSON output emits `vidNotInUSBIFList` with hex VID in detail.
- [x] Confirmed zero VID does not double-fire.
- [x] H3 combines correctly with reserved-encoding flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
