### PR TITLE
Surface Active Cable VDO 2 fields in advanced view

### DIFF
--- a/Sources/WhatCable/ContentView.swift
+++ b/Sources/WhatCable/ContentView.swift
@@ -512,7 +512,11 @@ struct PortCard: View {
 
             if showAdvanced {
                 Divider()
-                AdvancedPortDetails(port: port, thunderboltChain: thunderboltChain)
+                AdvancedPortDetails(
+                    port: port,
+                    cableEmarker: cableEmarker,
+                    thunderboltChain: thunderboltChain
+                )
             }
         }
         .padding(14)
@@ -581,6 +585,7 @@ struct PowerSourceList: View {
 
 struct AdvancedPortDetails: View {
     let port: USBCPort
+    let cableEmarker: PDIdentity?
     let thunderboltChain: [ThunderboltSwitch]
 
     var body: some View {
@@ -597,6 +602,9 @@ struct AdvancedPortDetails: View {
                 row("Supported", port.transportsSupported.joined(separator: ", "))
                 row("Provisioned", port.transportsProvisioned.joined(separator: ", "))
                 row("Active", port.transportsActive.isEmpty ? "—" : port.transportsActive.joined(separator: ", "))
+            }
+            if let v2 = cableEmarker?.activeCableVDO2 {
+                ActiveCableVDO2Section(vdo2: v2)
             }
             if !thunderboltChain.isEmpty {
                 ThunderboltFabricSection(chain: thunderboltChain)
@@ -638,6 +646,54 @@ struct AdvancedPortDetails: View {
     private func bool(_ v: Bool?) -> String {
         guard let v else { return "—" }
         return v ? "Yes" : "No"
+    }
+}
+
+/// Renders every field in Active Cable VDO 2. Hidden behind the
+/// existing "show technical details" toggle. The bullet list above the
+/// fold already surfaces the user-facing essentials (medium, active
+/// element, optical isolation), so this section is the deep view for
+/// people who want to see USB protocol support, lane count, idle power,
+/// thermal limits, etc.
+struct ActiveCableVDO2Section: View {
+    let vdo2: PDVDO.ActiveCableVDO2
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text("Active cable (VDO 2)")
+                .scaledFont(.caption, weight: .bold)
+                .foregroundStyle(.secondary)
+            row("Physical connection", vdo2.physicalConnection.label)
+            row("Active element", vdo2.activeElement.label)
+            row("Optically isolated", bool(vdo2.opticallyIsolated))
+            row("USB lanes", vdo2.twoLanesSupported ? "Two" : "One")
+            row("USB Gen", vdo2.usbGen2OrHigher ? "Gen 2 or higher" : "Gen 1")
+            row("USB4 supported", bool(vdo2.usb4Supported))
+            row("USB 3.2 supported", bool(vdo2.usb32Supported))
+            row("USB 2.0 supported", bool(vdo2.usb2Supported))
+            row("USB 2.0 hub hops", String(vdo2.usb2HubHopsConsumed))
+            row("USB4 asymmetric", bool(vdo2.usb4AsymmetricMode))
+            row("U3 to U0 transition", vdo2.u3ToU0TransitionThroughU3S ? "Through U3S" : "Direct")
+            row("Idle power (U3/CLd)", vdo2.u3CLdPower.label)
+            row("Max operating temp", temp(vdo2.maxOperatingTempC))
+            row("Shutdown temp", temp(vdo2.shutdownTempC))
+        }
+    }
+
+    private func row(_ key: String, _ value: String) -> some View {
+        HStack {
+            Text(key).scaledFont(.caption).foregroundStyle(.secondary).frame(width: 160, alignment: .leading)
+            Text(value).scaledFont(.caption, design: .monospaced)
+            Spacer()
+        }
+    }
+
+    private func bool(_ v: Bool) -> String { v ? "Yes" : "No" }
+
+    /// 0 in this field means "not specified" per the spec text. Show
+    /// the dash placeholder rather than the misleading literal "0°C".
+    private func temp(_ v: Int) -> String {
+        v == 0 ? "—" : "\(v)°C"
     }
 }
 

--- a/Sources/WhatCableCore/TextFormatter.swift
+++ b/Sources/WhatCableCore/TextFormatter.swift
@@ -81,6 +81,30 @@ public enum TextFormatter {
         }
 
         if showRaw {
+            // Active Cable VDO 2 deep view: every decoded field. Surfaced
+            // here (not in the bullet list) because most users don't care
+            // about idle power or thermal limits, but engineers diagnosing
+            // a cable do.
+            if let cable = identities.first(where: {
+                $0.endpoint == .sopPrime || $0.endpoint == .sopDoublePrime
+            }), let v2 = cable.activeCableVDO2 {
+                out += "\n" + ANSI.wrap(ANSI.bold, "Active cable (VDO 2):") + "\n"
+                out += rawRow("Physical connection", v2.physicalConnection.label)
+                out += rawRow("Active element", v2.activeElement.label)
+                out += rawRow("Optically isolated", yesNo(v2.opticallyIsolated))
+                out += rawRow("USB lanes", v2.twoLanesSupported ? "Two" : "One")
+                out += rawRow("USB Gen", v2.usbGen2OrHigher ? "Gen 2 or higher" : "Gen 1")
+                out += rawRow("USB4 supported", yesNo(v2.usb4Supported))
+                out += rawRow("USB 3.2 supported", yesNo(v2.usb32Supported))
+                out += rawRow("USB 2.0 supported", yesNo(v2.usb2Supported))
+                out += rawRow("USB 2.0 hub hops", String(v2.usb2HubHopsConsumed))
+                out += rawRow("USB4 asymmetric", yesNo(v2.usb4AsymmetricMode))
+                out += rawRow("U3 to U0 transition", v2.u3ToU0TransitionThroughU3S ? "Through U3S" : "Direct")
+                out += rawRow("Idle power (U3/CLd)", v2.u3CLdPower.label)
+                out += rawRow("Max operating temp", tempLabel(v2.maxOperatingTempC))
+                out += rawRow("Shutdown temp", tempLabel(v2.shutdownTempC))
+            }
+
             out += "\n" + ANSI.wrap(ANSI.bold, "Raw IOKit properties:") + "\n"
             for key in port.rawProperties.keys.sorted() {
                 let value = port.rawProperties[key] ?? ""
@@ -89,6 +113,17 @@ public enum TextFormatter {
         }
 
         return out
+    }
+
+    private static func rawRow(_ key: String, _ value: String) -> String {
+        "  " + ANSI.wrap(ANSI.gray, key) + " = \(value)\n"
+    }
+
+    private static func yesNo(_ v: Bool) -> String { v ? "Yes" : "No" }
+
+    /// 0 in the temperature fields means "not specified" per the spec.
+    private static func tempLabel(_ v: Int) -> String {
+        v == 0 ? "—" : "\(v)°C"
     }
 
     private static func color(for status: PortSummary.Status) -> String {

--- a/Tests/WhatCableCoreTests/TextFormatterTests.swift
+++ b/Tests/WhatCableCoreTests/TextFormatterTests.swift
@@ -139,6 +139,54 @@ final class TextFormatterTests: XCTestCase {
         XCTAssertTrue(output.contains(TrustFlag.reservedSpeedEncoding(7).title))
     }
 
+    // MARK: - Active Cable VDO 2 raw view
+
+    func testActiveCableVDO2SectionAppearsInRawMode() {
+        let port = makePort()
+        // VDO2 with optical + retimer + isolated + USB4 supported (bit 8 = 0).
+        var vdo4: UInt32 = 0
+        vdo4 |= UInt32(1) << 10  // optical
+        vdo4 |= UInt32(1) << 9   // retimer
+        vdo4 |= UInt32(1) << 2   // isolated
+        // bits 8 / 5 / 4 left at 0 = USB4 / USB 3.2 / USB 2.0 supported.
+        let vdo3: UInt32 = UInt32(0b011) | UInt32(2 << 5) | UInt32(1 << 13) | UInt32(0b10 << 11)
+        let active = PDIdentity(
+            id: 1, endpoint: .sopPrime,
+            parentPortType: 2,
+            parentPortNumber: port.portNumber ?? 1,
+            vendorID: 0x05AC, productID: 0, bcdDevice: 0,
+            vdos: [(4 << 27) | UInt32(0x05AC), 0, 0, vdo3, vdo4],
+            specRevision: 3
+        )
+        let output = TextFormatter.render(
+            ports: [port], sources: [], identities: [active], showRaw: true
+        )
+        XCTAssertTrue(output.contains("Active cable (VDO 2)"))
+        XCTAssertTrue(output.contains("Physical connection") && output.contains("Optical"))
+        XCTAssertTrue(output.contains("Active element") && output.contains("Re-timer"))
+        XCTAssertTrue(output.contains("USB4 supported") && output.contains("Yes"))
+    }
+
+    func testActiveCableVDO2SectionAbsentWithoutRawFlag() {
+        let port = makePort()
+        let vdo3: UInt32 = UInt32(0b011) | UInt32(2 << 5) | UInt32(1 << 13) | UInt32(0b10 << 11)
+        let active = PDIdentity(
+            id: 1, endpoint: .sopPrime,
+            parentPortType: 2,
+            parentPortNumber: port.portNumber ?? 1,
+            vendorID: 0x05AC, productID: 0, bcdDevice: 0,
+            vdos: [(4 << 27) | UInt32(0x05AC), 0, 0, vdo3, 0],
+            specRevision: 3
+        )
+        let output = TextFormatter.render(
+            ports: [port], sources: [], identities: [active], showRaw: false
+        )
+        XCTAssertFalse(
+            output.contains("Active cable (VDO 2)"),
+            "VDO 2 deep view should only render with --raw"
+        )
+    }
+
     func testTrustSignalsSuppressedForNonCableEndpoint() {
         // SOP (port partner) shouldn't be evaluated as a cable, so even
         // a zero VID on a port-partner identity shouldn't trip the section.


### PR DESCRIPTION
## Summary

#76 decoded Active Cable VDO 2 and surfaced the user-facing essentials (medium, active element, optical isolation) in the bullet list. This adds the **deep view** behind the existing "show technical details" toggle in the popover and the `whatcable --raw` flag in the CLI, so engineers diagnosing a cable can see every decoded field at a glance.

### What lands

**GUI**: new `ActiveCableVDO2Section` view rendered inside `AdvancedPortDetails` when the cable's e-marker has VDO 2 data. `AdvancedPortDetails` gains a `cableEmarker` parameter so it doesn't have to dig the identity out of port state.

**CLI**: new `"Active cable (VDO 2):"` block under `whatcable --raw`, mirroring the GUI section.

**Fields surfaced**:
- Physical connection (Copper / Optical)
- Active element (Re-driver / Re-timer)
- Optically isolated
- USB lane count
- USB Gen
- USB4 / USB 3.2 / USB 2.0 supported
- USB 2.0 hub hops consumed
- USB4 asymmetric mode
- U3 to U0 transition mode
- Idle power (U3/CLd)
- Max operating temperature
- Shutdown temperature

Temperature fields render as `—` when the value is `0`, since the spec text treats `0` as "not specified" rather than the literal "0°C."

## Test plan

- [x] `swift test` — 247/247 green (2 new TextFormatter tests for `--raw` on/off behaviour).
- [x] `swift build` clean.
- [x] `WHATCABLE_MAS=1 swift build --product WhatCable` clean.
- [x] Codex review: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
