### PR TITLE
Decode and surface Active Cable VDO 2

### DIFF
--- a/Sources/WhatCableCore/JSONFormatter.swift
+++ b/Sources/WhatCableCore/JSONFormatter.swift
@@ -160,6 +160,7 @@ private struct CableDTO: Codable {
     let maxVolts: Int?
     let maxWatts: Int?
     let type: String?
+    let active: ActiveCableDTO?
     let trustFlags: [TrustFlagDTO]?
 
     init(identity: PDIdentity) {
@@ -180,8 +181,38 @@ private struct CableDTO: Codable {
             self.type = nil
         }
 
+        self.active = identity.activeCableVDO2.map(ActiveCableDTO.init)
+
         let report = CableTrustReport(identity: identity)
         self.trustFlags = report.isEmpty ? nil : report.flags.map(TrustFlagDTO.init)
+    }
+}
+
+private struct ActiveCableDTO: Codable {
+    let physicalConnection: String
+    let activeElement: String
+    let opticallyIsolated: Bool
+    let twoLanesSupported: Bool
+    let usb4Supported: Bool
+    let usb32Supported: Bool
+    let usb2Supported: Bool
+    let usbGen2OrHigher: Bool
+    let maxOperatingTempC: Int
+    let shutdownTempC: Int
+    let u3CLdPower: String
+
+    init(_ v2: PDVDO.ActiveCableVDO2) {
+        self.physicalConnection = v2.physicalConnection.label
+        self.activeElement = v2.activeElement.label
+        self.opticallyIsolated = v2.opticallyIsolated
+        self.twoLanesSupported = v2.twoLanesSupported
+        self.usb4Supported = v2.usb4Supported
+        self.usb32Supported = v2.usb32Supported
+        self.usb2Supported = v2.usb2Supported
+        self.usbGen2OrHigher = v2.usbGen2OrHigher
+        self.maxOperatingTempC = v2.maxOperatingTempC
+        self.shutdownTempC = v2.shutdownTempC
+        self.u3CLdPower = v2.u3CLdPower.label
     }
 }
 

--- a/Sources/WhatCableCore/PDIdentity.swift
+++ b/Sources/WhatCableCore/PDIdentity.swift
@@ -65,4 +65,15 @@ public struct PDIdentity: Identifiable, Hashable {
         let isActive = header?.ufpProductType == .activeCable
         return PDVDO.decodeCableVDO(vdos[3], isActive: isActive)
     }
+
+    /// Active Cable VDO 2 lives at index 4 and is only present on active
+    /// cables. Carries info that doesn't fit in VDO[3]: physical medium
+    /// (copper/optical), active element (re-driver/re-timer), thermal
+    /// limits, idle-state power, and per-lane / per-protocol support.
+    public var activeCableVDO2: PDVDO.ActiveCableVDO2? {
+        guard endpoint == .sopPrime || endpoint == .sopDoublePrime,
+              vdos.count > 4,
+              idHeader?.ufpProductType == .activeCable else { return nil }
+        return PDVDO.decodeActiveCableVDO2(vdos[4])
+    }
 }

--- a/Sources/WhatCableCore/PDVDO.swift
+++ b/Sources/WhatCableCore/PDVDO.swift
@@ -297,6 +297,133 @@ public enum PDVDO {
         )
     }
 
