### PR TITLE
Add Mac App Store build path (Phase 1: code scaffolding)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,3 +28,25 @@ NOTARY_PROFILE="WhatCable-notary"
 # Set to 1 (with CASK_VERIFY_REMOTE=1) to treat a missing release asset as
 # fatal rather than a warning.
 # CASK_VERIFY_STRICT="0"
+
+# --- Mac App Store build (optional, used by scripts/build-app-mas.sh
+#     and scripts/release-mas.sh) ---
+# Independent of the OSS Developer ID flow above. Both pipelines can
+# coexist on the same machine.
+
+# App Store signing identity, exactly as shown by:
+#   security find-identity -v -p codesigning | grep "3rd Party Mac Developer Application"
+# MAS_APP_IDENTITY="3rd Party Mac Developer Application: Your Name (TEAMID)"
+
+# App Store installer signing identity, exactly as shown by:
+#   security find-identity -v | grep "3rd Party Mac Developer Installer"
+# MAS_INSTALLER_IDENTITY="3rd Party Mac Developer Installer: Your Name (TEAMID)"
+
+# Absolute path to the Mac App Store provisioning profile downloaded
+# from developer.apple.com (e.g. secrets/WhatCable_MAS.provisionprofile).
+# MAS_PROVISIONING_PROFILE="$PWD/secrets/WhatCable_MAS.provisionprofile"
+
+# App Store Connect upload credentials (used by release-mas.sh only).
+# Generate the app-specific password at appleid.apple.com.
+# MAS_APPLE_ID="you@example.com"
+# MAS_APP_PASSWORD="xxxx-xxxx-xxxx-xxxx"

--- a/.gitignore
+++ b/.gitignore
@@ -3,10 +3,14 @@
 DerivedData/
 build/
 dist/
+dist-mas/
 *.xcodeproj
 .DS_Store
 .env
 .claude/
+
+# App Store provisioning profile and any other local-only signing material.
+secrets/
 
 # Local planning / design / scratch docs (kept uncommitted by convention)
 planning/

--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,18 @@
 // swift-tools-version: 5.9
 import PackageDescription
