### PR TITLE
Drop curated VendorDB layer, defer to USB-IF list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ CLAUDE.md
 # Release notes are staged here, then copied into the homebrew-whatcable tap
 # repo and used as the GitHub release body. The tap repo is the canonical home.
 release-notes/
+
+# USB-IF spec PDFs (copyrighted, not for distribution)
+reference/

--- a/Sources/WhatCableCore/VendorDB.swift
+++ b/Sources/WhatCableCore/VendorDB.swift
@@ -1,123 +1,38 @@
 import Foundation
 
-/// USB-IF vendor name lookup. Two layers:
+/// USB-IF vendor name lookup, backed by the bundled USB-IF list shipped
+/// in `Sources/WhatCableCore/Resources/usbif-vendors.tsv` (refreshed by
+/// `scripts/update-vendor-db.sh`).
 ///
-/// 1. A small hand-curated map of common vendors, where we want a clean
-///    short display name (e.g. "Apple" rather than the USB-IF's verbose
-///    "Apple Inc."). Add entries here when you want to override or
-///    shorten what the bundled list provides.
-///
-/// 2. The bundled USB-IF list (~13,000+ entries), refreshed by
-///    `scripts/update-vendor-db.sh`. Used as a fallback so cables and
-///    devices from any USB-IF registered vendor get a real name even if
-///    we haven't curated them.
-///
-/// Lookup checks the curated map first, then falls back to the bundled
-/// list. Returns nil only when the VID is in neither layer.
+/// A `curatedOverrides` escape hatch is kept available for the rare
+/// cases where USB-IF's published name is genuinely wrong, mojibake'd,
+/// or unintelligible. The default policy is **don't add overrides**.
+/// Trust upstream; if you're tempted to shorten "Anker Innovations
+/// Limited" to "Anker", don't, the longer form is accurate. Past
+/// curated entries drifted out of date (e.g. `0x103C` was labelled
+/// "HP" in the curated map but is registered to AMX Corp. per
+/// USB-IF, and we shipped that wrong label for months).
 public enum VendorDB {
-    private static let names: [Int: String] = [
-        0x05AC: "Apple",
-        0x004C: "Apple (legacy)",
-        // Cable e-marker silicon vendors. Cable e-markers carry the chip
-        // vendor's VID, not the cable brand's, so these come up far more
-        // often than the consumer-device VIDs further down. Verified
-        // against USB-IF's March 2026 vendor ID list.
-        0x20C2: "Sumitomo Electric Optical Comm",
-        0x315C: "Chengdu Convenientpower Semiconductor",
-        0x2095: "CE LINK",
-        0x2E99: "Hynetek Semiconductor",
-        0x201C: "Hongkong Freeport Electronics",
-        0x2B1D: "Lintes Technology",
-        0x05E3: "Genesys Logic",
-        0x0BDA: "Realtek",
-        0x174C: "ASMedia",
-        0x2109: "VIA Labs",
-        0x152D: "JMicron",
-        0x067B: "Prolific",
-        0x0451: "Texas Instruments",
-        0x8087: "Intel",
-        0x046D: "Logitech",
-        0x0BB4: "HTC",
-        0x18D1: "Google",
-        0x12D1: "Huawei",
-        0x04E8: "Samsung",
-        0x2717: "Xiaomi",
-        0x22D9: "OPPO",
-        0x2A70: "OnePlus",
-        0x05C6: "Qualcomm",
-        0x0BC2: "Seagate",
-        0x1058: "Western Digital",
-        0x0781: "SanDisk",
-        0x0930: "Toshiba",
-        0x0951: "Kingston",
-        0x125F: "ADATA",
-        0x1B1C: "Corsair",
-        0x154B: "PNY",
-        0x0080: "Crucial",
-        0x174F: "Syntek",
-        0x046E: "Behavior Tech",
-        0x05DC: "Lexar",
-        0x0E8D: "MediaTek",
-        0x148F: "Ralink",
-        0x0B95: "ASIX",
-        0x0CF3: "Qualcomm Atheros",
-        0x06CB: "Synaptics",
-        0x056A: "Wacom",
-        0x040A: "Kodak",
-        0x056D: "EIZO",
-        0x0AF8: "Belkin",
-        0x050D: "Belkin (older)",
-        0x291A: "Anker",
-        0x0BB8: "Plantronics / Poly",
-        0x0763: "M-Audio",
-        0x0FCE: "Sony Mobile",
-        0x054C: "Sony",
-        0x04F2: "Chicony",
-        0x046A: "Cherry",
-        0x04D9: "Holtek",
-        0x1532: "Razer",
-        0x1B7E: "Holosonics",
-        0x07AA: "Corega",
-        0x2188: "SmartAction",
-        0x0E0F: "VMware",
-        0x0FFE: "OWC",
-        0x152E: "Lenovo",
-        0x17EF: "Lenovo (older)",
-        0x0BAF: "U.S. Robotics",
-        0x0DCD: "Diconix",
-        0x0FCA: "Research In Motion",
-        0x05E0: "Symbol",
-        0x05DD: "Delorme",
-        0x0764: "CyberPower",
-        0x051D: "American Power Conversion (APC)",
-        0x2C7C: "Quectel",
-        0x2341: "Arduino",
-        0x1A40: "Terminus (hub chips)",
-        0x1D6B: "Linux Foundation",
-        0x0CF8: "Targus",
-        0x0B05: "ASUS",
-        0x103C: "HP",
-        0x413C: "Dell",
-        0x0CCD: "TerraTec",
-        0x0E58: "Aopen",
-        0x14AD: "Microvision"
-    ]
+    /// Override map. Empty by default. Add an entry only when the
+    /// upstream USB-IF name is materially wrong or unusable, not
+    /// merely verbose.
+    private static let curatedOverrides: [Int: String] = [:]
 
     public static func name(for vendorID: Int) -> String? {
-        if let curated = names[vendorID] { return curated }
+        if let override = curatedOverrides[vendorID] { return override }
         return USBIFVendors.name(for: vendorID)
     }
 
-    /// True if the VID is present in either the curated map or the
+    /// True if the VID is present in either the override map or the
     /// bundled USB-IF list. Distinct from `name(for:) != nil` only for
     /// VID 0, which the bundled lookup hides for display purposes but
     /// is still considered "registered" (USB-IF assigns 0 to itself).
     public static func isRegistered(_ vendorID: Int) -> Bool {
-        if names[vendorID] != nil { return true }
+        if curatedOverrides[vendorID] != nil { return true }
         return USBIFVendors.isRegistered(vendorID)
     }
 
-    /// Returns "Realtek (0x0BDA)" if known, else "0x0BDA".
+    /// Returns "Apple (0x05AC)" if known, else "0x05AC".
     public static func label(for vendorID: Int) -> String {
         if let n = name(for: vendorID) {
             return "\(n) (0x\(String(format: "%04X", vendorID)))"

--- a/Tests/WhatCableCoreTests/VendorDBTests.swift
+++ b/Tests/WhatCableCoreTests/VendorDBTests.swift
@@ -3,67 +3,69 @@ import XCTest
 
 final class VendorDBTests: XCTestCase {
 
-    func testKnownVendorReturnsName() {
+    // MARK: - Names come from the bundled USB-IF list
+
+    func testKnownVendorsReturnUSBIFNames() {
+        // No curated overrides. USB-IF's published name is what we show,
+        // verbatim. The legal-suffix forms are accurate and not misleading.
         XCTAssertEqual(VendorDB.name(for: 0x05AC), "Apple")
-        XCTAssertEqual(VendorDB.name(for: 0x0BDA), "Realtek")
-        // Anker's actual USB-IF VID is 0x291A (verified against the
-        // March 2026 USB-IF vendor list).
-        XCTAssertEqual(VendorDB.name(for: 0x291A), "Anker")
+        XCTAssertEqual(VendorDB.name(for: 0x0BDA), "Realtek Semiconductor Corp.")
+        XCTAssertEqual(VendorDB.name(for: 0x046D), "Logitech Inc.")
+        XCTAssertEqual(VendorDB.name(for: 0x291A), "Anker Innovations Limited")
+        XCTAssertEqual(VendorDB.name(for: 0x18D1), "Google Inc.")
     }
 
     func testCableEmarkerChipVendorsResolve() {
         // E-marker silicon vendors observed in real cable reports
-        // (#44, #45, #48, #49, #60, #62). Verified against USB-IF's
-        // March 2026 vendor list.
-        XCTAssertEqual(VendorDB.name(for: 0x20C2), "Sumitomo Electric Optical Comm")
-        XCTAssertEqual(VendorDB.name(for: 0x315C), "Chengdu Convenientpower Semiconductor")
-        XCTAssertEqual(VendorDB.name(for: 0x2095), "CE LINK")
-        XCTAssertEqual(VendorDB.name(for: 0x2E99), "Hynetek Semiconductor")
-        XCTAssertEqual(VendorDB.name(for: 0x201C), "Hongkong Freeport Electronics")
-        XCTAssertEqual(VendorDB.name(for: 0x2B1D), "Lintes Technology")
+        // (#44, #45, #48, #49, #60, #62). USB-IF carries each of them
+        // with its full legal name; we surface that as-is.
+        XCTAssertEqual(
+            VendorDB.name(for: 0x20C2),
+            "Sumitomo Electric Ind., Ltd., Optical Comm. R&D Lab"
+        )
+        XCTAssertEqual(
+            VendorDB.name(for: 0x315C),
+            "Chengdu Convenientpower Semiconductor Co., LTD"
+        )
+        XCTAssertEqual(VendorDB.name(for: 0x2095), "CE LINK LIMITED")
+        XCTAssertEqual(VendorDB.name(for: 0x2E99), "Hynetek Semiconductor Co., Ltd")
+        XCTAssertEqual(
+            VendorDB.name(for: 0x201C),
+            "Hongkong Freeport Electronics Co., Limited"
+        )
+        XCTAssertEqual(VendorDB.name(for: 0x2B1D), "Lintes Technology Co., Ltd.")
     }
 
-    func testRetiredIncorrectEntries() {
-        // 0x2BCF was previously labelled "Anker" in the curated list
-        // but is actually Magtrol, Inc. per USB-IF. 0x32AC was labelled
-        // "Apple (Thunderbolt 4)" but is actually Framework Computer.
-        // Both wrong labels are gone from the curated overrides; they
-        // now fall through to the bundled USB-IF list and resolve to
-        // the correct registered vendors. This test pins both the
-        // removal of the wrong overrides and the correct fallback.
+    // MARK: - Formerly-wrong curated entries now resolve correctly
+
+    func testFormerlyWrongCuratedEntriesNowReflectUSBIF() {
+        // Before this audit several curated entries attributed VIDs to
+        // the wrong companies. With the curated layer dropped, each
+        // resolves via the bundled USB-IF list to the correct vendor.
+        // Pin them so a future "let's add an override" can't silently
+        // restore the bad data without going through review.
         XCTAssertEqual(VendorDB.name(for: 0x2BCF), "Magtrol, Inc.")
         XCTAssertEqual(VendorDB.name(for: 0x32AC), "Framework Computer Inc")
+        XCTAssertEqual(VendorDB.name(for: 0x103C), "AMX Corp.")
+        XCTAssertEqual(VendorDB.name(for: 0x0FFE), "ASKA Corporation")
+        XCTAssertEqual(VendorDB.name(for: 0x152E), "HLDS (Hitachi-LG Data Storage, Inc.)")
+        XCTAssertEqual(VendorDB.name(for: 0x0AF8), "Taiwan Regular Electronics Co., Ltd.")
     }
 
-    func testBundledUSBIFListProvidesFallbackNames() {
-        // VIDs not in the curated list but registered with USB-IF
-        // should now resolve via the bundled list. 0x121A is
-        // TimeKeeping Systems per USB-IF March 2026.
-        XCTAssertEqual(VendorDB.name(for: 0x121A), "TimeKeeping Systems, Inc.")
-    }
+    // MARK: - Unregistered VIDs
 
-    func testCuratedNamesOverrideBundledList() {
-        // Apple's USB-IF entry says simply "Apple" in the bundled list,
-        // which matches our curated entry. Pick a VID where the curated
-        // form differs from USB-IF's verbose form to confirm the curated
-        // override wins.
-        // Hongkong Freeport: USB-IF lists the long form, our curated
-        // entry uses the shorter "Hongkong Freeport Electronics".
-        XCTAssertEqual(VendorDB.name(for: 0x201C), "Hongkong Freeport Electronics")
-    }
-
-    func testTotallyUnregisteredVIDStillReturnsNil() {
-        // 0xDEAD is not a registered VID; both layers should miss.
+    func testUnregisteredVIDReturnsNil() {
         XCTAssertNil(VendorDB.name(for: 0xDEAD))
     }
 
-    func testUnknownVendorReturnsNil() {
-        XCTAssertNil(VendorDB.name(for: 0xDEAD))
-    }
+    // MARK: - label()
 
     func testLabelIncludesNameAndHex() {
         XCTAssertEqual(VendorDB.label(for: 0x05AC), "Apple (0x05AC)")
-        XCTAssertEqual(VendorDB.label(for: 0x0BDA), "Realtek (0x0BDA)")
+        XCTAssertEqual(
+            VendorDB.label(for: 0x0BDA),
+            "Realtek Semiconductor Corp. (0x0BDA)"
+        )
     }
 
     func testLabelFallsBackToHexOnly() {
@@ -71,8 +73,11 @@ final class VendorDBTests: XCTestCase {
         XCTAssertEqual(VendorDB.label(for: 0x0001), "0x0001")
     }
 
-    func testLabelHexIsUppercaseFourDigits() {
-        // VID 0x004C should render as 004C (zero-padded), uppercase.
-        XCTAssertEqual(VendorDB.label(for: 0x004C), "Apple (legacy) (0x004C)")
+    // MARK: - isRegistered
+
+    func testIsRegisteredCoversBundledList() {
+        XCTAssertTrue(VendorDB.isRegistered(0x05AC))
+        XCTAssertTrue(VendorDB.isRegistered(0x291A))
+        XCTAssertFalse(VendorDB.isRegistered(0xDEAD))
     }
 }


### PR DESCRIPTION
## Summary

The curated `VendorDB.names` map was a holdover from before we bundled the full USB-IF list. With the bundled lookup in place it stopped earning its keep — and worse, it was actively shipping wrong data.

**Audit findings:**

| Outcome | VID | Curated label | USB-IF (March 2026) |
|---|---|---|---|
| Redundant | `0x05AC` | Apple | Apple |
| Redundant | `0x0451` | Texas Instruments | Texas Instruments |
| Redundant | `0x8087` | Intel | Intel |
| **Wrong** | `0x103C` | **HP** | AMX Corp. |
| **Wrong** | `0x0FFE` | **OWC** | ASKA Corporation |
| **Wrong** | `0x152E` | **Lenovo** | HLDS (Hitachi-LG Data Storage) |
| **Wrong** | `0x0AF8` | **Belkin** | Taiwan Regular Electronics |
| Unverified | `0x004C` | Apple (legacy) | (not in 2026 USB-IF list) |
| Just shorter | rest | "Anker" / "Logitech" / etc. | "Anker Innovations Limited" / "Logitech Inc." / etc. |

The shorter forms read fine but they're maintenance debt with drift risk. Trust upstream.

## Change

- Empty the curated map. Single-source-of-truth on the bundled USB-IF list.
- Keep the `curatedOverrides` dictionary literal as a documented escape hatch — the comment says "default policy is don't add overrides," so a future genuinely-broken USB-IF entry has a place to land without restoring the broader curation pattern.
- Drop `0x004C "Apple (legacy)"` since we couldn't verify it.
- Update `VendorDBTests` to pin the post-cleanup behaviour: well-known vendors return their full USB-IF names, formerly-wrong VIDs (the four above plus the two from PR #64) all resolve to their actual registered companies, and `isRegistered` + `label` fallback semantics still hold.

## Second commit

Adds `reference/` to `.gitignore`. Unrelated to the cleanup itself — that directory holds local copies of USB-IF spec PDFs which are copyrighted and shouldn't be redistributed via the repo.

## Test plan

- [x] `swift test` — 202 tests green (was 205; net -3 from collapsed redundant test cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