+    // MARK: Active Cable VDO 2 (active cables only, VDO[4] in PD 3.0+)
+
+    /// Physical medium the cable uses to carry data.
+    public enum PhysicalConnection: Int {
+        case copper = 0
+        case optical = 1
+
+        public var label: String {
+            switch self {
+            case .copper: return "Copper"
+            case .optical: return "Optical"
+            }
+        }
+    }
+
+    /// What the active silicon inside the cable's connector does to the
+    /// signal. A re-driver boosts the signal in place; a re-timer fully
+    /// decodes and re-emits it. Re-timers are more capable and usually
+    /// found in higher-end cables.
+    public enum ActiveElement: Int {
+        case redriver = 0
+        case retimer = 1
+
+        public var label: String {
+            switch self {
+            case .redriver: return "Re-driver"
+            case .retimer: return "Re-timer"
+            }
+        }
+    }
+
+    /// Idle-state power consumption of the active chip while the cable
+    /// is in U3 / CLd. Matters for thermal and battery-life accounting on
+    /// portable hosts. Bits 14..12.
+    public enum U3CLdPower: Int {
+        case greaterThan10mW = 0      // > 10 mW
+        case fiveTo10mW = 1           // 5-10 mW
+        case oneTo5mW = 2             // 1-5 mW
+        case halfTo1mW = 3            // 0.5-1 mW
+        case fifthToHalfmW = 4        // 0.2-0.5 mW
+        case fiftyTo200uW = 5         // 50-200 µW
+        case lessThan50uW = 6         // < 50 µW
+        case reserved = 7
+
+        public var label: String {
+            switch self {
+            case .greaterThan10mW: return "> 10 mW"
+            case .fiveTo10mW: return "5-10 mW"
+            case .oneTo5mW: return "1-5 mW"
+            case .halfTo1mW: return "0.5-1 mW"
+            case .fifthToHalfmW: return "0.2-0.5 mW"
+            case .fiftyTo200uW: return "50-200 µW"
+            case .lessThan50uW: return "< 50 µW"
+            case .reserved: return "Reserved"
+            }
+        }
+    }
+
+    public struct ActiveCableVDO2: Hashable {
+        /// Bits 31..24, in degrees C. 0 means "not specified."
+        public let maxOperatingTempC: Int
+        /// Bits 23..16, in degrees C. 0 means "not specified."
+        public let shutdownTempC: Int
+        /// Bits 14..12.
+        public let u3CLdPower: U3CLdPower
+        /// Bit 11. `true` = transition through U3S (saves power but slower
+        /// to wake), `false` = direct.
+        public let u3ToU0TransitionThroughU3S: Bool
+        /// Bit 10.
+        public let physicalConnection: PhysicalConnection
+        /// Bit 9.
+        public let activeElement: ActiveElement
+        /// Bit 8.
+        public let usb4Supported: Bool
+        /// Bits 7..6. Number of USB 2.0 hub hops the cable consumes from
+        /// the topology budget.
+        public let usb2HubHopsConsumed: Int
+        /// Bit 5.
+        public let usb2Supported: Bool
+        /// Bit 4. Set when USB 3.2 signalling is supported.
+        public let usb32Supported: Bool
+        /// Bit 3. `true` = two USB lanes supported, `false` = one lane.
+        public let twoLanesSupported: Bool
+        /// Bit 2. Optical cables that carry their signal on glass fiber
+        /// are physically isolated by construction; cables that bring
+        /// power or ground continuity through copper alongside the fiber
+        /// will set this to `false`.
+        public let opticallyIsolated: Bool
+        /// Bit 1.
+        public let usb4AsymmetricMode: Bool
+        /// Bit 0. `true` = Gen2 or higher, `false` = Gen1.
+        public let usbGen2OrHigher: Bool
+    }
+
+    public static func decodeActiveCableVDO2(_ vdo: UInt32) -> ActiveCableVDO2 {
+        let maxTemp = Int((vdo >> 24) & 0xFF)
+        let shutdownTemp = Int((vdo >> 16) & 0xFF)
+        let powerBits = Int((vdo >> 12) & 0b111)
+        let power = U3CLdPower(rawValue: powerBits) ?? .reserved
+        let physBits = Int((vdo >> 10) & 1)
+        let phys = PhysicalConnection(rawValue: physBits) ?? .copper
+        let elemBits = Int((vdo >> 9) & 1)
+        let elem = ActiveElement(rawValue: elemBits) ?? .redriver
+
+        // The protocol-supported bits (USB4, USB 3.2, USB 2.0) are
+        // *inverted* in the spec: a 0 bit means "supported," a 1 means
+        // "not supported." The other Bool fields use the conventional
+        // 1 = yes encoding. Keep the API ergonomic (`usb4Supported = true`
+        // when the cable actually supports USB4) by inverting here.
+        return ActiveCableVDO2(
+            maxOperatingTempC: maxTemp,
+            shutdownTempC: shutdownTemp,
+            u3CLdPower: power,
+            u3ToU0TransitionThroughU3S: (vdo >> 11) & 1 == 1,
+            physicalConnection: phys,
+            activeElement: elem,
+            usb4Supported: (vdo >> 8) & 1 == 0,
+            usb2HubHopsConsumed: Int((vdo >> 6) & 0b11),
+            usb2Supported: (vdo >> 5) & 1 == 0,
+            usb32Supported: (vdo >> 4) & 1 == 0,
+            twoLanesSupported: (vdo >> 3) & 1 == 1,
+            opticallyIsolated: (vdo >> 2) & 1 == 1,
+            usb4AsymmetricMode: (vdo >> 1) & 1 == 1,
+            usbGen2OrHigher: vdo & 1 == 1
+        )
+    }
+
     // MARK: Cert Stat VDO (always VDO[1])
 
     /// USB-IF certification identity. Issued before product certification;

