### PR TITLE
Group PortSummary bullets by user mental model

### DIFF
--- a/Sources/WhatCableCore/PortSummary.swift
+++ b/Sources/WhatCableCore/PortSummary.swift
@@ -75,7 +75,27 @@ extension PortSummary {
 
         var bullets: [String] = []
 
-        // Speed
+        // Bullets are grouped by the question the user is mentally asking,
+        // so related facts sit next to each other:
+        //
+        //   A. What's happening on this port and what's plugged in?
+        //      - link speed / Thunderbolt link
+        //      - DisplayPort note
+        //      - connected device
+        //   B. What does the cable advertise?
+        //      - e-marker presence
+        //      - cable speed and power rating
+        //      - active-cable details (medium, element, isolation)
+        //      - port-level optical flag
+        //      - cable maker
+        //   C. What does the power negotiation look like?
+        //      - charger max
+        //      - currently negotiated PDO
+
+        // ------------------------------------------------------------
+        // A. Live link / what's plugged in
+        // ------------------------------------------------------------
+
         if hasTB {
             // If we have a matching Thunderbolt switch graph for this port,
             // emit specific link-state bullets (negotiated speed, lane
@@ -97,12 +117,23 @@ extension PortSummary {
             bullets.append("Carrying DisplayPort video")
         }
 
-        // E-marker. The whole cable-details bullet only makes sense on
-        // USB-C, where the user can swap cables and might wonder why
-        // details are missing. On MagSafe the cable is part of the brick
-        // (and MagSafe absolutely does negotiate Power Delivery, just over
-        // its own pins, not the CC line we test for `pdCapable`), so don't
-        // emit any "no e-marker" wording there.
+        // Partner identity (SOP): what's connected.
+        if let partner = identities.first(where: { $0.endpoint == .sop }),
+           let header = partner.idHeader {
+            let kind = header.ufpProductType != .undefined ? header.ufpProductType.label : header.dfpProductType.label
+            bullets.append("Connected device: \(kind) — \(VendorDB.label(for: partner.vendorID))")
+        }
+
+        // ------------------------------------------------------------
+        // B. The cable
+        // ------------------------------------------------------------
+
+        // E-marker presence. The whole cable-details bullet only makes
+        // sense on USB-C, where the user can swap cables and might wonder
+        // why details are missing. On MagSafe the cable is part of the
+        // brick (and MagSafe absolutely does negotiate Power Delivery,
+        // just over its own pins, not the CC line we test for
+        // `pdCapable`), so don't emit any "no e-marker" wording there.
         let isMagSafe = port.portTypeDescription?.hasPrefix("MagSafe") == true
         if hasEmarker {
             bullets.append("Cable has an e-marker chip (advertises its capabilities)")
@@ -114,24 +145,7 @@ extension PortSummary {
             }
         }
 
-        if port.opticalCable == true {
-            bullets.append("Optical cable")
-        }
-
-        // Power summary from PD or MagSafe power sources.
-        let chargingSource = PowerSource.preferredChargingSource(in: sources)
-        if let chargingSource {
-            let maxW = Int((Double(chargingSource.maxPowerMW) / 1000).rounded())
-            let hasOptions = !chargingSource.options.isEmpty
-            if hasOptions && maxW > 0 {
-                bullets.append("Charger advertises up to \(maxW)W")
-            }
-            if let win = chargingSource.winning {
-                bullets.append("Currently negotiated: \(win.voltsLabel) @ \(win.ampsLabel) (\(win.wattsLabel))")
-            }
-        }
-
-        // Cable e-marker (SOP'): the cable's own capabilities
+        // Cable e-marker (SOP'): the cable's own capabilities.
         let cableEmarker = identities.first(where: {
             $0.endpoint == .sopPrime || $0.endpoint == .sopDoublePrime
         })
@@ -157,16 +171,32 @@ extension PortSummary {
             }
         }
 
-        // Partner identity (SOP): what's connected
-        if let partner = identities.first(where: { $0.endpoint == .sop }),
-           let header = partner.idHeader {
-            let kind = header.ufpProductType != .undefined ? header.ufpProductType.label : header.dfpProductType.label
-            bullets.append("Connected device: \(kind) — \(VendorDB.label(for: partner.vendorID))")
+        // Port-level optical flag. Independent of the e-marker's claim;
+        // kept on its own line for now so users can see both signals.
+        if port.opticalCable == true {
+            bullets.append("Optical cable")
         }
 
-        // Cable e-marker vendor (SOP'): who made the cable
+        // Cable e-marker vendor (SOP'): who made the cable.
         if let cable = cableEmarker, cable.vendorID != 0 {
             bullets.append("Cable made by \(VendorDB.label(for: cable.vendorID))")
+        }
+
+        // ------------------------------------------------------------
+        // C. Charging numbers
+        // ------------------------------------------------------------
+
+        // Power summary from PD or MagSafe power sources.
+        let chargingSource = PowerSource.preferredChargingSource(in: sources)
+        if let chargingSource {
+            let maxW = Int((Double(chargingSource.maxPowerMW) / 1000).rounded())
+            let hasOptions = !chargingSource.options.isEmpty
+            if hasOptions && maxW > 0 {
+                bullets.append("Charger advertises up to \(maxW)W")
+            }
+            if let win = chargingSource.winning {
+                bullets.append("Currently negotiated: \(win.voltsLabel) @ \(win.ampsLabel) (\(win.wattsLabel))")
+            }
         }
 
         // Headline + status

--- a/Tests/WhatCableCoreTests/PortSummaryTests.swift
+++ b/Tests/WhatCableCoreTests/PortSummaryTests.swift
@@ -267,4 +267,68 @@ final class PortSummaryTests: XCTestCase {
             "expected a negotiated PDO bullet, got: \(summary.bullets)"
         )
     }
+
+    // MARK: - Bullet ordering / grouping
+
+    /// Pins the three-block grouping in the bullet list. Concrete
+    /// expectation: link state and connected device come before any
+    /// cable-specific lines, and cable-specific lines come before the
+    /// charger-power numbers. Refactors that move bullets between these
+    /// blocks should fail this test.
+    func testBulletsAreGroupedLinkThenCableThenPower() {
+        let port = makePort(active: ["USB3"], superSpeed: true)
+        let cable = PDIdentity(
+            id: 99, endpoint: .sopPrime,
+            parentPortType: 2, parentPortNumber: 1,
+            vendorID: 0x05AC, productID: 0, bcdDevice: 0,
+            vdos: [
+                (3 << 27) | UInt32(0x05AC),
+                0,
+                0,
+                UInt32(0b011) | UInt32(2 << 5) | UInt32(1 << 13) // USB4 Gen3, 5A, ~1m
+            ],
+            specRevision: 3
+        )
+        let partner = PDIdentity(
+            id: 100, endpoint: .sop,
+            parentPortType: 2, parentPortNumber: 1,
+            vendorID: 0x05AC, productID: 0, bcdDevice: 0,
+            vdos: [(2 << 27) | UInt32(0x05AC)], // USB Peripheral
+            specRevision: 3
+        )
+        let summary = PortSummary(
+            port: port,
+            sources: [usbPD(maxW: 96, winningW: 60)],
+            identities: [cable, partner]
+        )
+
+        func index(_ predicate: (String) -> Bool) -> Int? {
+            summary.bullets.firstIndex(where: predicate)
+        }
+
+        let speedIdx = index { $0.contains("SuperSpeed USB") }
+        let deviceIdx = index { $0.contains("Connected device") }
+        let cableSpeedIdx = index { $0.contains("Cable speed") }
+        let cableMakerIdx = index { $0.contains("Cable made by") }
+        let chargerIdx = index { $0.contains("Charger advertises") }
+        let negotiatedIdx = index { $0.contains("Currently negotiated") }
+
+        XCTAssertNotNil(speedIdx)
+        XCTAssertNotNil(deviceIdx)
+        XCTAssertNotNil(cableSpeedIdx)
+        XCTAssertNotNil(cableMakerIdx)
+        XCTAssertNotNil(chargerIdx)
+        XCTAssertNotNil(negotiatedIdx)
+
+        // A: link + connected device come first
+        XCTAssertLessThan(speedIdx!, deviceIdx!, "Speed should come before connected device")
+        XCTAssertLessThan(deviceIdx!, cableSpeedIdx!, "Connected device should come before cable details")
+
+        // B: cable details (speed -> maker) come before power numbers
+        XCTAssertLessThan(cableSpeedIdx!, cableMakerIdx!, "Cable speed should come before cable maker")
+        XCTAssertLessThan(cableMakerIdx!, chargerIdx!, "Cable maker should come before charger numbers")
+
+        // C: power negotiation tail
+        XCTAssertLessThan(chargerIdx!, negotiatedIdx!, "Charger max should come before currently negotiated")
+    }
 }


### PR DESCRIPTION
## Summary

The bullet order grew organically as new fields were added. Things that read together ended up scattered: e-marker presence near the top, cable speed/rating much lower; cable maker line all alone at the bottom; charger numbers between e-marker and cable details; connected device buried near the end.

This regroups the bullets into three blocks the user mentally asks about:

**A. Live link / what's plugged in**
- speed (TB / USB3 / USB2)
- DisplayPort
- connected device

**B. The cable**
- e-marker presence
- cable speed
- cable rating (current / volts / watts)
- active cable details (medium + element)
- optical isolation note
- port-level optical flag
- cable maker

**C. Charging numbers**
- charger advertises up to NW
- currently negotiated PDO

No string changes, no new fields, no behaviour changes. Existing tests all pass because they use order-independent `contains`.

## Test plan

- [x] `swift test` — 245/245 green (1 new ordering test).
- [x] `swift build` clean.
- [x] `WHATCABLE_MAS=1 swift build --product WhatCable` clean.
- [x] New `testBulletsAreGroupedLinkThenCableThenPower` pins the three-block structure so future refactors can't drift it.
- [x] Codex review: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
