### PR TITLE
Add three spec-backed trust flags: H6, H7, H9a

### DIFF
--- a/Sources/WhatCableCore/CableTrustReport.swift
+++ b/Sources/WhatCableCore/CableTrustReport.swift
@@ -49,6 +49,12 @@ public struct CableTrustReport: Hashable {
                     collected.append(.reservedCurrentEncoding(bits))
                 case .reservedCableLatencyEncoding(let bits):
                     collected.append(.reservedCableLatencyEncoding(bits))
+                case .invalidVDOVersion(let bits):
+                    collected.append(.invalidVDOVersion(bits))
+                case .invalidCableTermination(let bits):
+                    collected.append(.invalidCableTermination(bits))
+                case .eprClaimedWithLowMaxVoltage:
+                    collected.append(.eprClaimedWithLowMaxVoltage)
                 }
             }
         }
@@ -85,6 +91,18 @@ public enum TrustFlag: Hashable {
     /// from a knock-off chip programmer. Hedged accordingly.
     case vidNotInUSBIFList(Int)
 
+    /// Cable VDO Version (bits 23..21) is a value the spec marks as
+    /// Invalid for this cable type.
+    case invalidVDOVersion(Int)
+
+    /// Cable Termination (bits 12..11) is a value the spec marks as
+    /// Invalid for this cable type.
+    case invalidCableTermination(Int)
+
+    /// Passive cable claims EPR Capable but reports only 20V Max VBUS.
+    /// The two fields contradict each other: EPR requires 48V or 50V.
+    case eprClaimedWithLowMaxVoltage
+
     /// Short identifier suitable for JSON output. Stable across releases.
     public var code: String {
         switch self {
@@ -93,6 +111,9 @@ public enum TrustFlag: Hashable {
         case .reservedCurrentEncoding: return "reservedCurrentEncoding"
         case .reservedCableLatencyEncoding: return "reservedCableLatencyEncoding"
         case .vidNotInUSBIFList: return "vidNotInUSBIFList"
+        case .invalidVDOVersion: return "invalidVDOVersion"
+        case .invalidCableTermination: return "invalidCableTermination"
+        case .eprClaimedWithLowMaxVoltage: return "eprClaimedWithLowMaxVoltage"
         }
     }
 
@@ -109,6 +130,12 @@ public enum TrustFlag: Hashable {
             return "E-marker uses a reserved cable-latency value"
         case .vidNotInUSBIFList:
             return "Vendor ID isn't in USB-IF's published list"
+        case .invalidVDOVersion:
+            return "E-marker uses an invalid VDO version"
+        case .invalidCableTermination:
+            return "E-marker uses an invalid cable-termination value"
+        case .eprClaimedWithLowMaxVoltage:
+            return "E-marker claims EPR support but reports only 20V max VBUS"
         }
     }
 
@@ -126,6 +153,12 @@ public enum TrustFlag: Hashable {
         case .vidNotInUSBIFList(let vid):
             let hex = String(format: "0x%04X", vid)
             return "The cable's e-marker reports vendor \(hex), which isn't in our bundled USB-IF list. The number could be unassigned, copied, or assigned after the bundled list was generated. On its own this isn't proof of a problem, but on a clone cable it often appears alongside other inconsistencies."
+        case .invalidVDOVersion(let bits):
+            return "The cable's e-marker reports VDO version \(bits), which is reserved or marked Invalid by the USB-PD spec for this cable type. Real e-marker silicon should not emit Invalid version values."
+        case .invalidCableTermination(let bits):
+            return "The cable's e-marker reports cable termination \(bits), which the USB-PD spec marks as Invalid for this cable type. Mis-flashed e-markers commonly disagree with the cable's actual physical wiring here."
+        case .eprClaimedWithLowMaxVoltage:
+            return "The cable's e-marker advertises EPR Capable, but reports its Max VBUS Voltage as 20V. EPR operation needs 48V or 50V VBUS, so the two fields contradict each other."
         }
     }
 }

