### PR TITLE
Show cable wattage limit in headline when below charger

### DIFF
--- a/Sources/WhatCableCore/PortSummary.swift
+++ b/Sources/WhatCableCore/PortSummary.swift
@@ -209,29 +209,43 @@ extension PortSummary {
         }()
         let chargerSuffix = chargerW.map { " · \($0)W charger" } ?? ""
 
+        // Cable limit suffix: only emitted when the cable's e-marker
+        // reports a maxWatts that is strictly less than what the charger
+        // advertises. The diagnostic banner already explains this in
+        // detail when a cable is plugged in; the headline suffix is the
+        // at-a-glance equivalent so the user can spot a cable mismatch
+        // without reading further.
+        let cableLimitSuffix: String = {
+            guard let chargerW,
+                  let cableW = cableEmarker?.cableVDO?.maxWatts,
+                  cableW > 0,
+                  cableW < chargerW else { return "" }
+            return " · \(cableW)W cable"
+        }()
+
         if hasTB {
             self.status = .thunderboltCable
-            self.headline = "Thunderbolt / USB4" + chargerSuffix
+            self.headline = "Thunderbolt / USB4" + chargerSuffix + cableLimitSuffix
             self.subtitle = subtitleForCapabilities(usb3: true, dp: hasDP, emarker: hasEmarker)
         } else if hasUSB3 && hasDP {
             self.status = .displayCable
-            self.headline = "USB-C with video" + chargerSuffix
+            self.headline = "USB-C with video" + chargerSuffix + cableLimitSuffix
             self.subtitle = "Carrying both data and DisplayPort video."
         } else if hasDP {
             self.status = .displayCable
-            self.headline = "Display connected" + chargerSuffix
+            self.headline = "Display connected" + chargerSuffix + cableLimitSuffix
             self.subtitle = "DisplayPort video over USB-C alt mode."
         } else if hasUSB3 {
             self.status = .dataDevice
-            self.headline = "USB device" + chargerSuffix
+            self.headline = "USB device" + chargerSuffix + cableLimitSuffix
             self.subtitle = "SuperSpeed data link is active."
         } else if hasUSB2 && !hasUSB3 {
             self.status = .dataDevice
-            self.headline = "Slow USB device or charge-only cable" + chargerSuffix
+            self.headline = "Slow USB device or charge-only cable" + chargerSuffix + cableLimitSuffix
             self.subtitle = "Only USB 2.0 is active. If you expected high speed, the cable may not support it."
         } else if chargingSource != nil {
             self.status = .charging
-            self.headline = "Charging" + chargerSuffix
+            self.headline = "Charging" + chargerSuffix + cableLimitSuffix
             self.subtitle = "Power is flowing. No data connection."
         } else if active.isEmpty && supported.contains("USB2") {
             self.status = .charging

--- a/Tests/WhatCableCoreTests/PortSummaryTests.swift
+++ b/Tests/WhatCableCoreTests/PortSummaryTests.swift
@@ -268,6 +268,69 @@ final class PortSummaryTests: XCTestCase {
         )
     }
 
+    // MARK: - Cable wattage limit suffix
+
+    /// Helper: build an SOP' cable identity with the given current bits.
+    /// Uses USB4 Gen 3 (3) as the speed baseline and a valid latency.
+    /// `currentBits = 1` => 3A (60W); `currentBits = 2` => 5A (100W).
+    private func cableIdentity(currentBits: Int) -> PDIdentity {
+        let vdo: UInt32 = UInt32(0b011) | UInt32(currentBits << 5) | UInt32(1 << 13)
+        return PDIdentity(
+            id: 99, endpoint: .sopPrime,
+            parentPortType: 2, parentPortNumber: 1,
+            vendorID: 0x05AC, productID: 0, bcdDevice: 0,
+            vdos: [(3 << 27) | UInt32(0x05AC), 0, 0, vdo],
+            specRevision: 3
+        )
+    }
+
+    func testCableLimitSuffixAppearsWhenCableUnderAdvertised() {
+        // Charger says 96W; cable rated 60W (3A * 20V).
+        let port = makePort(active: ["USB3"], superSpeed: true)
+        let summary = PortSummary(
+            port: port,
+            sources: [usbPD(maxW: 96, winningW: 60)],
+            identities: [cableIdentity(currentBits: 1)]
+        )
+        XCTAssertEqual(summary.headline, "USB device · 96W charger · 60W cable")
+    }
+
+    func testCableLimitSuffixAbsentWhenCableMatchesCharger() {
+        // Charger 96W, cable 100W (5A * 20V): cable can carry full power.
+        let port = makePort(active: ["CIO"], superSpeed: true)
+        let summary = PortSummary(
+            port: port,
+            sources: [usbPD(maxW: 96, winningW: 60)],
+            identities: [cableIdentity(currentBits: 2)]
+        )
+        XCTAssertEqual(summary.headline, "Thunderbolt / USB4 · 96W charger")
+    }
+
+    func testCableLimitSuffixAbsentWhenNoCharger() {
+        // No charger: nothing to compare against, so no cable suffix.
+        let port = makePort(active: ["USB3"], superSpeed: true)
+        let summary = PortSummary(port: port, identities: [cableIdentity(currentBits: 1)])
+        XCTAssertEqual(summary.headline, "USB device")
+    }
+
+    func testCableLimitSuffixAbsentWhenNoCable() {
+        // No e-marker: no cable wattage to surface.
+        let port = makePort(active: ["USB3"], superSpeed: true)
+        let summary = PortSummary(port: port, sources: [usbPD(maxW: 96, winningW: 60)])
+        XCTAssertEqual(summary.headline, "USB device · 96W charger")
+    }
+
+    func testCableLimitSuffixOnChargingOnlyHeadline() {
+        // The charging-only state path also gets the suffix when relevant.
+        let port = makePort(connected: true, active: [], supported: ["USB2"])
+        let summary = PortSummary(
+            port: port,
+            sources: [usbPD(maxW: 96, winningW: 60)],
+            identities: [cableIdentity(currentBits: 1)]
+        )
+        XCTAssertEqual(summary.headline, "Charging · 96W charger · 60W cable")
+    }
+
     // MARK: - Bullet ordering / grouping
 
     /// Pins the three-block grouping in the bullet list. Concrete


### PR DESCRIPTION
## Summary

The headline already credits the charger when there is one (`· 96W charger`). Until now there has been no equivalent at-a-glance signal when the cable can't carry that wattage. The diagnostic banner spells out the mismatch when something is plugged in, but the user has to read past the headline to see it.

Append `· NW cable` to the headline when:

- the charger advertises a wattage (chargerW > 0), AND
- the cable's e-marker reports a maxWatts > 0, AND
- the cable's maxWatts < chargerW

Examples:
- `Thunderbolt / USB4 · 96W charger · 60W cable` &mdash; charger can deliver 96W, cable is rated 60W
- `Thunderbolt / USB4 · 96W charger` &mdash; cable matches or exceeds the charger; no extra noise
- `USB device` &mdash; no charger to compare against; nothing to say

Suffix is suppressed when the cable matches or exceeds the charger (no information to add) and when either side is unknown (don't claim a mismatch we can't substantiate). MagSafe cables don't carry e-markers, so this only ever fires on USB-C ports.

## Test plan

- [x] `swift test` &mdash; 250/250 green (5 new tests covering each suppression path).
- [x] `swift build` clean.
- [x] `WHATCABLE_MAS=1 swift build --product WhatCable` clean.
- [x] Codex review: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