+import Foundation
+
+// Mac App Store build flag. When `WHATCABLE_MAS=1` is in the environment at
+// build time, the WhatCable executable target is compiled with the
+// `WHATCABLE_MAS` Swift define. That gates out the self-hosted update path
+// (App Review forbids self-updaters) so the same source tree produces both
+// the OSS GitHub/Homebrew build and the App Store build.
+//
+// The flag is intentionally only consulted by Package.swift (and a small
+// set of source files marked in CLAUDE.md). If you find yourself wanting
+// to read it elsewhere, reread the discipline rule first.
+let isMASBuild = ProcessInfo.processInfo.environment["WHATCABLE_MAS"] == "1"
+let appSwiftSettings: [SwiftSetting] = isMASBuild ? [.define("WHATCABLE_MAS")] : []
 
 let package = Package(
     name: "WhatCable",
@@ -26,7 +39,8 @@ let package = Package(
         .executableTarget(
             name: "WhatCable",
             dependencies: ["WhatCableCore", "WhatCableDarwinBackend"],
-            path: "Sources/WhatCable"
+            path: "Sources/WhatCable",
+            swiftSettings: appSwiftSettings
         ),
         .executableTarget(
             name: "WhatCableCLI",

--- a/Sources/WhatCable/App.swift
+++ b/Sources/WhatCable/App.swift
@@ -17,11 +17,13 @@ struct WhatCableApp: App {
                         delegate.showAboutPanel()
                     }
                 }
+                #if !WHATCABLE_MAS
                 CommandGroup(after: .appInfo) {
                     Button("Check for Updates…") {
                         UpdateChecker.shared.check(silent: false)
                     }
                 }
+                #endif
                 CommandGroup(replacing: .help) {
                     Button("WhatCable on GitHub") {
                         NSWorkspace.shared.open(AppInfo.helpURL)
@@ -57,7 +59,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate, NSW
         ProcessInfo.processInfo.setValue(AppInfo.name, forKey: "processName")
 
         NotificationManager.shared.start()
+        #if !WHATCABLE_MAS
         UpdateChecker.shared.start()
+        #endif
 
         applyDisplayMode(menuBar: AppSettings.shared.useMenuBarMode)
 
@@ -188,7 +192,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate, NSW
         menu.addItem(pinItem)
         menu.addItem(.separator())
         menu.addItem(.init(title: "Settings…", action: #selector(menuSettings), keyEquivalent: ","))
+        #if !WHATCABLE_MAS
         menu.addItem(.init(title: "Check for Updates…", action: #selector(menuCheckUpdates), keyEquivalent: ""))
+        #endif
         menu.addItem(.separator())
         menu.addItem(.init(title: "About \(AppInfo.name)", action: #selector(showAboutPanel), keyEquivalent: ""))
         menu.addItem(.init(title: "WhatCable on GitHub", action: #selector(menuHelp), keyEquivalent: ""))
@@ -252,9 +258,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate, NSW
         ])
     }
 
+    #if !WHATCABLE_MAS
     @objc private func menuCheckUpdates() {
         UpdateChecker.shared.check(silent: false)
     }
+    #endif
 
     @objc private func menuHelp() {
         NSWorkspace.shared.open(AppInfo.helpURL)

--- a/Sources/WhatCable/ContentView.swift
+++ b/Sources/WhatCable/ContentView.swift
@@ -75,7 +75,9 @@ struct ContentView: View {
     @StateObject private var tbWatcher = ThunderboltWatcher()
     @EnvironmentObject private var refresh: RefreshSignal
     @ObservedObject private var settings = AppSettings.shared
+    #if !WHATCABLE_MAS
     @ObservedObject private var updates = UpdateChecker.shared
+    #endif
     @State private var portRefreshTask: Task<Void, Never>?
     @State private var portPollTask: Task<Void, Never>?
 
@@ -164,9 +166,11 @@ struct ContentView: View {
     private var mainContent: some View {
         VStack(spacing: 0) {
             header
+            #if !WHATCABLE_MAS
             if let update = updates.available {
                 UpdateBanner(update: update)
             }
+            #endif
             Divider()
             let visiblePorts = settings.hideEmptyPorts
                 ? portWatcher.ports.filter { isPortLive($0) }
@@ -323,6 +327,7 @@ struct ContentView: View {
     }
 }
 
+#if !WHATCABLE_MAS
 struct UpdateBanner: View {
     let update: AvailableUpdate
     @ObservedObject private var installer = Installer.shared
@@ -385,6 +390,7 @@ struct UpdateBanner: View {
         }
     }
 }
+#endif // !WHATCABLE_MAS
 
 // MARK: - Port card
 

--- a/Sources/WhatCable/Installer.swift
+++ b/Sources/WhatCable/Installer.swift
@@ -1,3 +1,8 @@
+// In-process installer for the OSS self-update path. Compiled out of
+// the Mac App Store build (`WHATCABLE_MAS`) since the App Store handles
+// install/upgrade itself and `AvailableUpdate` (declared in
+// `UpdateChecker.swift`) is also gated out.
+#if !WHATCABLE_MAS
 import Foundation
 import AppKit
 import os.log
@@ -202,4 +207,6 @@ private struct InstallError: LocalizedError {
     let errorDescription: String?
     init(_ message: String) { self.errorDescription = message }
 }
+
+#endif // !WHATCABLE_MAS
 

--- a/Sources/WhatCable/UpdateChecker.swift
+++ b/Sources/WhatCable/UpdateChecker.swift
@@ -1,3 +1,7 @@
+// Self-hosted update checker for the OSS build. Compiled out of the
+// Mac App Store build (`WHATCABLE_MAS`) because App Review rejects apps
+// that ship their own updater — the App Store handles updates itself.
+#if !WHATCABLE_MAS
 import Foundation
 import AppKit
 import UserNotifications
@@ -178,4 +182,6 @@ final class UpdateChecker: ObservableObject {
         return trusted.contains(host)
     }
 }
+
+#endif // !WHATCABLE_MAS
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -711,7 +711,11 @@ brew install --cask whatcable</pre>
     <footer>
       <div class="wrap">
         <span>Built by <a href="https://github.com/darrylmorley">Darryl Morley</a>. MIT licensed.</span>
-        <a href="https://github.com/darrylmorley/whatcable">View source on GitHub</a>
+        <span>
+          <a href="/privacy">Privacy</a>
+          &nbsp;·&nbsp;
+          <a href="https://github.com/darrylmorley/whatcable">View source on GitHub</a>
+        </span>
       </div>
     </footer>
   </body>

--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -1,0 +1,177 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>WhatCable: Privacy Policy</title>
+    <meta
+      name="description"
+      content="Privacy policy for WhatCable, the macOS menu bar app for USB-C cable diagnostics."
+    >
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+    <style>
+      :root {
+        color-scheme: light;
+        --ink: #0e1620;
+        --ink-soft: #364152;
+        --muted: #6a7585;
+        --line: #e3e8ef;
+        --bg: #fafbfc;
+        --panel: #ffffff;
+        --accent: #0c8ca6;
+      }
+
+      * { box-sizing: border-box; }
+      html { scroll-behavior: smooth; }
+      body {
+        margin: 0;
+        background: var(--bg);
+        color: var(--ink);
+        font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        font-size: 16px;
+        line-height: 1.6;
+        -webkit-font-smoothing: antialiased;
+      }
+      a { color: var(--accent); text-decoration: none; }
+      a:hover { text-decoration: underline; }
+
+      .wrap {
+        width: min(720px, calc(100% - 40px));
+        margin: 0 auto;
+      }
+
+      .nav {
+        border-bottom: 1px solid var(--line);
+        background: var(--panel);
+      }
+      .nav-inner {
+        height: 64px;
+        display: flex;
+        align-items: center;
+        gap: 16px;
+      }
+      .brand {
+        font-weight: 700;
+        font-size: 17px;
+        color: var(--ink);
+      }
+      .brand a { color: inherit; }
+
+      main {
+        padding: 48px 0 80px;
+      }
+      h1 {
+        font-size: 32px;
+        font-weight: 800;
+        letter-spacing: -0.01em;
+        margin: 0 0 8px;
+      }
+      .subtitle {
+        color: var(--muted);
+        font-size: 14px;
+        margin: 0 0 32px;
+      }
+      h2 {
+        font-size: 20px;
+        font-weight: 700;
+        margin: 32px 0 12px;
+      }
+      p {
+        margin: 0 0 14px;
+        color: var(--ink-soft);
+      }
+      ul {
+        margin: 0 0 14px;
+        padding-left: 20px;
+        color: var(--ink-soft);
+      }
+      li { margin-bottom: 6px; }
+
+      footer {
+        border-top: 1px solid var(--line);
+        padding: 24px 0;
+        color: var(--muted);
+        font-size: 13px;
+      }
+    </style>
+  </head>
+  <body>
+    <header class="nav">
+      <div class="wrap nav-inner">
+        <span class="brand"><a href="/">WhatCable</a></span>
+      </div>
+    </header>
+
+    <main>
+      <div class="wrap">
+        <h1>Privacy Policy</h1>
+        <p class="subtitle">Last updated: 2026-05-07</p>
+
+        <p>
+          WhatCable is a small macOS menu bar app that tells you what each USB-C
+          cable plugged into your Mac can actually do. This page explains what
+          data the app handles.
+        </p>
+
+        <h2>What WhatCable reads</h2>
+        <p>
+          WhatCable reads USB-C port state, USB-PD Discover Identity messages,
+          power source data, and Thunderbolt switch information from your Mac
+          through Apple's IOKit framework. All of this stays on your Mac. It is
+          used only to render the popover you see in the menu bar.
+        </p>
+
+        <h2>What WhatCable sends</h2>
+        <p>
+          The Mac App Store version of WhatCable does not make any network calls
+          of its own. App Store updates are handled by macOS.
+        </p>
+        <p>
+          The free GitHub / Homebrew version of WhatCable checks the public
+          GitHub Releases API once every six hours to see if a newer version is
+          available. That request includes a <code>User-Agent</code> header
+          naming the app and your installed version (for example,
+          <code>WhatCable/0.8.4</code>). It does not include any personal
+          information, and no analytics, telemetry, or identifiers are sent.
+        </p>
+        <p>
+          If you click "Report this cable", WhatCable opens GitHub in your
+          default browser with the cable's public e-marker fields pre-filled in
+          a new issue. You review the contents and decide whether to submit it.
+          Nothing is sent automatically.
+        </p>
+
+        <h2>What WhatCable stores</h2>
+        <p>
+          WhatCable stores your in-app preferences (display mode, hidden ports,
+          notification toggles, font size) in the standard macOS user defaults
+          system, on your Mac. Nothing else is stored.
+        </p>
+
+        <h2>What WhatCable does not do</h2>
+        <p>WhatCable does not collect, store, or transmit:</p>
+        <ul>
+          <li>Personal information (name, email, address, phone number).</li>
+          <li>Account or device identifiers.</li>
+          <li>Browsing or app usage analytics.</li>
+          <li>Information about other apps or files on your Mac.</li>
+          <li>Anything about devices connected to ports WhatCable does not need to read.</li>
+        </ul>
+
+        <h2>Contact</h2>
+        <p>
+          Bug reports and questions go through the public GitHub repository at
+          <a href="https://github.com/darrylmorley/whatcable">github.com/darrylmorley/whatcable</a>.
+        </p>
+      </div>
+    </main>
+
+    <footer>
+      <div class="wrap">
+        &copy; 2026 Darryl Morley. WhatCable is open source.
+      </div>
+    </footer>
+  </body>
+</html>

--- a/scripts/WhatCable.MAS.entitlements
+++ b/scripts/WhatCable.MAS.entitlements
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  Mac App Store entitlements for WhatCable.
+
+  Intentionally minimal:
+    - app-sandbox: required for the App Store.
+    - No com.apple.security.device.usb. The IOKit registry reads WhatCable
+      uses (USB-C port state, power sources, USB-PD Discover Identity,
+      Thunderbolt switch tree) all work under the sandbox alone. Adding
+      the USB device entitlement would only signal scope to App Review
+      that the app does not exercise.
+    - No com.apple.security.network.client. The MAS build has the OSS
+      UpdateChecker compiled out and "Report this cable" opens GitHub in
+      the user's browser via NSWorkspace.open; the build makes no
+      network calls of its own.
+
+  If a future feature actually needs an entitlement (widget extension,
+  in-app network call, etc.) add it then. Don't pre-grant.
+-->
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.app-sandbox</key>
+    <true/>
+</dict>
+</plist>

--- a/scripts/build-app-mas.sh
+++ b/scripts/build-app-mas.sh
@@ -1,0 +1,210 @@
+#!/usr/bin/env bash
+# Build, sign, and package WhatCable.app for the Mac App Store.
+#
+# This is the App Store sibling of scripts/smoke-test.sh. The OSS pipeline
+# stays the canonical path for the GitHub + Homebrew release. This script
+# never touches the OSS build, the Homebrew tap, or notarisation.
+#
+# What it does, in order:
+#   1. Builds release binaries with the WHATCABLE_MAS Swift define.
+#   2. Assembles dist-mas/WhatCable.app (same layout as smoke-test.sh).
+#   3. Embeds the Mac App Store provisioning profile inside the bundle.
+#   4. Signs the inner CLI + outer app with the App Store identities and
+#      the sandbox-only entitlements file.
+#   5. Productbuilds a signed .pkg ready to upload via Transporter or
+#      `xcrun altool --upload-app`.
+#
+# What it does NOT do:
+#   - Notarisation. App Store submissions go through App Review, which
+#     is a separate pipeline.
+#   - Tag, commit, or push anything. release-mas.sh handles submission;
+#     this script only produces the artefact.
+#
+# Prerequisites (script fails fast if any are missing):
+#   - 3rd Party Mac Developer Application: <Team Name> (<TEAM_ID>) in keychain.
+#   - 3rd Party Mac Developer Installer:   <Team Name> (<TEAM_ID>) in keychain.
+#   - Mac App Store provisioning profile for uk.whatcable.whatcable at
+#     the path given by MAS_PROVISIONING_PROFILE.
+#   - .env (or environment) provides:
+#       MAS_APP_IDENTITY     "3rd Party Mac Developer Application: ..."
+#       MAS_INSTALLER_IDENTITY "3rd Party Mac Developer Installer: ..."
+#       MAS_PROVISIONING_PROFILE  /path/to/WhatCable_MAS.provisionprofile
+#
+# Version constants are read from scripts/smoke-test.sh so OSS and MAS
+# builds always ship the same version + build number per release.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+# Load .env if present
+if [[ -f ".env" ]]; then
+    # shellcheck disable=SC1091
+    set -a; source .env; set +a
+fi
+
+APP_NAME="WhatCable"
+BUNDLE_ID="uk.whatcable.whatcable"
+MIN_OS="14.0"
+CLI_PRODUCT="whatcable-cli"
+CLI_BIN_NAME="whatcable"
+
+# Pull VERSION + BUILD_NUMBER from the OSS smoke-test.sh so both pipelines
+# stay anchored to the same release. release.sh patches those constants
+# during a release; release-mas.sh re-reads them here.
+VERSION=$(grep -E '^VERSION=' scripts/smoke-test.sh | head -1 | sed -E 's/VERSION="(.*)"/\1/')
+BUILD_NUMBER=$(grep -E '^BUILD_NUMBER=' scripts/smoke-test.sh | head -1 | sed -E 's/BUILD_NUMBER="(.*)"/\1/')
+
+if [[ -z "${VERSION}" || -z "${BUILD_NUMBER}" ]]; then
+    echo "ERROR: failed to read VERSION/BUILD_NUMBER from scripts/smoke-test.sh" >&2
+    exit 1
+fi
+
+# Required env. Documented at top of script.
+: "${MAS_APP_IDENTITY:?MAS_APP_IDENTITY not set (3rd Party Mac Developer Application: ...)}"
+: "${MAS_INSTALLER_IDENTITY:?MAS_INSTALLER_IDENTITY not set (3rd Party Mac Developer Installer: ...)}"
+: "${MAS_PROVISIONING_PROFILE:?MAS_PROVISIONING_PROFILE not set (path to .provisionprofile)}"
+
+if [[ ! -f "${MAS_PROVISIONING_PROFILE}" ]]; then
+    echo "ERROR: provisioning profile not found at ${MAS_PROVISIONING_PROFILE}" >&2
+    exit 1
+fi
+
+# Confirm the App Store identities are actually in the keychain. Fast-fail
+# beats letting codesign emit an opaque error 30 seconds in.
+if ! security find-identity -v -p codesigning | grep -q "${MAS_APP_IDENTITY}"; then
+    echo "ERROR: app identity not found in keychain: ${MAS_APP_IDENTITY}" >&2
+    exit 1
+fi
+if ! security find-identity -v -p basic | grep -q "${MAS_INSTALLER_IDENTITY}"; then
+    echo "ERROR: installer identity not found in keychain: ${MAS_INSTALLER_IDENTITY}" >&2
+    exit 1
+fi
+
+DIST_DIR="dist-mas"
+APP_DIR="${DIST_DIR}/${APP_NAME}.app"
+CONTENTS_DIR="${APP_DIR}/Contents"
+MACOS_DIR="${CONTENTS_DIR}/MacOS"
+HELPERS_DIR="${CONTENTS_DIR}/Helpers"
+RESOURCES_DIR="${CONTENTS_DIR}/Resources"
+ENTITLEMENTS="scripts/${APP_NAME}.MAS.entitlements"
+PKG_PATH="${DIST_DIR}/${APP_NAME}.pkg"
+
+echo "==> Running tests"
+swift test
+
+echo "==> Cleaning previous MAS build"
+rm -rf "${DIST_DIR}"
+mkdir -p "${MACOS_DIR}" "${HELPERS_DIR}" "${RESOURCES_DIR}"
+
+echo "==> Building MAS release binaries (WHATCABLE_MAS=1, arm64 + x86_64)"
+WHATCABLE_MAS=1 swift build -c release --product "${APP_NAME}" \
+    --arch arm64 --arch x86_64
+WHATCABLE_MAS=1 swift build -c release --product "${CLI_PRODUCT}" \
+    --arch arm64 --arch x86_64
+
+BIN_PATH=$(WHATCABLE_MAS=1 swift build -c release --product "${APP_NAME}" \
+    --arch arm64 --arch x86_64 --show-bin-path)
+cp "${BIN_PATH}/${APP_NAME}" "${MACOS_DIR}/${APP_NAME}"
+cp "${BIN_PATH}/${CLI_PRODUCT}" "${HELPERS_DIR}/${CLI_BIN_NAME}"
+
+# Bundled WhatCableCore resources (USB-IF vendor list, etc.). Same layout
+# as smoke-test.sh.
+SPM_BUNDLE_NAME="WhatCable_WhatCableCore.bundle"
+SPM_RESOURCES_SRC="Sources/WhatCableCore/Resources"
+if [[ -d "${SPM_RESOURCES_SRC}" ]]; then
+    bundle_path="${RESOURCES_DIR}/${SPM_BUNDLE_NAME}"
+    rm -rf "${bundle_path}"
+    mkdir -p "${bundle_path}"
+    cp -R "${SPM_RESOURCES_SRC}/." "${bundle_path}/"
+fi
+
+echo "==> Verifying universal binaries"
+lipo -archs "${MACOS_DIR}/${APP_NAME}" | sed 's/^/    app: /'
+lipo -archs "${HELPERS_DIR}/${CLI_BIN_NAME}" | sed 's/^/    cli: /'
+
+echo "==> Copying app icon"
+if [[ ! -f "scripts/AppIcon.icns" ]]; then
+    ./scripts/make-icon.sh
+fi
+cp "scripts/AppIcon.icns" "${RESOURCES_DIR}/AppIcon.icns"
+
+echo "==> Writing Info.plist"
+cat > "${CONTENTS_DIR}/Info.plist" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>en</string>
+    <key>CFBundleExecutable</key>
+    <string>${APP_NAME}</string>
+    <key>CFBundleIconFile</key>
+    <string>AppIcon</string>
+    <key>CFBundleIdentifier</key>
+    <string>${BUNDLE_ID}</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>${APP_NAME}</string>
+    <key>CFBundleDisplayName</key>
+    <string>${APP_NAME}</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>${VERSION}</string>
+    <key>CFBundleVersion</key>
+    <string>${BUILD_NUMBER}</string>
+    <key>LSApplicationCategoryType</key>
+    <string>public.app-category.utilities</string>
+    <key>LSMinimumSystemVersion</key>
+    <string>${MIN_OS}</string>
+    <key>LSUIElement</key>
+    <true/>
+    <key>NSHumanReadableCopyright</key>
+    <string>© $(date +%Y) Darryl Morley</string>
+    <key>NSHighResolutionCapable</key>
+    <true/>
+</dict>
+</plist>
+PLIST
+
+printf "APPL????" > "${CONTENTS_DIR}/PkgInfo"
+
+echo "==> Embedding Mac App Store provisioning profile"
+cp "${MAS_PROVISIONING_PROFILE}" "${CONTENTS_DIR}/embedded.provisionprofile"
+
+echo "==> Signing CLI binary (inner) with App Store identity + sandbox entitlements"
+# Helper executables in a sandboxed bundle must themselves carry the
+# sandbox entitlement, otherwise App Store validation rejects the package
+# with "helper tools must be sandboxed". Same entitlements file as the
+# outer app.
+codesign --force --options runtime --timestamp \
+    --entitlements "${ENTITLEMENTS}" \
+    --sign "${MAS_APP_IDENTITY}" \
+    "${HELPERS_DIR}/${CLI_BIN_NAME}"
+
+echo "==> Signing app bundle (outer) with App Store identity + sandbox entitlements"
+echo "    Identity: ${MAS_APP_IDENTITY}"
+codesign --force --options runtime --timestamp \
+    --entitlements "${ENTITLEMENTS}" \
+    --sign "${MAS_APP_IDENTITY}" \
+    "${APP_DIR}"
+
+echo "==> Verifying signature"
+codesign --verify --deep --strict --verbose=2 "${APP_DIR}" 2>&1 | sed 's/^/    /'
+
+echo "==> Producing signed installer .pkg"
+productbuild \
+    --component "${APP_DIR}" /Applications \
+    --sign "${MAS_INSTALLER_IDENTITY}" \
+    "${PKG_PATH}"
+
+echo
+echo "Done."
+echo "  App:  ${APP_DIR}"
+echo "  Pkg:  ${PKG_PATH}"
+echo
+echo "Upload via Transporter.app or:"
+echo "  xcrun altool --upload-app -f ${PKG_PATH} -t macos \\"
+echo "    --apple-id <APPLE_ID> --password <APP_SPECIFIC_PASSWORD>"

--- a/scripts/release-mas.sh
+++ b/scripts/release-mas.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Mac App Store submission, downstream of scripts/release.sh.
+#
+# This script is non-mutating. It does not bump the version, commit,
+# tag, push, or touch the Homebrew tap. The OSS release.sh has already
+# done all of that. release-mas.sh just builds the same VERSION /
+# BUILD_NUMBER as a signed App Store .pkg and uploads it to App Store
+# Connect.
+#
+# Typical sequence:
+#   1. scripts/release.sh 0.X.Y      # OSS release (bump, tag, push, GH)
+#   2. scripts/release-mas.sh        # MAS submission, same version
+#
+# Re-running this on the same version is safe: App Store Connect handles
+# build-number versioning of resubmissions on its side. If a build was
+# rejected and a code change is needed, run release.sh first to ship a
+# new OSS release with a new VERSION/BUILD_NUMBER, then re-run this.
+#
+# Required env (loaded from .env, see .env.example):
+#   MAS_APP_IDENTITY
+#   MAS_INSTALLER_IDENTITY
+#   MAS_PROVISIONING_PROFILE
+#   MAS_APPLE_ID                Apple ID email for altool upload
+#   MAS_APP_PASSWORD            App-specific password (App Store Connect)
+#
+# Pass --no-upload to build the .pkg locally without uploading. Useful
+# for verification before the first real submission.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+if [[ -f ".env" ]]; then
+    # shellcheck disable=SC1091
+    set -a; source .env; set +a
+fi
+
+UPLOAD=1
+if [[ "${1:-}" == "--no-upload" ]]; then
+    UPLOAD=0
+fi
+
+# Sanity: working tree should be clean and tag should match smoke-test.sh.
+# We don't enforce on-tag (caller might run from main right after release.sh),
+# but a dirty tree is a footgun.
+if ! git diff-index --quiet HEAD --; then
+    echo "ERROR: working tree has uncommitted changes. Commit or stash first." >&2
+    exit 1
+fi
+
+VERSION=$(grep -E '^VERSION=' scripts/smoke-test.sh | head -1 | sed -E 's/VERSION="(.*)"/\1/')
+BUILD_NUMBER=$(grep -E '^BUILD_NUMBER=' scripts/smoke-test.sh | head -1 | sed -E 's/BUILD_NUMBER="(.*)"/\1/')
+
+echo "==> MAS release: WhatCable ${VERSION} (build ${BUILD_NUMBER})"
+
+./scripts/build-app-mas.sh
+
+PKG_PATH="dist-mas/WhatCable.pkg"
+
+if [[ "${UPLOAD}" -eq 0 ]]; then
+    echo
+    echo "Built ${PKG_PATH}. Skipping upload (--no-upload)."
+    exit 0
+fi
+
+: "${MAS_APPLE_ID:?MAS_APPLE_ID not set}"
+: "${MAS_APP_PASSWORD:?MAS_APP_PASSWORD not set (use an app-specific password)}"
+
+echo "==> Uploading ${PKG_PATH} to App Store Connect"
+xcrun altool --upload-app \
+    --type macos \
+    --file "${PKG_PATH}" \
+    --apple-id "${MAS_APPLE_ID}" \
+    --password "${MAS_APP_PASSWORD}"
+
+echo
+echo "Upload submitted. App Store Connect will process the build, then"
+echo "you can submit it for review from https://appstoreconnect.apple.com."


### PR DESCRIPTION
## Summary

Phase 1 of the App Store work in `planning/appstore-distribution.md`:
infrastructure only, no certs baked in, no submission. The OSS GitHub
+ Homebrew release path is unchanged.

The same source tree now produces two builds:

- OSS build (default): unchanged. Self-hosted UpdateChecker, signed
  with Developer ID, distributed via GitHub release zip + Homebrew.
- App Store build (`WHATCABLE_MAS=1`): UpdateChecker compiled out,
  signed with 3rd Party Mac Developer Application + sandbox
  entitlements, packaged as a signed `.pkg` for App Store Connect.

## Code changes

- `Package.swift`: reads `WHATCABLE_MAS=1` from the environment at
  package eval and adds the `WHATCABLE_MAS` Swift define to the
  WhatCable executable target only.
- `UpdateChecker.swift` and `Installer.swift`: gated as whole files
  (App Review forbids self-updaters; Installer references
  `AvailableUpdate` from UpdateChecker).
- `App.swift`: 4 gated sites (`Check for Updates…` Help command, the
  `start()` call, the status menu item, the `@objc` handler).
- `ContentView.swift`: 3 gated sites (`@ObservedObject` property,
  banner usage in `mainContent`, `UpdateBanner` struct itself).

Total: 9 conditional sites. CLAUDE.md trip-wire is at ~5 sites, but
this is mostly App.swift menu wiring spread across separate methods,
which is how the existing code is structured. No conditionals leaked
into `PortSummary`, watchers, or general UI.

## Build / release infrastructure

- `scripts/WhatCable.MAS.entitlements`: sandbox only. Empirically
  verified that all IOKit reads WhatCable uses work under
  `com.apple.security.app-sandbox` alone, no
  `com.apple.security.device.usb` required.
- `scripts/build-app-mas.sh`: builds with `WHATCABLE_MAS=1`, signs
  both the inner CLI and outer app with the App Store identities and
  the MAS entitlements, embeds the provisioning profile, and
  productbuilds a signed `.pkg`. No notarisation (App Review handles
  it). Fails fast if any cert or profile is missing.
- `scripts/release-mas.sh`: non-mutating downstream of `release.sh`.
  Reuses VERSION / BUILD_NUMBER from `smoke-test.sh` so OSS and MAS
  releases always ship the same version. `--no-upload` flag for
  build-only dry runs.
- `docs/privacy.html`: privacy policy page for the App Store
  privacy URL requirement, served at `whatcable.uk/privacy` once
  Pages redeploys.
- `.env.example` mirrors the new `MAS_*` variables.
- `.gitignore` excludes `secrets/` (provisioning profile) and
  `dist-mas/` (build output).

## Verification

- `swift build` clean for both OSS and `WHATCABLE_MAS=1` paths.
- `swift test`: 216/216 passing.
- `scripts/build-app-mas.sh` end-to-end: produces a signed `.pkg`,
  cert chain valid through 2027, both app and CLI carry only the
  `app-sandbox = true` entitlement.
- Sandbox-signed CLI run from inside the bundle populates all IOKit
  watchers correctly (USB-C ports with charging diagnostic, PD
  negotiation, Thunderbolt switches). The empirical claim from the
  planning doc holds for the actual app, not just the standalone
  probe.

## Out of scope (follow-ups)

- Generating the three required certs and provisioning profile in
  the Apple Developer portal (manual, separate enrolment work).
- Creating the App Store Connect record, signing the Paid Apps
  Agreement, applying to the Small Business Program.
- Screenshots and metadata for the listing.
- First submission.

## Test plan

- [x] OSS `swift build` clean.
- [x] MAS `swift build` clean.
- [x] `swift test` green (216 tests).
- [x] `scripts/build-app-mas.sh` produces a valid signed `.pkg`.
- [x] Sandboxed `.app` shows full IOKit watcher coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)