--- a/Sources/WhatCableCore/PDVDO.swift
+++ b/Sources/WhatCableCore/PDVDO.swift
@@ -119,6 +119,19 @@ public enum PDVDO {
         /// invalid; active cables treat 0000 and 1011..1111 as invalid
         /// (1001 and 1010 carry valid optical-cable latencies).
         case reservedCableLatencyEncoding(Int)
+        /// Cable VDO Version field (bits 23..21) uses a value the spec
+        /// marks as Invalid for this cable type. Passive cables: only
+        /// `000` (v1.0) is valid. Active cables: `000` (deprecated v1.0),
+        /// `010` (deprecated v1.2), and `011` (v1.3) are accepted.
+        case invalidVDOVersion(Int)
+        /// Cable Termination field (bits 12..11) uses a value the spec
+        /// marks as Invalid for this cable type. Passive cables: `00`
+        /// and `01` valid. Active cables: `10` and `11` valid.
+        case invalidCableTermination(Int)
+        /// Passive cable's e-marker advertises EPR Capable but reports
+        /// only 20V Max VBUS. EPR requires 48V or 50V VBUS, so this
+        /// pair of fields is internally contradictory.
+        case eprClaimedWithLowMaxVoltage
     }
 
     public struct CableVDO: Hashable {
@@ -134,6 +147,15 @@ public enum PDVDO {
         /// values per cable type are flagged via `decodeWarnings`. Use
         /// `latencyNanoseconds` for a typed interpretation.
         public let cableLatencyEncoded: Int
+        /// Raw 3-bit "VDO Version" field (bits 23..21). Validity depends
+        /// on cable type and is reported via `decodeWarnings`.
+        public let vdoVersionEncoded: Int
+        /// Raw 2-bit "Cable Termination" field (bits 12..11). Validity
+        /// depends on cable type and is reported via `decodeWarnings`.
+        public let cableTerminationEncoded: Int
+        /// Bit 17, "EPR Capable." When true, the cable claims to be safe
+        /// for Extended Power Range operation (48V / 50V).
+        public let eprCapable: Bool
         public let decodeWarnings: [DecodeWarning]
 
         public var maxVolts: Int {
@@ -179,6 +201,9 @@ public enum PDVDO {
         let maxV = Int((vdo >> 9) & 0b11)
         let latencyBits = Int((vdo >> 13) & 0b1111)
         let cableType: CableType = isActive ? .active : .passive
+        let cableTerminationBits = Int((vdo >> 11) & 0b11)
+        let vdoVersionBits = Int((vdo >> 21) & 0b111)
+        let eprCapable = (vdo >> 17) & 1 == 1
         var warnings: [DecodeWarning] = []
         if decodedSpeed == nil {
             warnings.append(.reservedSpeedEncoding(speedBits))
@@ -209,6 +234,44 @@ public enum PDVDO {
             warnings.append(.reservedCableLatencyEncoding(latencyBits))
         }
 
+        // VDO Version (bits 23..21).
+        // Passive: only 000 (v1.0) is valid; everything else Invalid.
+        // Active: 000 (deprecated v1.0), 010 (deprecated v1.2), 011 (v1.3)
+        // are accepted. 001 and 100..111 are Invalid per Table 6.43.
+        let vdoVersionInvalid: Bool
+        if isActive {
+            vdoVersionInvalid = !(vdoVersionBits == 0 || vdoVersionBits == 0b010 || vdoVersionBits == 0b011)
+        } else {
+            vdoVersionInvalid = vdoVersionBits != 0
+        }
+        if vdoVersionInvalid {
+            warnings.append(.invalidVDOVersion(vdoVersionBits))
+        }
+
+        // Cable Termination (bits 12..11).
+        // Passive: 00 (VCONN not required) and 01 (VCONN required) are
+        // valid; 10 and 11 are Invalid.
+        // Active: 00 and 01 are Invalid; 10 (one end active) and 11
+        // (both ends active) are valid.
+        let cableTerminationInvalid: Bool
+        if isActive {
+            cableTerminationInvalid = cableTerminationBits < 0b10
+        } else {
+            cableTerminationInvalid = cableTerminationBits >= 0b10
+        }
+        if cableTerminationInvalid {
+            warnings.append(.invalidCableTermination(cableTerminationBits))
+        }
+
+        // H9a: Passive cable claims EPR Capable but reports 20V Max VBUS.
+        // EPR requires 48V or 50V; only encoding 11 (50V) is consistent
+        // with an EPR claim. We flag the 20V case (encoding 0) explicitly,
+        // matching what the planning doc calls out. Active cables aren't
+        // flagged here: their EPR semantics need the Active VDO2 decoder.
+        if !isActive && eprCapable && maxV == 0 {
+            warnings.append(.eprClaimedWithLowMaxVoltage)
+        }
+
         let volts: Double
         switch maxV {
         case 1: volts = 30
@@ -227,6 +290,9 @@ public enum PDVDO {
             vbusThroughCable: vbusThrough,
             maxVoltageEncoded: maxV,
             cableLatencyEncoded: latencyBits,
+            vdoVersionEncoded: vdoVersionBits,
+            cableTerminationEncoded: cableTerminationBits,
+            eprCapable: eprCapable,
             decodeWarnings: warnings
         )
     }

--- a/Tests/WhatCableCoreTests/CableTrustReportTests.swift
+++ b/Tests/WhatCableCoreTests/CableTrustReportTests.swift
@@ -98,7 +98,7 @@ final class CableTrustReportTests: XCTestCase {
                 UInt32(4 << 27) | UInt32(0x05AC), // active cable ID header
                 0,
                 0,
-                UInt32(0b011) | UInt32(2 << 5) | (UInt32(0b1010) << 13) // ~2000 ns
+                UInt32(0b011) | UInt32(2 << 5) | (UInt32(0b1010) << 13) | UInt32(0b10 << 11) // ~2000 ns, valid active termination
             ],
             specRevision: 3
         )
@@ -180,6 +180,29 @@ final class CableTrustReportTests: XCTestCase {
         ])
     }
 
+    // MARK: - H6 / H7 / H9a propagate from decoder to trust report
+
+    func testInvalidVDOVersionSurfacesAsTrustFlag() {
+        // Passive cable with VDO version 001 (any non-zero) is invalid.
+        let vdo = UInt32(0b011) | UInt32(2 << 5) | Self.validLatency | (UInt32(1) << 21)
+        let report = CableTrustReport(identity: cableIdentity(cableVDO: vdo))
+        XCTAssertEqual(report.flags, [.invalidVDOVersion(1)])
+    }
+
+    func testInvalidCableTerminationSurfacesAsTrustFlag() {
+        // Passive cable with termination 11 (invalid for passive).
+        let vdo = UInt32(0b011) | UInt32(2 << 5) | Self.validLatency | UInt32(0b11 << 11)
+        let report = CableTrustReport(identity: cableIdentity(cableVDO: vdo))
+        XCTAssertEqual(report.flags, [.invalidCableTermination(0b11)])
+    }
+
+    func testEPRClaimedWithLowMaxVoltageSurfacesAsTrustFlag() {
+        // Passive cable, EPR Capable set, max VBUS 20V.
+        let vdo = UInt32(0b011) | UInt32(2 << 5) | Self.validLatency | UInt32(1 << 17)
+        let report = CableTrustReport(identity: cableIdentity(cableVDO: vdo))
+        XCTAssertEqual(report.flags, [.eprClaimedWithLowMaxVoltage])
+    }
+
     // MARK: - JSON contract
 
     func testFlagCodesAreStable() {
@@ -189,6 +212,9 @@ final class CableTrustReportTests: XCTestCase {
         XCTAssertEqual(TrustFlag.reservedCurrentEncoding(3).code, "reservedCurrentEncoding")
         XCTAssertEqual(TrustFlag.reservedCableLatencyEncoding(0).code, "reservedCableLatencyEncoding")
         XCTAssertEqual(TrustFlag.vidNotInUSBIFList(0xDEAD).code, "vidNotInUSBIFList")
+        XCTAssertEqual(TrustFlag.invalidVDOVersion(1).code, "invalidVDOVersion")
+        XCTAssertEqual(TrustFlag.invalidCableTermination(0b11).code, "invalidCableTermination")
+        XCTAssertEqual(TrustFlag.eprClaimedWithLowMaxVoltage.code, "eprClaimedWithLowMaxVoltage")
     }
 
     func testH3DetailIncludesVIDInHex() {

--- a/Tests/WhatCableCoreTests/PDVDOTests.swift
+++ b/Tests/WhatCableCoreTests/PDVDOTests.swift
@@ -43,6 +43,11 @@ final class PDVDOTests: XCTestCase {
     /// value. Real cable reports we've collected use 0001 or 1000.
     private static let validLatency: UInt32 = 1 << 13
 
+    /// Valid Cable Termination bits for active cables (bits 12..11).
+    /// `10` = one end active. Active cable fixtures need this OR'd in,
+    /// otherwise the new H7 termination check fires.
+    private static let validActiveTermination: UInt32 = 0b10 << 11
+
     func testThunderboltCable_5A_40Gbps() {
         // speed=3 (USB4 Gen3), current=2 (5A) -> 2<<5=0x40, vbus-through bit 4=1
         let vdo: UInt32 = 0b011 | (1 << 4) | (2 << 5) | Self.validLatency
@@ -80,7 +85,7 @@ final class PDVDOTests: XCTestCase {
     }
 
     func testActiveCableType() {
-        let vdo: UInt32 = Self.validLatency
+        let vdo: UInt32 = Self.validLatency | Self.validActiveTermination
         let cable = PDVDO.decodeCableVDO(vdo, isActive: true)
         XCTAssertEqual(cable.cableType, .active)
         XCTAssertTrue(cable.decodeWarnings.isEmpty)
@@ -151,7 +156,7 @@ final class PDVDOTests: XCTestCase {
         // Active cables carry optical-length latencies 1001 (~1000 ns)
         // and 1010 (~2000 ns) that passive cables would treat as invalid.
         for latencyBits in [9, 10] {
-            let vdo = UInt32(0b011) | UInt32(2 << 5) | (UInt32(latencyBits) << 13)
+            let vdo = UInt32(0b011) | UInt32(2 << 5) | (UInt32(latencyBits) << 13) | Self.validActiveTermination
             let cable = PDVDO.decodeCableVDO(vdo, isActive: true)
             XCTAssertTrue(
                 cable.decodeWarnings.isEmpty,
@@ -162,7 +167,7 @@ final class PDVDOTests: XCTestCase {
 
     func testActiveCableLatency_1011AndUpInvalid() {
         for latencyBits in 11...15 {
-            let vdo = UInt32(0b011) | UInt32(2 << 5) | (UInt32(latencyBits) << 13)
+            let vdo = UInt32(0b011) | UInt32(2 << 5) | (UInt32(latencyBits) << 13) | Self.validActiveTermination
             let cable = PDVDO.decodeCableVDO(vdo, isActive: true)
             XCTAssertEqual(
                 cable.decodeWarnings,
@@ -189,6 +194,147 @@ final class PDVDOTests: XCTestCase {
         let invalidPassive = UInt32(0b011) | UInt32(2 << 5) | (UInt32(9) << 13)
         let cable = PDVDO.decodeCableVDO(invalidPassive, isActive: false)
         XCTAssertNil(cable.latencyNanoseconds)
+    }
+
+    // MARK: - VDO Version (H6)
+
+    func testPassiveVDOVersionZeroIsValid() {
+        // 000 = v1.0, the only valid passive value.
+        let vdo: UInt32 = 0b011 | UInt32(2 << 5) | Self.validLatency
+        let cable = PDVDO.decodeCableVDO(vdo, isActive: false)
+        XCTAssertEqual(cable.vdoVersionEncoded, 0)
+        XCTAssertTrue(cable.decodeWarnings.isEmpty)
+    }
+
+    func testPassiveVDOVersionNonZeroFlags() {
+        // Anything other than 000 is invalid for passive cables.
+        for version in 1...7 {
+            let vdo: UInt32 = 0b011 | UInt32(2 << 5) | Self.validLatency | (UInt32(version) << 21)
+            let cable = PDVDO.decodeCableVDO(vdo, isActive: false)
+            XCTAssertEqual(
+                cable.decodeWarnings,
+                [.invalidVDOVersion(version)],
+                "VDO version \(version) should be invalid for passive"
+            )
+        }
+    }
+
+    func testActiveVDOVersionAcceptsDeprecatedAndV13() {
+        // 000 (deprecated v1.0), 010 (deprecated v1.2), 011 (v1.3) all valid.
+        for version in [0, 0b010, 0b011] {
+            let vdo: UInt32 = 0b011 | UInt32(2 << 5) | Self.validLatency
+                | Self.validActiveTermination | (UInt32(version) << 21)
+            let cable = PDVDO.decodeCableVDO(vdo, isActive: true)
+            XCTAssertTrue(
+                cable.decodeWarnings.isEmpty,
+                "VDO version \(version) should be valid for active"
+            )
+        }
+    }
+
+    func testActiveVDOVersionInvalidValuesFlag() {
+        // 001 and 100..111 are invalid for active cables.
+        for version in [0b001, 0b100, 0b101, 0b110, 0b111] {
+            let vdo: UInt32 = 0b011 | UInt32(2 << 5) | Self.validLatency
+                | Self.validActiveTermination | (UInt32(version) << 21)
+            let cable = PDVDO.decodeCableVDO(vdo, isActive: true)
+            XCTAssertEqual(
+                cable.decodeWarnings,
+                [.invalidVDOVersion(version)],
+                "VDO version \(version) should be invalid for active"
+            )
+        }
+    }
+
+    // MARK: - Cable Termination (H7)
+
+    func testPassiveCableTerminationValid() {
+        // 00 (VCONN not required) and 01 (VCONN required) both valid.
+        for term in [0, 0b01] {
+            let vdo: UInt32 = 0b011 | UInt32(2 << 5) | Self.validLatency | (UInt32(term) << 11)
+            let cable = PDVDO.decodeCableVDO(vdo, isActive: false)
+            XCTAssertEqual(cable.cableTerminationEncoded, term)
+            XCTAssertTrue(
+                cable.decodeWarnings.isEmpty,
+                "Termination \(term) should be valid for passive"
+            )
+        }
+    }
+
+    func testPassiveCableTerminationInvalid() {
+        // 10 and 11 are invalid for passive cables.
+        for term in [0b10, 0b11] {
+            let vdo: UInt32 = 0b011 | UInt32(2 << 5) | Self.validLatency | (UInt32(term) << 11)
+            let cable = PDVDO.decodeCableVDO(vdo, isActive: false)
+            XCTAssertEqual(
+                cable.decodeWarnings,
+                [.invalidCableTermination(term)],
+                "Termination \(term) should be invalid for passive"
+            )
+        }
+    }
+
+    func testActiveCableTerminationValid() {
+        // 10 (one end active) and 11 (both ends active) valid.
+        for term in [0b10, 0b11] {
+            let vdo: UInt32 = 0b011 | UInt32(2 << 5) | Self.validLatency | (UInt32(term) << 11)
+            let cable = PDVDO.decodeCableVDO(vdo, isActive: true)
+            XCTAssertTrue(
+                cable.decodeWarnings.isEmpty,
+                "Termination \(term) should be valid for active"
+            )
+        }
+    }
+
+    func testActiveCableTerminationInvalid() {
+        // 00 and 01 invalid for active cables.
+        for term in [0, 0b01] {
+            let vdo: UInt32 = 0b011 | UInt32(2 << 5) | Self.validLatency | (UInt32(term) << 11)
+            let cable = PDVDO.decodeCableVDO(vdo, isActive: true)
+            XCTAssertEqual(
+                cable.decodeWarnings,
+                [.invalidCableTermination(term)],
+                "Termination \(term) should be invalid for active"
+            )
+        }
+    }
+
+    // MARK: - EPR / VBUS contradiction (H9a)
+
+    func testPassiveEPRWith20VFlags() {
+        // EPR Capable bit 17 set, max VBUS encoding 00 (20V).
+        let vdo: UInt32 = 0b011 | UInt32(2 << 5) | Self.validLatency | UInt32(1 << 17)
+        let cable = PDVDO.decodeCableVDO(vdo, isActive: false)
+        XCTAssertTrue(cable.eprCapable)
+        XCTAssertEqual(cable.maxVoltageEncoded, 0)
+        XCTAssertEqual(cable.decodeWarnings, [.eprClaimedWithLowMaxVoltage])
+    }
+
+    func testPassiveEPRWith50VDoesNotFlag() {
+        // EPR + 50V max is consistent.
+        let vdo: UInt32 = 0b011 | UInt32(2 << 5) | Self.validLatency
+            | UInt32(1 << 17) | UInt32(0b11 << 9)
+        let cable = PDVDO.decodeCableVDO(vdo, isActive: false)
+        XCTAssertTrue(cable.eprCapable)
+        XCTAssertEqual(cable.maxVoltageEncoded, 0b11)
+        XCTAssertTrue(cable.decodeWarnings.isEmpty)
+    }
+
+    func testPassiveNoEPRWith20VDoesNotFlag() {
+        // Plain 20V cable that doesn't claim EPR is fine.
+        let vdo: UInt32 = 0b011 | UInt32(2 << 5) | Self.validLatency
+        let cable = PDVDO.decodeCableVDO(vdo, isActive: false)
+        XCTAssertFalse(cable.eprCapable)
+        XCTAssertTrue(cable.decodeWarnings.isEmpty)
+    }
+
+    func testActiveEPRWith20VDoesNotFlag() {
+        // H9a is passive-only; active cable EPR semantics need VDO2 decoder.
+        let vdo: UInt32 = 0b011 | UInt32(2 << 5) | Self.validLatency
+            | Self.validActiveTermination | UInt32(1 << 17)
+        let cable = PDVDO.decodeCableVDO(vdo, isActive: true)
+        XCTAssertTrue(cable.eprCapable)
+        XCTAssertTrue(cable.decodeWarnings.isEmpty)
     }
 
     // MARK: - Cert Stat VDO


### PR DESCRIPTION
## Summary

Three new spec-backed trust signal flags pulled from `planning/cable-trust-signals.md`. All three plug into the existing `DecodeWarning` -> `TrustFlag` pipeline, so JSON output, the popover's `TrustFlagsCard`, and the CLI text trust signals (just shipped in #74) all pick them up with no additional wiring.

### H6: Invalid VDO Version (bits 23..21)
- Passive cables: only `000` (v1.0) is valid per Table 6.42, USB-PD R3.2 V1.2.
- Active cables: `000` (deprecated v1.0), `010` (deprecated v1.2), and `011` (v1.3) are accepted per Table 6.43; `001` and `100..111` are Invalid.

### H7: Invalid Cable Termination (bits 12..11)
- Passive cables: `00` and `01` valid; `10..11` Invalid.
- Active cables: `00..01` Invalid; `10` (one end active) and `11` (both ends active) valid.

The decoder did not extract this field at all before; this PR adds `cableTerminationEncoded` to `CableVDO` alongside the warning emission.

### H9a: EPR Capable + 20V Max VBUS (cross-field)
A passive cable that claims EPR Capable (bit 17) but reports Max VBUS as 20V (encoding `00`) contradicts itself. EPR requires 48V or 50V VBUS, so the only consistent Max VBUS encoding for an EPR cable is `11` (50V). Active cable EPR semantics need the Active VDO2 decoder so they're intentionally out of scope here.

## Codex review note

Codex flagged a worry that passive `011` (v1.3) might also be valid for passive cables, which would have made H6 false-positive on legitimate PD 3.1 / EPR cables. A follow-up clarification round confirmed Codex had no spec citation backing that, and `planning/spec-reference.md` Table 6.42 (extracted from USB-PD R3.2 V1.2, March 17 2026) is unambiguous: "000=v1.0. All others Invalid." Codex withdrew the objection.

## Test plan

- [x] `swift test` — 235/235 green (15 new tests).
- [x] `swift build` clean.
- [x] `WHATCABLE_MAS=1 swift build --product WhatCable` clean (App Store gating still compiles).
- [x] Codex review: only finding withdrawn after spec citation check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