--- a/Sources/WhatCableCore/PortSummary.swift
+++ b/Sources/WhatCableCore/PortSummary.swift
@@ -139,7 +139,21 @@ extension PortSummary {
             bullets.append("Cable speed: \(cv.speed.label)")
             bullets.append("Cable rated for \(cv.current.label) at up to \(cv.maxVolts)V (~\(cv.maxWatts)W)")
             if cv.cableType == .active {
-                bullets.append("Active cable (contains signal-conditioning electronics)")
+                if let v2 = cable.activeCableVDO2 {
+                    // Lead with the most user-relevant facts: medium and
+                    // active element. Optional follow-up for optical
+                    // cables noting whether they're isolated.
+                    bullets.append("Active \(v2.physicalConnection.label.lowercased()) cable, \(v2.activeElement.label.lowercased())")
+                    if v2.physicalConnection == .optical {
+                        if v2.opticallyIsolated {
+                            bullets.append("Optical fibres are electrically isolated end-to-end")
+                        } else {
+                            bullets.append("Optical cable, not electrically isolated (carries copper alongside the fibres)")
+                        }
+                    }
+                } else {
+                    bullets.append("Active cable (contains signal-conditioning electronics)")
+                }
             }
         }
 

--- a/Tests/WhatCableCoreTests/JSONFormatterTests.swift
+++ b/Tests/WhatCableCoreTests/JSONFormatterTests.swift
@@ -251,6 +251,66 @@ final class JSONFormatterTests: XCTestCase {
         XCTAssertTrue(detail.contains("0xDEAD"), "detail should include hex VID, got: \(detail)")
     }
 
