### PR TITLE
Render cable trust signals in CLI text output

### DIFF
--- a/Sources/WhatCableCore/TextFormatter.swift
+++ b/Sources/WhatCableCore/TextFormatter.swift
@@ -65,6 +65,21 @@ public enum TextFormatter {
             out += "  " + ANSI.wrap(ANSI.dim, diag.detail) + "\n"
         }
 
+        // Cable trust signals: hedged flags raised against the e-marker.
+        // Match the popover's behaviour: only render when at least one flag
+        // fires, and use the same titles + details so wording stays
+        // consistent across surfaces.
+        if let cable = identities.first(where: { $0.endpoint == .sopPrime || $0.endpoint == .sopDoublePrime }) {
+            let trust = CableTrustReport(identity: cable)
+            if !trust.isEmpty {
+                out += "\n" + ANSI.wrap(ANSI.bold + ANSI.yellow, "Cable trust signals:") + "\n"
+                for flag in trust.flags {
+                    out += "  " + ANSI.wrap(ANSI.yellow, "⚠") + " " + ANSI.wrap(ANSI.bold, flag.title) + "\n"
+                    out += "    " + ANSI.wrap(ANSI.dim, flag.detail) + "\n"
+                }
+            }
+        }
+
         if showRaw {
             out += "\n" + ANSI.wrap(ANSI.bold, "Raw IOKit properties:") + "\n"
             for key in port.rawProperties.keys.sorted() {

--- a/Tests/WhatCableCoreTests/TextFormatterTests.swift
+++ b/Tests/WhatCableCoreTests/TextFormatterTests.swift
@@ -77,4 +77,86 @@ final class TextFormatterTests: XCTestCase {
             "ANSI escape sequences should not appear when stdout is not a TTY"
         )
     }
+
+    // MARK: - Cable trust signals
+
+    /// Build an SOP' identity for trust-signal tests. `cableVDO` is VDO[3].
+    /// Default uses USB4 Gen3 / 5A / ~1m latency, which produces no flags.
+    private func cableIdentity(
+        portNumber: Int = 1,
+        vendorID: Int = 0x05AC,
+        cableVDO: UInt32 = (0b10 << 5) | 0b011 | (1 << 13)
+    ) -> PDIdentity {
+        PDIdentity(
+            id: 1,
+            endpoint: .sopPrime,
+            parentPortType: 2,
+            parentPortNumber: portNumber,
+            vendorID: vendorID,
+            productID: 0x1234,
+            bcdDevice: 0,
+            vdos: [(3 << 27) | UInt32(vendorID), 0, 0, cableVDO],
+            specRevision: 3
+        )
+    }
+
+    func testNoTrustSignalsHeadingWhenCableIsClean() {
+        let port = makePort()
+        let cable = cableIdentity(portNumber: port.portNumber ?? 1)
+        let output = TextFormatter.render(
+            ports: [port], sources: [], identities: [cable], showRaw: false
+        )
+        XCTAssertFalse(
+            output.contains("Cable trust signals"),
+            "Clean cable should not surface a trust-signals section"
+        )
+    }
+
+    func testTrustSignalsRenderWhenFlagFires() {
+        let port = makePort()
+        let cable = cableIdentity(portNumber: port.portNumber ?? 1, vendorID: 0)
+        let output = TextFormatter.render(
+            ports: [port], sources: [], identities: [cable], showRaw: false
+        )
+        XCTAssertTrue(output.contains("Cable trust signals"))
+        XCTAssertTrue(output.contains(TrustFlag.zeroVendorID.title))
+        XCTAssertTrue(output.contains(TrustFlag.zeroVendorID.detail))
+    }
+
+    func testMultipleTrustFlagsAllRender() {
+        let port = makePort()
+        // Unregistered VID + reserved speed = two flags.
+        let vdo = UInt32(0b111) | UInt32(2 << 5) | UInt32(1 << 13)
+        let cable = cableIdentity(
+            portNumber: port.portNumber ?? 1,
+            vendorID: 0xDEAD,
+            cableVDO: vdo
+        )
+        let output = TextFormatter.render(
+            ports: [port], sources: [], identities: [cable], showRaw: false
+        )
+        XCTAssertTrue(output.contains(TrustFlag.vidNotInUSBIFList(0xDEAD).title))
+        XCTAssertTrue(output.contains(TrustFlag.reservedSpeedEncoding(7).title))
+    }
+
+    func testTrustSignalsSuppressedForNonCableEndpoint() {
+        // SOP (port partner) shouldn't be evaluated as a cable, so even
+        // a zero VID on a port-partner identity shouldn't trip the section.
+        let port = makePort()
+        let partner = PDIdentity(
+            id: 1,
+            endpoint: .sop,
+            parentPortType: 2,
+            parentPortNumber: port.portNumber ?? 1,
+            vendorID: 0,
+            productID: 0,
+            bcdDevice: 0,
+            vdos: [0, 0, 0, 0],
+            specRevision: 3
+        )
+        let output = TextFormatter.render(
+            ports: [port], sources: [], identities: [partner], showRaw: false
+        )
+        XCTAssertFalse(output.contains("Cable trust signals"))
+    }
 }


### PR DESCRIPTION
## Summary

The popover and `--json` output already surface `CableTrustReport` flags. The plain `whatcable` text output didn't, which left the CLI silently omitting unusual e-marker data that the GUI would flag in orange. This brings the CLI into parity.

- New "Cable trust signals" section in `TextFormatter.renderPort`, rendered after the charging diagnostic.
- Reuses `CableTrustReport`, `flag.title`, and `flag.detail` so wording stays in lock-step with the popover. No new copy.
- Section only appears when at least one flag fires (matches the popover's behaviour).
- Yellow heading + ⚠ bullet per flag + dim detail line, matching the existing CLI styling vocabulary.

## Test plan

- [x] `swift test` (220/220 green, including 4 new TextFormatter tests).
- [x] New tests: clean cable suppresses section, single flag renders title + detail, multiple flags all render, SOP endpoint never trips the section even with VID 0.
- [x] `swift run whatcable-cli` against live ports renders cleanly (no flagged cables to hand on this dev machine, but the empty-port path is unaffected).
- [x] Codex review: no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
