### PR TITLE
Refresh README for v0.8.3: trust signals, USB-IF list, PD spec rev

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Per port, in plain English:
   - *"Charging at 30W (charger can do up to 96W)"* (Mac is asking for less, e.g. battery near full)
   - *"Charging well at 96W"* (everything matches)
 - **Cable e-marker info:** the cable's actual speed (USB 2.0, 5 / 10 / 20 / 40 / 80 Gbps), current rating (3 A / 5 A up to 60W / 100W / 240W), and the chip's vendor
+- **Cable trust signals:** an orange card appears when the e-marker reports values that look unusual against the USB-PD spec, like a zero vendor ID, a reserved bit pattern in the speed / current / cable-latency fields, or a VID that isn't in USB-IF's published list. Wording is hedged on purpose: a flag means "this looks unusual," not "this cable is fake."
 - **Charger PDO list:** every voltage profile the charger advertises (5V / 9V / 12V / 15V / 20V…) with the currently negotiated profile highlighted in real time
 - **Connected device identity:** vendor name and product type, decoded from the PD Discover Identity response
 - **Attached USB devices:** storage, hubs, and peripherals listed under the physical port they're plugged into, with their negotiated speed
@@ -93,7 +94,7 @@ WhatCable reads four families of IOKit services. No entitlements, no private API
 | `IOPortTransportComponentCCUSBPDSOP`, `...SOPp`, `...SOPpp` | PD Discover Identity VDOs from the port partner (SOP), the cable's near-end e-marker (SOP'), and the far-end e-marker (SOP'') if present |
 | XHCI controller subtree | Each connected USB device is paired to its physical port via the XHCI port node's `UsbIOPort` registry path, falling back to a bus-index derived from the controller's `locationID` upper byte and the port's `hpm` SPMI ancestor on machines that don't expose `UsbIOPort`. |
 
-Cable speed and power decoding follow the USB Power Delivery 3.x spec.
+Cable speed and power decoding follow the USB Power Delivery spec (aligned to USB-PD R3.2 V1.2, March 2026). Vendor names come from USB-IF's published vendor-ID list, bundled as a TSV refreshed by `scripts/update-vendor-db.sh`.
 
 ## Build from source
 
@@ -155,9 +156,9 @@ cp .env.example .env
 
 - **Cable e-marker info only appears for cables that carry one.** Most USB-C cables under 60 W are unmarked. Any Thunderbolt / USB4 cable, any 5 A / 100 W+ cable, and most quality data cables will be e-marked.
 - **Some cables only reveal their e-marker once something is plugged in at the other end.** The chip in the cable's plug runs off VCONN (a small power rail your Mac feeds into the cable) and only answers when the host issues a "Discover Identity" message. With nothing attached, some Macs read the e-marker straight away, others wait until they see a real partner to negotiate with. If a cable shows up as basic when bare, plug a charger, dock, or device into the far end and check again.
-- **WhatCable trusts the e-marker.** The cable speed, current rating, and vendor are read straight from the chip in the cable's plug. Counterfeit or mis-flashed cables can advertise capabilities they don't actually deliver, and there's no way for software to verify what's inside the jacket. If a cable claims 240W / 40 Gbps but performs poorly, the chip is lying, not WhatCable.
-- **PD spec coverage:** the decoder targets PD 3.0 / 3.1. PD 3.2 EPR variants may need tweaks once we see real data.
-- **Vendor name lookup is bundled but not exhaustive:** common cable, charger, hub, dock, and storage vendors are recognised; others fall back to the hex VID.
+- **WhatCable trusts the e-marker for capabilities.** Cable speed, current rating, and vendor come straight from the chip in the cable's plug, and software cannot verify what's inside the jacket. If a cable claims 240W / 40 Gbps but performs poorly, the chip is lying, not WhatCable. The trust-signals card flags a small set of internal-consistency tells (zero VID, reserved bit patterns in the Cable VDO, a VID not in the USB-IF list) that often appear on counterfeit or mis-flashed cables, but those flags are hedged signals, not proof.
+- **PD spec coverage:** the decoder is aligned to USB-PD R3.2 V1.2 (March 2026). Earlier 3.0 / 3.1 cables work fine.
+- **Vendor name lookup uses USB-IF's published list** (~13,650 entries, March 2026 snapshot). VIDs assigned by USB-IF after that snapshot will show as "Unregistered / unknown" and trip a trust-signal flag until the bundled list is refreshed.
 - **macOS only.** iOS sandboxing makes USB-C e-marker access much harder.
 - **Apple Silicon only.** Intel Macs route USB-C through Intel Thunderbolt 3 controllers (Titan Ridge / JHL9580). Apple's IOKit driver for those chips does not expose the USB-PD negotiation state or the cable e-marker VDOs, so there's no path to surface the same information on Intel hardware.
 - **Not on the App Store.** App Sandbox blocks the IOKit reads we depend on.


### PR DESCRIPTION
## Summary

Bringing the README in line with v0.8.3:

- New **Cable trust signals** bullet under "What it shows" so the feature is discoverable from the README.
- Replaces the now-stale "Vendor name lookup is bundled but not exhaustive" caveat with the current truth: the full USB-IF March 2026 list (~13,650 entries) is bundled, and post-snapshot VIDs trip the `vidNotInUSBIFList` flag rather than failing silently.
- Softens the **WhatCable trusts the e-marker** caveat to mention the trust-signals card as a hedged secondary defence, without retreating from the "we trust it for capabilities" stance.
- Updates the PD spec coverage line from "PD 3.x" to USB-PD R3.2 V1.2 (March 2026).

## Notes

- The **App Sandbox** caveat is intentionally untouched per `CLAUDE.md`. The line is wrong (the sandbox doesn't actually block our IOKit reads), but it stays until the App Store version actually ships.
- The CLI's text output (without `--json`) does not yet surface trust flags. Tracked separately as a follow-up.

## Test plan

- [x] No code changes; README only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