+    // MARK: - Active Cable VDO 2 surfacing
+
+    private func activeCableIdentity(vdo4: UInt32, vendorID: Int = 0x05AC) -> PDIdentity {
+        // Active cable: ufpProductType bits 29..27 = 100 = 4.
+        // Cable VDO with valid active termination + USB4 Gen3 + 5A + valid latency.
+        let cableVDO: UInt32 = UInt32(0b011) | UInt32(2 << 5) | Self.validLatency | UInt32(0b10 << 11)
+        return PDIdentity(
+            id: 1,
+            endpoint: .sopPrime,
+            parentPortType: 2,
+            parentPortNumber: 1,
+            vendorID: vendorID,
+            productID: 0x1234,
+            bcdDevice: 0,
+            vdos: [
+                (4 << 27) | UInt32(vendorID),
+                0,
+                0,
+                cableVDO,
+                vdo4
+            ],
+            specRevision: 3
+        )
+    }
+
+    func testActiveBlockOmittedForPassiveCable() throws {
+        let port = makePort()
+        let passive = cableIdentity(vendorID: 0x05AC, cableVDO: (0b10 << 5) | 0b011 | Self.validLatency)
+        let json = try JSONFormatter.render(
+            ports: [port], sources: [], identities: [passive], showRaw: false
+        )
+        let obj = parse(json)
+        let portObj = (obj["ports"] as? [[String: Any]])?.first ?? [:]
+        let cable = try XCTUnwrap(portObj["cable"] as? [String: Any])
+        XCTAssertNil(cable["active"], "Passive cables should not surface an active VDO2 block")
+    }
+
+    func testActiveBlockPresentForActiveCable() throws {
+        let port = makePort()
+        // VDO2: optical (bit 10) + retimer (bit 9) + isolated (bit 2).
+        // USB4 / USB 3.2 / USB 2.0 supported = leave bits 8, 5, 4 at 0
+        // (the spec-defined "supported" value is 0, not 1).
+        var vdo4: UInt32 = 0
+        vdo4 |= UInt32(1) << 10
+        vdo4 |= UInt32(1) << 9
+        vdo4 |= UInt32(1) << 2
+        let id = activeCableIdentity(vdo4: vdo4)
+        let json = try JSONFormatter.render(
+            ports: [port], sources: [], identities: [id], showRaw: false
+        )
+        let obj = parse(json)
+        let portObj = (obj["ports"] as? [[String: Any]])?.first ?? [:]
+        let cable = try XCTUnwrap(portObj["cable"] as? [String: Any])
+        let active = try XCTUnwrap(cable["active"] as? [String: Any])
+        XCTAssertEqual(active["physicalConnection"] as? String, "Optical")
+        XCTAssertEqual(active["activeElement"] as? String, "Re-timer")
+        XCTAssertEqual(active["opticallyIsolated"] as? Bool, true)
+        XCTAssertEqual(active["usb4Supported"] as? Bool, true)
+    }
+
     // MARK: - Raw properties gating
 
     func testRawPropertiesOmittedByDefault() throws {

--- a/Tests/WhatCableCoreTests/PDVDOTests.swift
+++ b/Tests/WhatCableCoreTests/PDVDOTests.swift
@@ -337,6 +337,167 @@ final class PDVDOTests: XCTestCase {
         XCTAssertTrue(cable.decodeWarnings.isEmpty)
     }
 
+    // MARK: - Active Cable VDO 2
+
+    func testDecodeActiveCableVDO2_AllFields() {
+        // Build a VDO2 exercising every field. Note that USB4 / USB 3.2 /
+        // USB 2.0 "Supported" bits are inverted in the spec: 0 = supported,
+        // 1 = not supported. Test fixture sets them to 0 to mean "all
+        // protocols supported" and asserts our decoder reports `true`.
+        //   31..24: maxOperatingTemp = 100°C
+        //   23..16: shutdownTemp     = 120°C
+        //   14..12: u3CLdPower       = 011 (0.5-1 mW)
+        //   11    : u3 transition through U3S = 1
+        //   10    : physicalConnection = 1 (optical)
+        //   9     : activeElement   = 1 (re-timer)
+        //   8     : USB4 bit = 0     (supported)
+        //   7..6  : hubHopsConsumed = 10 = 2
+        //   5     : USB 2.0 bit = 0  (supported)
+        //   4     : USB 3.2 bit = 0  (supported)
+        //   3     : twoLanesSupported = 1
+        //   2     : opticallyIsolated = 1
+        //   1     : usb4AsymmetricMode = 1
+        //   0     : usbGen2+ = 1
+        var vdo: UInt32 = 0
+        vdo |= UInt32(100) << 24
+        vdo |= UInt32(120) << 16
+        vdo |= UInt32(0b011) << 12
+        vdo |= UInt32(1) << 11
+        vdo |= UInt32(1) << 10
+        vdo |= UInt32(1) << 9
+        // bit 8 left as 0 (USB4 supported)
+        vdo |= UInt32(0b10) << 6
+        // bits 5 and 4 left as 0 (USB 2.0 + USB 3.2 supported)
+        vdo |= UInt32(1) << 3
+        vdo |= UInt32(1) << 2
+        vdo |= UInt32(1) << 1
+        vdo |= UInt32(1)
+        let v2 = PDVDO.decodeActiveCableVDO2(vdo)
+        XCTAssertEqual(v2.maxOperatingTempC, 100)
+        XCTAssertEqual(v2.shutdownTempC, 120)
+        XCTAssertEqual(v2.u3CLdPower, .halfTo1mW)
+        XCTAssertTrue(v2.u3ToU0TransitionThroughU3S)
+        XCTAssertEqual(v2.physicalConnection, .optical)
+        XCTAssertEqual(v2.activeElement, .retimer)
+        XCTAssertTrue(v2.usb4Supported)
+        XCTAssertEqual(v2.usb2HubHopsConsumed, 2)
+        XCTAssertTrue(v2.usb2Supported)
+        XCTAssertTrue(v2.usb32Supported)
+        XCTAssertTrue(v2.twoLanesSupported)
+        XCTAssertTrue(v2.opticallyIsolated)
+        XCTAssertTrue(v2.usb4AsymmetricMode)
+        XCTAssertTrue(v2.usbGen2OrHigher)
+    }
+
+    func testDecodeActiveCableVDO2_AllZero() {
+        // All-zeros VDO. Counter-intuitive but spec-correct: the protocol
+        // "supported" bits read 0 = supported, so an all-zero VDO claims
+        // USB4, USB 3.2, and USB 2.0 are all supported.
+        let v2 = PDVDO.decodeActiveCableVDO2(0)
+        XCTAssertEqual(v2.maxOperatingTempC, 0)
+        XCTAssertEqual(v2.shutdownTempC, 0)
+        XCTAssertEqual(v2.u3CLdPower, .greaterThan10mW)
+        XCTAssertFalse(v2.u3ToU0TransitionThroughU3S)
+        XCTAssertEqual(v2.physicalConnection, .copper)
+        XCTAssertEqual(v2.activeElement, .redriver)
+        XCTAssertTrue(v2.usb4Supported)
+        XCTAssertTrue(v2.usb32Supported)
+        XCTAssertTrue(v2.usb2Supported)
+        XCTAssertEqual(v2.usb2HubHopsConsumed, 0)
+        XCTAssertFalse(v2.opticallyIsolated)
+    }
+
+    func testDecodeActiveCableVDO2_ProtocolBitsAreInverted() {
+        // Setting bits 8, 5, 4 all to 1 means "not supported."
+        var vdo: UInt32 = 0
+        vdo |= UInt32(1) << 8
+        vdo |= UInt32(1) << 5
+        vdo |= UInt32(1) << 4
+        let v2 = PDVDO.decodeActiveCableVDO2(vdo)
+        XCTAssertFalse(v2.usb4Supported, "bit 8 = 1 means USB4 NOT supported")
+        XCTAssertFalse(v2.usb2Supported, "bit 5 = 1 means USB 2.0 NOT supported")
+        XCTAssertFalse(v2.usb32Supported, "bit 4 = 1 means USB 3.2 NOT supported")
+    }
+
+    func testDecodeActiveCableVDO2_ReservedPower() {
+        // 111 in bits 14..12 maps to .reserved.
+        let vdo: UInt32 = UInt32(0b111) << 12
+        let v2 = PDVDO.decodeActiveCableVDO2(vdo)
+        XCTAssertEqual(v2.u3CLdPower, .reserved)
+    }
+
+    func testActiveCableVDO2AccessorRequiresActiveCable() {
+        // Passive cable (ufpProductType=3) shouldn't expose VDO2 even if
+        // vdos[4] is present.
+        let passive = PDIdentity(
+            id: 1,
+            endpoint: .sopPrime,
+            parentPortType: 2,
+            parentPortNumber: 1,
+            vendorID: 0x05AC,
+            productID: 0,
+            bcdDevice: 0,
+            vdos: [
+                (3 << 27) | UInt32(0x05AC),    // passive product type
+                0,
+                0,
+                UInt32(0b011) | UInt32(2 << 5) | (1 << 13), // valid passive cable VDO
+                0xDEADBEEF                    // would-be VDO2
+            ],
+            specRevision: 3
+        )
+        XCTAssertNil(passive.activeCableVDO2)
+    }
+
+    func testActiveCableVDO2AccessorWorksOnActiveCable() {
+        // Active cable (ufpProductType=4) with five VDOs.
+        let vdo3: UInt32 = UInt32(0b011) | UInt32(2 << 5) | (1 << 13) | (UInt32(0b10) << 11) // valid active termination
+        let vdo4: UInt32 = (1 << 10) | (1 << 9) | (1 << 2) // optical, re-timer, isolated
+        let active = PDIdentity(
+            id: 1,
+            endpoint: .sopPrime,
+            parentPortType: 2,
+            parentPortNumber: 1,
+            vendorID: 0x05AC,
+            productID: 0,
+            bcdDevice: 0,
+            vdos: [
+                (4 << 27) | UInt32(0x05AC),
+                0,
+                0,
+                vdo3,
+                vdo4
+            ],
+            specRevision: 3
+        )
+        let v2 = active.activeCableVDO2
+        XCTAssertNotNil(v2)
+        XCTAssertEqual(v2?.physicalConnection, .optical)
+        XCTAssertEqual(v2?.activeElement, .retimer)
+        XCTAssertEqual(v2?.opticallyIsolated, true)
+    }
+
+    func testActiveCableVDO2AccessorReturnsNilWhenVDO4Missing() {
+        // Active cable but only 4 VDOs (no VDO2 present).
+        let active = PDIdentity(
+            id: 1,
+            endpoint: .sopPrime,
+            parentPortType: 2,
+            parentPortNumber: 1,
+            vendorID: 0x05AC,
+            productID: 0,
+            bcdDevice: 0,
+            vdos: [
+                (4 << 27) | UInt32(0x05AC),
+                0,
+                0,
+                UInt32(0b011) | UInt32(2 << 5) | (1 << 13) | (UInt32(0b10) << 11)
+            ],
+            specRevision: 3
+        )
+        XCTAssertNil(active.activeCableVDO2)
+    }
+
     // MARK: - Cert Stat VDO
 
     func testCertStatPresentWhenNonZero() {


### PR DESCRIPTION
## Summary

Active cables carry a second Cable VDO at `vdos[4]` with information that doesn't fit in VDO1: physical medium, active element type, thermal limits, idle power, USB protocol support, lane count, and optical isolation. Until now WhatCable ignored it entirely and showed only a generic "active cable" line. This decodes the field and surfaces the user-relevant parts everywhere.

### What lands

- **`PDVDO.ActiveCableVDO2`** struct + `decodeActiveCableVDO2`. Includes enums for `PhysicalConnection` (copper/optical), `ActiveElement` (re-driver/re-timer), and `U3CLdPower` (idle-state power buckets per spec).
- **`PDIdentity.activeCableVDO2`** accessor. Only populated when the endpoint is `sopPrime` / `sopDoublePrime`, the ID Header reports active-cable, and `vdos.count > 4`.
- **Popover + CLI text** (via `PortSummary.bullets`): replaces "Active cable (contains signal-conditioning electronics)" with `"Active optical cable, re-timer"` / `"Active copper cable, re-driver"`, plus a follow-up note on isolation for optical cables.
- **JSON output**: new `cable.active` block with all decoded fields.

### Spec gotcha worth flagging

Bits 8 (USB4), 5 (USB 2.0), and 4 (USB 3.2) "Supported" in Table 6.44 are *inverted*. From the spec PDF (`reference/USB_PD_R3.2_V1.2.../Table 6.44`):

> 8 — USB4 Supported — `0b - [USB4] supported`, `1b - [USB4] not supported`

Same encoding for bits 5 and 4. The decoder inverts these so the public Swift API uses the conventional "true = supported" convention. A new test (`testDecodeActiveCableVDO2_ProtocolBitsAreInverted`) pins this explicitly.

Codex's first review flagged the inversion as a bug. A direct read of the spec confirmed Codex was wrong; a re-review with the corrected code came back clean. (Same pattern as #75, where Codex challenged passive `011` until cited against the spec.)

### Out of scope (Phase B follow-up)

- **H9b** (active optical cable claiming optical but reporting `Optically Isolated = 0`). The decoder now exposes both fields, so the cross-field check is straightforward to add. Holding off until we have field reports — some optical cables intentionally ship copper power alongside the fibres and would set `isolated = 0` legitimately.
- Surfacing temps, idle power, lane count in the UI. The data lands in JSON for now; UI decisions can be a separate, smaller PR.

## Test plan

- [x] `swift test` — 244/244 green (10 new tests).
- [x] `swift build` clean.
- [x] `WHATCABLE_MAS=1 swift build --product WhatCable` clean.
- [x] `swift run whatcable-cli` against live ports renders without regressions.
- [x] Codex review: clean after inversion fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
