### PR TITLE
Cable-latency trust flag, USB-IF cert ID display, 0xFFFF metadata

### DIFF
--- a/Sources/WhatCableCore/CableReport.swift
+++ b/Sources/WhatCableCore/CableReport.swift
@@ -37,6 +37,10 @@ public enum CableReport {
         /// cable genuinely sent zero" when calibrating heuristics like the
         /// zero-PID flag.
         public let vdos: [UInt32]
+        /// USB-IF-issued certification ID from the Cert Stat VDO, or
+        /// `nil` when the e-marker carries no XID. Surfaced as neutral
+        /// information; many reputable cables ship without certification.
+        public let usbifCertID: UInt32?
 
         public init(identity: PDIdentity) {
             self.vendorID = identity.vendorID
@@ -45,6 +49,11 @@ public enum CableReport {
             self.productIDHex = String(format: "0x%04X", identity.productID)
             self.vendorName = VendorDB.name(for: identity.vendorID) ?? "Unregistered / unknown"
             self.vdos = identity.vdos
+            if let cs = identity.certStatVDO, cs.isPresent {
+                self.usbifCertID = cs.xid
+            } else {
+                self.usbifCertID = nil
+            }
             if let cv = identity.cableVDO {
                 self.speed = cv.speed.label
                 self.currentRating = cv.current.label
@@ -146,6 +155,21 @@ extension CableReport.Payload {
             lines.append("| Type | \(t) |")
         }
         lines.append("| Has e-marker | \(cable.hasEmarker ? "Yes" : "No") |")
+        if cable.hasEmarker {
+            // Neutral display: many reputable cables ship without an XID,
+            // so this is a fact about the e-marker, not a trust signal.
+            // We distinguish "macOS didn't surface VDO[1]" from "cable
+            // reports XID 0" so calibration data stays faithful.
+            if cable.vdos.count > 1 {
+                if let xid = cable.usbifCertID {
+                    lines.append("| USB-IF certification ID | `\(String(format: "0x%08X", xid))` |")
+                } else {
+                    lines.append("| USB-IF certification ID | none (XID = 0) |")
+                }
+            } else {
+                lines.append("| USB-IF certification ID | not provided by this Mac |")
+            }
+        }
         lines.append("")
         if !cable.vdos.isEmpty {
             lines.append("### Raw VDOs")

--- a/Sources/WhatCableCore/CableTrustReport.swift
+++ b/Sources/WhatCableCore/CableTrustReport.swift
@@ -23,12 +23,20 @@ public struct CableTrustReport: Hashable {
 
         var collected: [TrustFlag] = []
 
+        // Vendor ID handling:
+        //   0x0000 — no value; suspicious blank, fires zeroVendorID.
+        //   0xFFFF — spec-defined "vendor opted out of USB-IF
+        //            registration." Legitimate per spec, so this is
+        //            neutral metadata, not a trust flag. Surfaced via
+        //            the vendor-name path (see VendorDB.name) so the
+        //            UI describes it without flagging a warning.
+        //   anything else not in the bundled USB-IF list — fires
+        //            vidNotInUSBIFList (H3).
         if identity.vendorID == 0 {
             collected.append(.zeroVendorID)
+        } else if identity.vendorID == 0xFFFF {
+            // Intentionally no flag.
         } else if !VendorDB.isRegistered(identity.vendorID) {
-            // Only flag non-zero unregistered VIDs. The zeroed-VID case
-            // is already covered by .zeroVendorID with stronger wording;
-            // we don't want to double-flag.
             collected.append(.vidNotInUSBIFList(identity.vendorID))
         }
 
@@ -39,6 +47,8 @@ public struct CableTrustReport: Hashable {
                     collected.append(.reservedSpeedEncoding(bits))
                 case .reservedCurrentEncoding(let bits):
                     collected.append(.reservedCurrentEncoding(bits))
+                case .reservedCableLatencyEncoding(let bits):
+                    collected.append(.reservedCableLatencyEncoding(bits))
                 }
             }
         }
@@ -50,6 +60,11 @@ public struct CableTrustReport: Hashable {
 public enum TrustFlag: Hashable {
     /// E-marker present but vendor ID is zero. Legitimate USB-IF members
     /// have non-zero VIDs, so this is a common counterfeit signature.
+    ///
+    /// Note: the *spec-defined* sentinel `0xFFFF` (vendor opted out of
+    /// USB-IF registration) is intentionally NOT a TrustFlag — it's
+    /// allowed by the PD spec, so flagging it as a warning would be
+    /// misleading. It's surfaced via VendorDB / the cable report instead.
     case zeroVendorID
 
     /// Cable VDO speed field uses a reserved bit pattern (5, 6, or 7).
@@ -58,6 +73,11 @@ public enum TrustFlag: Hashable {
 
     /// Cable VDO current field uses the reserved bit pattern (3).
     case reservedCurrentEncoding(Int)
+
+    /// Cable VDO cable-latency field uses a reserved value. Bounds depend
+    /// on cable type (passive: 0000 / 1001..1111; active: 0000 /
+    /// 1011..1111).
+    case reservedCableLatencyEncoding(Int)
 
     /// E-marker reports a non-zero vendor ID that isn't in any of our
     /// known sources (the curated VendorDB or the bundled USB-IF list).
@@ -71,6 +91,7 @@ public enum TrustFlag: Hashable {
         case .zeroVendorID: return "zeroVendorID"
         case .reservedSpeedEncoding: return "reservedSpeedEncoding"
         case .reservedCurrentEncoding: return "reservedCurrentEncoding"
+        case .reservedCableLatencyEncoding: return "reservedCableLatencyEncoding"
         case .vidNotInUSBIFList: return "vidNotInUSBIFList"
         }
     }
@@ -84,6 +105,8 @@ public enum TrustFlag: Hashable {
             return "E-marker uses a reserved data-speed value"
         case .reservedCurrentEncoding:
             return "E-marker uses a reserved current-rating value"
+        case .reservedCableLatencyEncoding:
+            return "E-marker uses a reserved cable-latency value"
         case .vidNotInUSBIFList:
             return "Vendor ID isn't in USB-IF's published list"
         }
@@ -98,6 +121,8 @@ public enum TrustFlag: Hashable {
             return "The cable's e-marker reports speed value \(bits), which is reserved by the USB-PD spec. Real e-marker chips should not emit reserved values."
         case .reservedCurrentEncoding(let bits):
             return "The cable's e-marker reports current value \(bits), which is reserved by the USB-PD spec. Real e-marker chips should not emit reserved values."
+        case .reservedCableLatencyEncoding(let bits):
+            return "The cable's e-marker reports cable-latency value \(bits), which is reserved by the USB-PD spec for this cable type. Real e-marker chips should not emit reserved values."
         case .vidNotInUSBIFList(let vid):
             let hex = String(format: "0x%04X", vid)
             return "The cable's e-marker reports vendor \(hex), which isn't in our bundled USB-IF list. The number could be unassigned, copied, or assigned after the bundled list was generated. On its own this isn't proof of a problem, but on a clone cable it often appears alongside other inconsistencies."

--- a/Sources/WhatCableCore/PDIdentity.swift
+++ b/Sources/WhatCableCore/PDIdentity.swift
@@ -49,6 +49,14 @@ public struct PDIdentity: Identifiable, Hashable {
         return PDVDO.decodeIDHeader(v)
     }
 
+    /// The Cert Stat VDO is at index 1. Carries the USB-IF-issued XID,
+    /// or 0 for cables that haven't gone through certification.
+    public var certStatVDO: PDVDO.CertStat? {
+        guard endpoint == .sopPrime || endpoint == .sopDoublePrime,
+              vdos.count > 1 else { return nil }
+        return PDVDO.decodeCertStat(vdos[1])
+    }
+
     /// The Cable VDO is at index 3 (VDO[3] in 1-indexed PD spec terms).
     public var cableVDO: PDVDO.CableVDO? {
         guard endpoint == .sopPrime || endpoint == .sopDoublePrime,

--- a/Sources/WhatCableCore/PDVDO.swift
+++ b/Sources/WhatCableCore/PDVDO.swift
@@ -114,6 +114,11 @@ public enum PDVDO {
     public enum DecodeWarning: Hashable {
         case reservedSpeedEncoding(Int)
         case reservedCurrentEncoding(Int)
+        /// Cable latency field uses a reserved value. Bounds depend on
+        /// cable type: passive cables treat 0000 and 1001..1111 as
+        /// invalid; active cables treat 0000 and 1011..1111 as invalid
+        /// (1001 and 1010 carry valid optical-cable latencies).
+        case reservedCableLatencyEncoding(Int)
     }
 
     public struct CableVDO: Hashable {
@@ -125,6 +130,10 @@ public enum PDVDO {
         public let vbusThroughCable: Bool
         /// Encoded "Maximum VBUS Voltage" field. 0=20V, 1=30V, 2=40V, 3=50V.
         public let maxVoltageEncoded: Int
+        /// Raw 4-bit "Cable Latency" field (bits 16..13). 0000 and reserved
+        /// values per cable type are flagged via `decodeWarnings`. Use
+        /// `latencyNanoseconds` for a typed interpretation.
+        public let cableLatencyEncoded: Int
         public let decodeWarnings: [DecodeWarning]
 
         public var maxVolts: Int {
@@ -134,6 +143,27 @@ public enum PDVDO {
             case 2: return 40
             case 3: return 50
             default: return 20
+            }
+        }
+
+        /// Approximate one-way cable latency in nanoseconds, decoded from
+        /// `cableLatencyEncoded`. Returns `nil` for the reserved values
+        /// flagged in `decodeWarnings`. The 0001..1000 range maps roughly
+        /// 10 ns per cable metre. Active cables additionally carry 1001
+        /// (~1000 ns) and 1010 (~2000 ns) for optical lengths.
+        public var latencyNanoseconds: Int? {
+            switch cableLatencyEncoded {
+            case 0b0001: return 10
+            case 0b0010: return 20
+            case 0b0011: return 30
+            case 0b0100: return 40
+            case 0b0101: return 50
+            case 0b0110: return 60
+            case 0b0111: return 70
+            case 0b1000: return 80    // ">70 ns" per spec; treat as 80 for display purposes
+            case 0b1001 where cableType == .active: return 1000
+            case 0b1010 where cableType == .active: return 2000
+            default: return nil
             }
         }
     }
@@ -147,6 +177,7 @@ public enum PDVDO {
         let decodedCurrent = CableCurrent(rawValue: currentBits)
         let current = decodedCurrent ?? .usbDefault
         let maxV = Int((vdo >> 9) & 0b11)
+        let latencyBits = Int((vdo >> 13) & 0b1111)
         let cableType: CableType = isActive ? .active : .passive
         var warnings: [DecodeWarning] = []
         if decodedSpeed == nil {
@@ -154,6 +185,28 @@ public enum PDVDO {
         }
         if decodedCurrent == nil {
             warnings.append(.reservedCurrentEncoding(currentBits))
+        }
+        // The PD spec also flags `00` as Invalid for VBUS Current
+        // Handling (treat as 3 A), but real-world cables — including
+        // basic USB 2.0 charging cables — emit `00` as a "default"
+        // routinely. We intentionally don't warn on `00` because the
+        // false-positive rate would be high, and we lack calibration
+        // data showing it correlating with counterfeits. Revisit if
+        // future cable reports show otherwise.
+        // Cable Latency field. 0000 is "Invalid" for both cable types.
+        // Passive cables also treat 1001..1111 as Invalid. Active cables
+        // accept 1001 (~1000 ns optical) and 1010 (~2000 ns optical),
+        // and treat 1011..1111 as Invalid.
+        let latencyInvalid: Bool
+        if latencyBits == 0 {
+            latencyInvalid = true
+        } else if isActive {
+            latencyInvalid = latencyBits >= 0b1011
+        } else {
+            latencyInvalid = latencyBits >= 0b1001
+        }
+        if latencyInvalid {
+            warnings.append(.reservedCableLatencyEncoding(latencyBits))
         }
 
         let volts: Double
@@ -173,8 +226,26 @@ public enum PDVDO {
             cableType: cableType,
             vbusThroughCable: vbusThrough,
             maxVoltageEncoded: maxV,
+            cableLatencyEncoded: latencyBits,
             decodeWarnings: warnings
         )
+    }
+
+    // MARK: Cert Stat VDO (always VDO[1])
+
+    /// USB-IF certification identity. Issued before product certification;
+    /// `0` means the e-marker carries no certification ID. Common on
+    /// reputable but uncertified cables, so we surface it as a neutral
+    /// fact rather than a trust flag.
+    public struct CertStat: Hashable {
+        public let xid: UInt32
+
+        public var isPresent: Bool { xid != 0 }
+    }
+
+    public static func decodeCertStat(_ vdo: UInt32) -> CertStat {
+        // Spec table 6.38: bits 31..0 carry the XID.
+        return CertStat(xid: vdo)
     }
 
     // MARK: Helpers

--- a/Sources/WhatCableCore/VendorDB.swift
+++ b/Sources/WhatCableCore/VendorDB.swift
@@ -20,15 +20,24 @@ public enum VendorDB {
 
     public static func name(for vendorID: Int) -> String? {
         if let override = curatedOverrides[vendorID] { return override }
+        // 0xFFFF is the USB-PD spec-defined "no vendor ID assigned"
+        // sentinel (PID forced to 0). Surface that neutrally rather
+        // than letting it look unregistered.
+        if vendorID == 0xFFFF {
+            return "No vendor ID assigned (USB-PD spec sentinel)"
+        }
         return USBIFVendors.name(for: vendorID)
     }
 
     /// True if the VID is present in either the override map or the
     /// bundled USB-IF list. Distinct from `name(for:) != nil` only for
-    /// VID 0, which the bundled lookup hides for display purposes but
-    /// is still considered "registered" (USB-IF assigns 0 to itself).
+    /// VID 0 (which the bundled lookup hides for display purposes but
+    /// is still considered "registered" — USB-IF assigns 0 to itself)
+    /// and the spec sentinel `0xFFFF`, which we name but treat as not
+    /// a registered assignment.
     public static func isRegistered(_ vendorID: Int) -> Bool {
         if curatedOverrides[vendorID] != nil { return true }
+        if vendorID == 0xFFFF { return false }
         return USBIFVendors.isRegistered(vendorID)
     }
 

--- a/Tests/WhatCableCoreTests/CableReportTests.swift
+++ b/Tests/WhatCableCoreTests/CableReportTests.swift
@@ -12,8 +12,11 @@ final class CableReportTests: XCTestCase {
             (3 << 27) | UInt32(0x05AC),
             0,
             0,
-            // Cable VDO: USB4 Gen 3 (0b011), 5A (0b10), passive
-            (0b10 << 5) | 0b011
+            // Cable VDO: USB4 Gen 3 (0b011), 5A (0b10), passive,
+            // latency 0001 (~1 m). A bare-zero VDO would trip the
+            // reservedCableLatencyEncoding warning even though these
+            // tests aren't about trust signals.
+            (0b10 << 5) | 0b011 | (1 << 13)
         ]
     ) -> PDIdentity {
         PDIdentity(
@@ -132,6 +135,71 @@ final class CableReportTests: XCTestCase {
         XCTAssertFalse(md.contains("### Raw VDOs"))
     }
 
+    // MARK: - USB-IF certification ID (from Cert Stat VDO)
+
+    func testUSBIFCertIDPresentWhenNonZero() {
+        let id = PDIdentity(
+            id: 1,
+            endpoint: .sopPrime,
+            parentPortType: 0,
+            parentPortNumber: 0,
+            vendorID: 0x05AC,
+            productID: 0x1234,
+            bcdDevice: 0,
+            vdos: [
+                (3 << 27) | UInt32(0x05AC),
+                0x00012345,             // Cert Stat with XID
+                0,
+                (0b10 << 5) | 0b011 | (1 << 13)
+            ],
+            specRevision: 3
+        )
+        let payload = CableReport.payload(for: id)!
+        XCTAssertEqual(payload.cable.usbifCertID, 0x00012345)
+        let md = payload.markdown
+        XCTAssertTrue(md.contains("USB-IF certification ID"))
+        XCTAssertTrue(md.contains("0x00012345"))
+    }
+
+    func testUSBIFCertIDAbsentWhenZero() {
+        // Calibration: Anker #60 and Caldigit #62 both ship with XID = 0.
+        // We surface that as "none" rather than a trust signal.
+        let payload = CableReport.payload(for: cableIdentity())!
+        XCTAssertNil(payload.cable.usbifCertID)
+        let md = payload.markdown
+        XCTAssertTrue(md.contains("USB-IF certification ID"))
+        XCTAssertTrue(md.contains("none (XID = 0)"))
+    }
+
+    func testUSBIFCertIDDistinguishesAbsentVDOFromZeroValue() {
+        // Identity with only an ID Header VDO — macOS didn't surface a
+        // Cert Stat. The fingerprint should record that explicitly,
+        // not flatten it to "XID = 0", so calibration data stays
+        // faithful to what the cable actually reported.
+        let id = PDIdentity(
+            id: 1,
+            endpoint: .sopPrime,
+            parentPortType: 0,
+            parentPortNumber: 0,
+            vendorID: 0x05AC,
+            productID: 0,
+            bcdDevice: 0,
+            vdos: [
+                (3 << 27) | UInt32(0x05AC) // only ID Header, no Cert Stat
+            ],
+            specRevision: 3
+        )
+        let payload = CableReport.payload(for: id)!
+        XCTAssertNil(payload.cable.usbifCertID)
+        let md = payload.markdown
+        XCTAssertTrue(md.contains("USB-IF certification ID"))
+        XCTAssertTrue(md.contains("not provided by this Mac"))
+        XCTAssertFalse(
+            md.contains("none (XID = 0)"),
+            "Missing VDO[1] must not be rendered the same as a real zero XID"
+        )
+    }
+
     func testMarkdownLabelsExtraVDOsAsOther() {
         // PD response can include up to 7 VDOs (ID Header + Cert Stat +
         // Product + up to 4 Product Type VDOs). Anything past index 3 we
@@ -148,7 +216,7 @@ final class CableReportTests: XCTestCase {
                 (3 << 27) | UInt32(0x05AC),
                 0,
                 0,
-                (0b10 << 5) | 0b011,
+                (0b10 << 5) | 0b011 | (1 << 13), // valid 1m latency
                 0xDEADBEEF,
                 0xCAFEBABE
             ],

--- a/Tests/WhatCableCoreTests/CableTrustReportTests.swift
+++ b/Tests/WhatCableCoreTests/CableTrustReportTests.swift
@@ -3,11 +3,16 @@ import XCTest
 
 final class CableTrustReportTests: XCTestCase {
 
+    /// Valid cable-latency bits (0001 = ~10 ns, ~1 m). The decoder
+    /// flags 0000 as a reserved value, so test fixtures that aren't
+    /// specifically about latency need a real value.
+    private static let validLatency: UInt32 = 1 << 13
+
     /// Build a synthetic SOP' identity. `cableVDO` is the raw VDO[3].
     private func cableIdentity(
         vendorID: Int = 0x05AC,
         endpoint: PDIdentity.Endpoint = .sopPrime,
-        cableVDO: UInt32 = (0b10 << 5) | 0b011 // USB4 Gen 3, 5A
+        cableVDO: UInt32 = (0b10 << 5) | 0b011 | (1 << 13) // USB4 Gen 3, 5A, ~1m
     ) -> PDIdentity {
         PDIdentity(
             id: 1,
@@ -45,28 +50,86 @@ final class CableTrustReportTests: XCTestCase {
     }
 
     func testReservedSpeedEncodingFlags() {
-        // speed=5 (reserved), current=1 (3A)
-        let vdo = UInt32(0b101) | UInt32(1 << 5)
+        // speed=5 (reserved), current=1 (3A), valid latency
+        let vdo = UInt32(0b101) | UInt32(1 << 5) | Self.validLatency
         let report = CableTrustReport(identity: cableIdentity(cableVDO: vdo))
         XCTAssertEqual(report.flags, [.reservedSpeedEncoding(5)])
     }
 
     func testReservedCurrentEncodingFlags() {
-        // speed=1 (USB 3.2 Gen1), current=3 (reserved)
-        let vdo = UInt32(0b001) | UInt32(3 << 5)
+        // speed=1 (USB 3.2 Gen1), current=3 (reserved), valid latency
+        let vdo = UInt32(0b001) | UInt32(3 << 5) | Self.validLatency
         let report = CableTrustReport(identity: cableIdentity(cableVDO: vdo))
         XCTAssertEqual(report.flags, [.reservedCurrentEncoding(3)])
     }
 
     func testAllThreeFlagsTogether() {
-        // VID=0, speed=6 (reserved), current=3 (reserved)
-        let vdo = UInt32(0b110) | UInt32(3 << 5)
+        // VID=0, speed=6 (reserved), current=3 (reserved), valid latency
+        let vdo = UInt32(0b110) | UInt32(3 << 5) | Self.validLatency
         let report = CableTrustReport(identity: cableIdentity(vendorID: 0, cableVDO: vdo))
         XCTAssertEqual(report.flags, [
             .zeroVendorID,
             .reservedSpeedEncoding(6),
             .reservedCurrentEncoding(3)
         ])
+    }
+
+    // MARK: - Cable Latency
+
+    func testReservedCableLatencyFlags() {
+        // 0000 invalid for both cable types
+        let zeroLatency = UInt32(0b011) | UInt32(2 << 5) // no latency bits
+        let report = CableTrustReport(identity: cableIdentity(cableVDO: zeroLatency))
+        XCTAssertEqual(report.flags, [.reservedCableLatencyEncoding(0)])
+    }
+
+    func testActiveCableLatencyOpticalRangeIsValid() {
+        // Build an active-cable identity. ufpProductType bits 29..27 = 100 = 4 (active).
+        // Latency 1010 = ~2000 ns optical. Should not flag.
+        let activeIdentity = PDIdentity(
+            id: 1,
+            endpoint: .sopPrime,
+            parentPortType: 0,
+            parentPortNumber: 0,
+            vendorID: 0x05AC,
+            productID: 0,
+            bcdDevice: 0,
+            vdos: [
+                UInt32(4 << 27) | UInt32(0x05AC), // active cable ID header
+                0,
+                0,
+                UInt32(0b011) | UInt32(2 << 5) | (UInt32(0b1010) << 13) // ~2000 ns
+            ],
+            specRevision: 3
+        )
+        let report = CableTrustReport(identity: activeIdentity)
+        XCTAssertTrue(
+            report.isEmpty,
+            "Active cable with optical latency 1010 should not flag"
+        )
+    }
+
+    // MARK: - VID 0xFFFF sentinel (neutral metadata, not a flag)
+
+    func testVID_FFFF_DoesNotFireAnyFlag() {
+        // 0xFFFF is the spec-defined "vendor opted out of USB-IF
+        // registration" sentinel. It's allowed by the spec, so we treat
+        // it as neutral metadata (surfaced via the vendor-name path)
+        // rather than a warning-style trust flag.
+        let report = CableTrustReport(identity: cableIdentity(vendorID: 0xFFFF))
+        XCTAssertTrue(
+            report.isEmpty,
+            "0xFFFF must not surface as any TrustFlag (would render as a warning)"
+        )
+    }
+
+    func testVID_FFFF_RendersDescriptiveVendorName() {
+        // The neutral surface for 0xFFFF: vendorName describes it.
+        XCTAssertEqual(
+            VendorDB.name(for: 0xFFFF),
+            "No vendor ID assigned (USB-PD spec sentinel)"
+        )
+        XCTAssertFalse(VendorDB.isRegistered(0xFFFF))
     }
 
     // MARK: - H3: VID not in USB-IF list
@@ -109,7 +172,7 @@ final class CableTrustReportTests: XCTestCase {
 
     func testH3CombinesWithReservedEncodings() {
         // Unregistered VID + reserved speed bits = both flags.
-        let vdo = UInt32(0b111) | UInt32(2 << 5)
+        let vdo = UInt32(0b111) | UInt32(2 << 5) | Self.validLatency
         let report = CableTrustReport(identity: cableIdentity(vendorID: 0xDEAD, cableVDO: vdo))
         XCTAssertEqual(report.flags, [
             .vidNotInUSBIFList(0xDEAD),
@@ -124,6 +187,7 @@ final class CableTrustReportTests: XCTestCase {
         XCTAssertEqual(TrustFlag.zeroVendorID.code, "zeroVendorID")
         XCTAssertEqual(TrustFlag.reservedSpeedEncoding(5).code, "reservedSpeedEncoding")
         XCTAssertEqual(TrustFlag.reservedCurrentEncoding(3).code, "reservedCurrentEncoding")
+        XCTAssertEqual(TrustFlag.reservedCableLatencyEncoding(0).code, "reservedCableLatencyEncoding")
         XCTAssertEqual(TrustFlag.vidNotInUSBIFList(0xDEAD).code, "vidNotInUSBIFList")
     }
 

--- a/Tests/WhatCableCoreTests/ChargingDiagnosticTests.swift
+++ b/Tests/WhatCableCoreTests/ChargingDiagnosticTests.swift
@@ -64,11 +64,16 @@ final class ChargingDiagnosticTests: XCTestCase {
     /// Build a cable e-marker identity advertising the given watt rating.
     /// We pin watts via maxV/current bits: 5A @ 20V = 100W, 3A @ 20V = 60W.
     private func cableIdentity(watts: Int) -> PDIdentity {
+        // Latency = 0001 (~10 ns / ~1 m). Real cables emit a non-zero
+        // latency; using 0 here would make every fixture trip the
+        // reservedCableLatencyEncoding warning even though these tests
+        // care only about the wattage maths.
+        let validLatency: UInt32 = 1 << 13
         let cableVDO: UInt32 = {
             switch watts {
-            case 100: return 0b011 | (1 << 4) | (2 << 5)  // 5A passive
-            case 60:  return 0b000 | (1 << 5)             // 3A USB2
-            case 240: return 0b011 | (2 << 5) | (3 << 9)  // 5A @ 50V (EPR)
+            case 100: return 0b011 | (1 << 4) | (2 << 5) | validLatency  // 5A passive
+            case 60:  return 0b000 | (1 << 5)            | validLatency  // 3A USB2
+            case 240: return 0b011 | (2 << 5) | (3 << 9) | validLatency  // 5A @ 50V (EPR)
             default:  fatalError("unhandled fixture wattage \(watts)")
             }
         }()

--- a/Tests/WhatCableCoreTests/JSONFormatterTests.swift
+++ b/Tests/WhatCableCoreTests/JSONFormatterTests.swift
@@ -193,10 +193,13 @@ final class JSONFormatterTests: XCTestCase {
         )
     }
 
+    /// Valid cable-latency bits (0001 = ~10 ns / ~1 m).
+    private static let validLatency: UInt32 = 1 << 13
+
     func testTrustFlagsOmittedForCleanCable() throws {
         let port = makePort()
-        // VID 0x05AC (Apple), USB4 Gen3, 5A: no flags expected.
-        let id = cableIdentity(vendorID: 0x05AC, cableVDO: (0b10 << 5) | 0b011)
+        // VID 0x05AC (Apple), USB4 Gen3, 5A, valid latency: no flags expected.
+        let id = cableIdentity(vendorID: 0x05AC, cableVDO: (0b10 << 5) | 0b011 | Self.validLatency)
         let json = try JSONFormatter.render(
             ports: [port], sources: [], identities: [id], showRaw: false
         )
@@ -208,8 +211,8 @@ final class JSONFormatterTests: XCTestCase {
 
     func testTrustFlagsPopulatedForZeroVidAndReservedBits() throws {
         let port = makePort()
-        // VID=0, speed=6 (reserved), current=3 (reserved): all three flags.
-        let vdo = UInt32(0b110) | UInt32(3 << 5)
+        // VID=0, speed=6 (reserved), current=3 (reserved), valid latency: three flags.
+        let vdo = UInt32(0b110) | UInt32(3 << 5) | Self.validLatency
         let id = cableIdentity(vendorID: 0, cableVDO: vdo)
         let json = try JSONFormatter.render(
             ports: [port], sources: [], identities: [id], showRaw: false
@@ -233,7 +236,7 @@ final class JSONFormatterTests: XCTestCase {
     func testTrustFlagsEmitsH3ForUnregisteredVID() throws {
         let port = makePort()
         // 0xDEAD isn't in the curated map or the bundled USB-IF list.
-        let id = cableIdentity(vendorID: 0xDEAD, cableVDO: (0b10 << 5) | 0b011)
+        let id = cableIdentity(vendorID: 0xDEAD, cableVDO: (0b10 << 5) | 0b011 | Self.validLatency)
         let json = try JSONFormatter.render(
             ports: [port], sources: [], identities: [id], showRaw: false
         )

--- a/Tests/WhatCableCoreTests/PDVDOTests.swift
+++ b/Tests/WhatCableCoreTests/PDVDOTests.swift
@@ -38,9 +38,14 @@ final class PDVDOTests: XCTestCase {
     //
     // Layout (low bits): speed [2:0], _, vbus-through [4], current [6:5], _, maxV [10:9]
 
+    /// Valid cable-latency bits to OR into fixtures that don't care
+    /// about latency. 0001 = ~10 ns (~1 m), the most common real-world
+    /// value. Real cable reports we've collected use 0001 or 1000.
+    private static let validLatency: UInt32 = 1 << 13
+
     func testThunderboltCable_5A_40Gbps() {
         // speed=3 (USB4 Gen3), current=2 (5A) -> 2<<5=0x40, vbus-through bit 4=1
-        let vdo: UInt32 = 0b011 | (1 << 4) | (2 << 5)
+        let vdo: UInt32 = 0b011 | (1 << 4) | (2 << 5) | Self.validLatency
         let cable = PDVDO.decodeCableVDO(vdo, isActive: false)
         XCTAssertEqual(cable.speed, .usb4Gen3)
         XCTAssertEqual(cable.current, .fiveAmp)
@@ -54,7 +59,7 @@ final class PDVDOTests: XCTestCase {
 
     func testCheap_USB2_3A() {
         // speed=0 (USB 2.0), current=1 (3A) -> 1<<5=0x20
-        let vdo: UInt32 = 0b000 | (1 << 5)
+        let vdo: UInt32 = 0b000 | (1 << 5) | Self.validLatency
         let cable = PDVDO.decodeCableVDO(vdo, isActive: false)
         XCTAssertEqual(cable.speed, .usb20)
         XCTAssertEqual(cable.current, .threeAmp)
@@ -64,7 +69,7 @@ final class PDVDOTests: XCTestCase {
 
     func testEPRCable_50V_5A() {
         // speed=4 (USB4 Gen4 / 80 Gbps), current=2 (5A), maxV=3 (50V)
-        let vdo: UInt32 = 0b100 | (2 << 5) | (3 << 9)
+        let vdo: UInt32 = 0b100 | (2 << 5) | (3 << 9) | Self.validLatency
         let cable = PDVDO.decodeCableVDO(vdo, isActive: false)
         XCTAssertEqual(cable.speed, .usb4Gen4)
         XCTAssertEqual(cable.current, .fiveAmp)
@@ -75,7 +80,7 @@ final class PDVDOTests: XCTestCase {
     }
 
     func testActiveCableType() {
-        let vdo: UInt32 = 0
+        let vdo: UInt32 = Self.validLatency
         let cable = PDVDO.decodeCableVDO(vdo, isActive: true)
         XCTAssertEqual(cable.cableType, .active)
         XCTAssertTrue(cable.decodeWarnings.isEmpty)
@@ -83,7 +88,7 @@ final class PDVDOTests: XCTestCase {
 
     func testReservedSpeedEncodingFallsBackAndWarns() {
         for speedBits in 5...7 {
-            let vdo = UInt32(speedBits) | UInt32(1 << 5)
+            let vdo = UInt32(speedBits) | UInt32(1 << 5) | Self.validLatency
             let cable = PDVDO.decodeCableVDO(vdo, isActive: false)
             XCTAssertEqual(cable.speed, .usb20)
             XCTAssertEqual(cable.current, .threeAmp)
@@ -92,7 +97,7 @@ final class PDVDOTests: XCTestCase {
     }
 
     func testReservedCurrentEncodingFallsBackAndWarns() {
-        let vdo: UInt32 = 0b001 | UInt32(3 << 5)
+        let vdo: UInt32 = 0b001 | UInt32(3 << 5) | Self.validLatency
         let cable = PDVDO.decodeCableVDO(vdo, isActive: false)
         XCTAssertEqual(cable.speed, .usb32Gen1)
         XCTAssertEqual(cable.current, .usbDefault)
@@ -100,7 +105,7 @@ final class PDVDOTests: XCTestCase {
     }
 
     func testReservedSpeedAndCurrentEncodingsBothWarn() {
-        let vdo: UInt32 = 0b101 | UInt32(3 << 5)
+        let vdo: UInt32 = 0b101 | UInt32(3 << 5) | Self.validLatency
         let cable = PDVDO.decodeCableVDO(vdo, isActive: false)
         XCTAssertEqual(cable.speed, .usb20)
         XCTAssertEqual(cable.current, .usbDefault)
@@ -108,6 +113,96 @@ final class PDVDOTests: XCTestCase {
             cable.decodeWarnings,
             [.reservedSpeedEncoding(5), .reservedCurrentEncoding(3)]
         )
+    }
+
+    // MARK: - Cable Latency
+
+    func testValidPassiveCableLatencyDoesNotWarn() {
+        for latencyBits in 1...8 {
+            let vdo = UInt32(0b011) | UInt32(2 << 5) | (UInt32(latencyBits) << 13)
+            let cable = PDVDO.decodeCableVDO(vdo, isActive: false)
+            XCTAssertTrue(
+                cable.decodeWarnings.isEmpty,
+                "Latency \(latencyBits) should be valid for passive cables"
+            )
+            XCTAssertEqual(cable.cableLatencyEncoded, latencyBits)
+        }
+    }
+
+    func testInvalidPassiveCableLatencyWarns() {
+        // 0000 invalid
+        let zero = UInt32(0b011) | UInt32(2 << 5)
+        let zeroCable = PDVDO.decodeCableVDO(zero, isActive: false)
+        XCTAssertEqual(zeroCable.decodeWarnings, [.reservedCableLatencyEncoding(0)])
+
+        // 1001..1111 invalid for passive
+        for latencyBits in 9...15 {
+            let vdo = UInt32(0b011) | UInt32(2 << 5) | (UInt32(latencyBits) << 13)
+            let cable = PDVDO.decodeCableVDO(vdo, isActive: false)
+            XCTAssertEqual(
+                cable.decodeWarnings,
+                [.reservedCableLatencyEncoding(latencyBits)],
+                "Latency \(latencyBits) should be invalid for passive"
+            )
+        }
+    }
+
+    func testActiveCableLatencyAccepts1001And1010() {
+        // Active cables carry optical-length latencies 1001 (~1000 ns)
+        // and 1010 (~2000 ns) that passive cables would treat as invalid.
+        for latencyBits in [9, 10] {
+            let vdo = UInt32(0b011) | UInt32(2 << 5) | (UInt32(latencyBits) << 13)
+            let cable = PDVDO.decodeCableVDO(vdo, isActive: true)
+            XCTAssertTrue(
+                cable.decodeWarnings.isEmpty,
+                "Latency \(latencyBits) should be valid for active cables"
+            )
+        }
+    }
+
+    func testActiveCableLatency_1011AndUpInvalid() {
+        for latencyBits in 11...15 {
+            let vdo = UInt32(0b011) | UInt32(2 << 5) | (UInt32(latencyBits) << 13)
+            let cable = PDVDO.decodeCableVDO(vdo, isActive: true)
+            XCTAssertEqual(
+                cable.decodeWarnings,
+                [.reservedCableLatencyEncoding(latencyBits)],
+                "Latency \(latencyBits) should be invalid even for active cables"
+            )
+        }
+    }
+
+    func testLatencyNanosecondsLookup() {
+        // Passive: 0001..1000 -> 10..80 ns
+        for (bits, ns) in [(1, 10), (4, 40), (8, 80)] {
+            let vdo = UInt32(0b011) | UInt32(2 << 5) | (UInt32(bits) << 13)
+            let cable = PDVDO.decodeCableVDO(vdo, isActive: false)
+            XCTAssertEqual(cable.latencyNanoseconds, ns)
+        }
+        // Active 1001 -> 1000 ns, 1010 -> 2000 ns
+        for (bits, ns) in [(9, 1000), (10, 2000)] {
+            let vdo = UInt32(0b011) | UInt32(2 << 5) | (UInt32(bits) << 13)
+            let cable = PDVDO.decodeCableVDO(vdo, isActive: true)
+            XCTAssertEqual(cable.latencyNanoseconds, ns)
+        }
+        // Invalid passive 1001 -> nil
+        let invalidPassive = UInt32(0b011) | UInt32(2 << 5) | (UInt32(9) << 13)
+        let cable = PDVDO.decodeCableVDO(invalidPassive, isActive: false)
+        XCTAssertNil(cable.latencyNanoseconds)
+    }
+
+    // MARK: - Cert Stat VDO
+
+    func testCertStatPresentWhenNonZero() {
+        let stat = PDVDO.decodeCertStat(0x12345)
+        XCTAssertEqual(stat.xid, 0x12345)
+        XCTAssertTrue(stat.isPresent)
+    }
+
+    func testCertStatMissingWhenZero() {
+        let stat = PDVDO.decodeCertStat(0)
+        XCTAssertEqual(stat.xid, 0)
+        XCTAssertFalse(stat.isPresent)
     }
 
     // MARK: - VDO from Data


### PR DESCRIPTION
## Summary

- New `reservedCableLatencyEncoding` trust flag, with cable-type-aware bounds (passive: 0000 / 1001..1111; active: 0000 / 1011..1111).
- Cable reports now include a USB-IF certification ID row sourced from the Cert Stat VDO (`vdos[1]`). Three distinct states so cable-report fingerprints stay faithful: hex XID, `"none (XID = 0)"`, or `"not provided by this Mac"`.
- VID `0xFFFF` is no longer surfaced as a trust flag. The PD spec defines it as the legitimate "vendor opted out of USB-IF registration" sentinel, so flagging it as a warning would be misleading. `VendorDB.name(for:)` now returns a descriptive label and the existing vendor-name path renders it neutrally.

## Notes

- VBUS Current `00b` is intentionally NOT flagged in this PR. Spec lists it as Invalid, but real USB 2.0 cables emit it routinely and we lack calibration data on the false-positive rate. There is a comment in `decodeCableVDO` recording the decision.
- Calibration: both real cable reports with raw VDO data (#60 Anker 333, #62 Caldigit Thunderbolt) have valid latency = `0001` (~1 m). No false positives from this flag in the calibration set.
- Both reports also have `XID = 0`, which is why XID is neutral display rather than a flag , too noisy as a warning when reputable brands hit it.

## Test plan

- [x] `swift build` clean
- [x] `swift test` 216/216 passing
- [x] New tests cover: passive vs active latency bounds, optical 1001/1010 active-only, `latencyNanoseconds` lookup, Cert Stat present/missing/zero, `0xFFFF` no-flag and descriptive vendor name
- [x] JSON `trustFlags` no longer emits anything for `0xFFFF`
- [x] Codex review pass , no correctness issues identified
- [ ] Smoke-test the GUI in `dist/WhatCable.app` after merge / before tagging

🤖 Generated with [Claude Code](https://claude.com/claude-code)
