### PR TITLE
Add localisation infrastructure with Swift String Catalogs

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,6 +16,7 @@ let appSwiftSettings: [SwiftSetting] = isMASBuild ? [.define("WHATCABLE_MAS")] :
 
 let package = Package(
     name: "WhatCable",
+    defaultLocalization: "en",
     platforms: [.macOS(.v14)],
     products: [
         // Explicit executable product so the binary name (whatcable-cli)
@@ -40,6 +41,7 @@ let package = Package(
             name: "WhatCable",
             dependencies: ["WhatCableCore", "WhatCableDarwinBackend"],
             path: "Sources/WhatCable",
+            resources: [.process("Resources")],
             swiftSettings: appSwiftSettings
         ),
         .executableTarget(

--- a/Sources/WhatCable/App.swift
+++ b/Sources/WhatCable/App.swift
@@ -13,24 +13,24 @@ struct WhatCableApp: App {
         Settings { EmptyView() }
             .commands {
                 CommandGroup(replacing: .appInfo) {
-                    Button("About \(AppInfo.name)") {
+                    Button(String(localized: "About \(AppInfo.name)", bundle: .module)) {
                         delegate.showAboutPanel()
                     }
                 }
                 #if !WHATCABLE_MAS
                 CommandGroup(after: .appInfo) {
-                    Button("Check for Updates…") {
+                    Button(String(localized: "Check for Updates…", bundle: .module)) {
                         UpdateChecker.shared.check(silent: false)
                     }
                 }
                 #endif
                 CommandGroup(replacing: .help) {
-                    Button("WhatCable on GitHub") {
+                    Button(String(localized: "WhatCable on GitHub", bundle: .module)) {
                         NSWorkspace.shared.open(AppInfo.helpURL)
                     }
                 }
                 CommandGroup(replacing: .appSettings) {
-                    Button("Settings…") {
+                    Button(String(localized: "Settings…", bundle: .module)) {
                         delegate.showSettingsPanel(nil)
                     }
                     .keyboardShortcut(",", modifiers: .command)
@@ -186,20 +186,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate, NSW
     private func showMenu(from button: NSStatusBarButton) {
         guard let statusItem else { return }
         let menu = NSMenu()
-        menu.addItem(.init(title: "Refresh", action: #selector(menuRefresh), keyEquivalent: "r"))
-        let pinItem = NSMenuItem(title: "Keep window open", action: #selector(menuTogglePin), keyEquivalent: "p")
+        menu.addItem(.init(title: String(localized: "Refresh", bundle: .module), action: #selector(menuRefresh), keyEquivalent: "r"))
+        let pinItem = NSMenuItem(title: String(localized: "Keep window open", bundle: .module), action: #selector(menuTogglePin), keyEquivalent: "p")
         pinItem.state = isPinned ? .on : .off
         menu.addItem(pinItem)
         menu.addItem(.separator())
-        menu.addItem(.init(title: "Settings…", action: #selector(menuSettings), keyEquivalent: ","))
+        menu.addItem(.init(title: String(localized: "Settings…", bundle: .module), action: #selector(menuSettings), keyEquivalent: ","))
         #if !WHATCABLE_MAS
-        menu.addItem(.init(title: "Check for Updates…", action: #selector(menuCheckUpdates), keyEquivalent: ""))
+        menu.addItem(.init(title: String(localized: "Check for Updates…", bundle: .module), action: #selector(menuCheckUpdates), keyEquivalent: ""))
         #endif
         menu.addItem(.separator())
-        menu.addItem(.init(title: "About \(AppInfo.name)", action: #selector(showAboutPanel), keyEquivalent: ""))
-        menu.addItem(.init(title: "WhatCable on GitHub", action: #selector(menuHelp), keyEquivalent: ""))
+        menu.addItem(.init(title: String(localized: "About \(AppInfo.name)", bundle: .module), action: #selector(showAboutPanel), keyEquivalent: ""))
+        menu.addItem(.init(title: String(localized: "WhatCable on GitHub", bundle: .module), action: #selector(menuHelp), keyEquivalent: ""))
         menu.addItem(.separator())
-        menu.addItem(.init(title: "Quit \(AppInfo.name)", action: #selector(menuQuit), keyEquivalent: "q"))
+        menu.addItem(.init(title: String(localized: "Quit \(AppInfo.name)", bundle: .module), action: #selector(menuQuit), keyEquivalent: "q"))
         for item in menu.items where item.action != nil { item.target = self }
 
         statusItem.menu = menu
@@ -242,8 +242,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate, NSW
 
     @objc func showAboutPanel() {
         NSApp.activate(ignoringOtherApps: true)
+        let creditText = String(localized: "Built by \(AppInfo.credit).", bundle: .module)
         let credits = NSAttributedString(
-            string: "\(AppInfo.tagline)\n\nBuilt by \(AppInfo.credit).",
+            string: "\(AppInfo.tagline)\n\n\(creditText)",
             attributes: [
                 .foregroundColor: NSColor.labelColor,
                 .font: NSFont.systemFont(ofSize: 11)

--- a/Sources/WhatCable/CableReportSheet.swift
+++ b/Sources/WhatCable/CableReportSheet.swift
@@ -23,14 +23,14 @@ struct CableReportSheet: View {
                     .font(.title2)
                     .foregroundStyle(.tint)
                 VStack(alignment: .leading, spacing: 2) {
-                    Text("Report this cable").font(.title3).bold()
-                    Text("Opens a pre-filled GitHub issue in your browser. Nothing is sent until you submit there.")
+                    Text(String(localized: "Report this cable", bundle: .module)).font(.title3).bold()
+                    Text(String(localized: "Opens a pre-filled GitHub issue in your browser. Nothing is sent until you submit there.", bundle: .module))
                         .font(.callout)
                         .foregroundStyle(.secondary)
                 }
             }
 
-            Text("Preview of what will be included:")
+            Text(String(localized: "Preview of what will be included:", bundle: .module))
                 .font(.caption).foregroundStyle(.secondary)
 
             if let payload {
@@ -47,8 +47,8 @@ struct CableReportSheet: View {
 
             Toggle(isOn: $includeSystemInfo) {
                 VStack(alignment: .leading, spacing: 2) {
-                    Text("Include Mac model and macOS version")
-                    Text("Helps the maintainer reproduce charger / cable behavior tied to specific hardware.")
+                    Text(String(localized: "Include Mac model and macOS version", bundle: .module))
+                    Text(String(localized: "Helps the maintainer reproduce charger / cable behavior tied to specific hardware.", bundle: .module))
                         .font(.caption).foregroundStyle(.secondary)
                 }
             }
@@ -57,12 +57,12 @@ struct CableReportSheet: View {
             Divider()
 
             HStack {
-                Link("What gets shared?", destination: URL(string: "https://github.com/darrylmorley/whatcable#privacy")!)
+                Link(String(localized: "What gets shared?", bundle: .module), destination: URL(string: "https://github.com/darrylmorley/whatcable#privacy")!)
                     .font(.caption)
                 Spacer()
-                Button("Cancel", action: dismiss)
+                Button(String(localized: "Cancel", bundle: .module), action: dismiss)
                     .keyboardShortcut(.cancelAction)
-                Button("Open in GitHub") {
+                Button(String(localized: "Open in GitHub", bundle: .module)) {
                     if let url = payload?.githubURL {
                         NSWorkspace.shared.open(url)
                     }

--- a/Sources/WhatCable/ContentView.swift
+++ b/Sources/WhatCable/ContentView.swift
@@ -221,14 +221,14 @@ struct ContentView: View {
                 Image(systemName: "arrow.clockwise")
             }
             .buttonStyle(.borderless)
-            .help("Refresh")
+            .help(String(localized: "Refresh", bundle: .module))
             Button {
                 refresh.showSettings = true
             } label: {
                 Image(systemName: "gearshape")
             }
             .buttonStyle(.borderless)
-            .help("Settings")
+            .help(String(localized: "Settings", bundle: .module))
         }
         .padding(12)
         .background(
@@ -243,16 +243,16 @@ struct ContentView: View {
 
     private var footer: some View {
         HStack {
-            Button("Quit") { NSApplication.shared.terminate(nil) }
+            Button(String(localized: "Quit", bundle: .module)) { NSApplication.shared.terminate(nil) }
                 .buttonStyle(.borderless)
                 .scaledFont(.caption)
                 .foregroundStyle(.secondary)
             Spacer()
-            Text("\(deviceWatcher.devices.count) USB device\(deviceWatcher.devices.count == 1 ? "" : "s")")
+            Text(String(localized: "\(deviceWatcher.devices.count) USB devices", bundle: .module))
                 .scaledFont(.caption)
                 .foregroundStyle(.secondary)
-            Text("·").scaledFont(.caption).foregroundStyle(.secondary)
-            Text("v\(AppInfo.version) · \(AppInfo.credit)")
+            Text(verbatim: "·").scaledFont(.caption).foregroundStyle(.secondary)
+            Text(verbatim: "v\(AppInfo.version) · \(AppInfo.credit)")
                 .scaledFont(.caption)
                 .foregroundStyle(.tertiary)
         }
@@ -265,9 +265,9 @@ struct ContentView: View {
             Image(systemName: "powerplug")
                 .scaledFont(.largeTitle)
                 .foregroundStyle(.secondary)
-            Text("No USB-C ports detected")
+            Text(String(localized: "No USB-C ports detected", bundle: .module))
                 .scaledFont(.headline, weight: .bold)
-            Text("This Mac doesn't seem to expose its port-controller services. Hit refresh, or check System Information > USB.")
+            Text(String(localized: "This Mac doesn't seem to expose its port-controller services. Hit refresh, or check System Information > USB.", bundle: .module))
                 .scaledFont(.caption)
                 .multilineTextAlignment(.center)
                 .foregroundStyle(.secondary)
@@ -282,9 +282,9 @@ struct ContentView: View {
             Image(systemName: "cable.connector.slash")
                 .scaledFont(.largeTitle)
                 .foregroundStyle(.secondary)
-            Text("Nothing connected")
+            Text(String(localized: "Nothing connected", bundle: .module))
                 .scaledFont(.headline, weight: .bold)
-            Text("\(portWatcher.ports.count) USB-C port\(portWatcher.ports.count == 1 ? "" : "s") detected, but nothing is currently plugged in. Turn off \"Hide empty ports\" in Settings to see them.")
+            Text(String(localized: "\(portWatcher.ports.count) USB-C ports detected, but nothing is currently plugged in. Turn off \"Hide empty ports\" in Settings to see them.", bundle: .module))
                 .scaledFont(.caption)
                 .multilineTextAlignment(.center)
                 .foregroundStyle(.secondary)
@@ -337,7 +337,7 @@ struct UpdateBanner: View {
             Image(systemName: "arrow.down.circle.fill")
                 .foregroundStyle(.tint)
             VStack(alignment: .leading, spacing: 2) {
-                Text("WhatCable \(update.version) is available")
+                Text(String(localized: "WhatCable \(update.version) is available", bundle: .module))
                     .scaledFont(.callout, weight: .bold)
                 statusLine
                     .scaledFont(.caption).foregroundStyle(.secondary)
@@ -354,15 +354,15 @@ struct UpdateBanner: View {
     private var statusLine: some View {
         switch installer.state {
         case .idle:
-            Text("You're on \(AppInfo.version)")
+            Text(String(localized: "You're on \(AppInfo.version)", bundle: .module))
         case .downloading:
-            Text("Downloading…")
+            Text(String(localized: "Downloading…", bundle: .module))
         case .verifying:
-            Text("Verifying signature…")
+            Text(String(localized: "Verifying signature…", bundle: .module))
         case .installing:
-            Text("Installing — WhatCable will relaunch")
+            Text(String(localized: "Installing, WhatCable will relaunch", bundle: .module))
         case .failed(let message):
-            Text("Install failed: \(message)").foregroundStyle(.red)
+            Text(String(localized: "Install failed: \(message)", bundle: .module)).foregroundStyle(.red)
         }
     }
 
@@ -371,14 +371,14 @@ struct UpdateBanner: View {
         switch installer.state {
         case .idle, .failed:
             HStack(spacing: 6) {
-                Button("View release") {
+                Button(String(localized: "View release", bundle: .module)) {
                     NSWorkspace.shared.open(update.url)
                 }
                 .buttonStyle(.bordered)
                 .controlSize(.small)
 
                 if update.downloadURL != nil {
-                    Button("Install update") {
+                    Button(String(localized: "Install update", bundle: .module)) {
                         Installer.shared.install(update)
                     }
                     .buttonStyle(.borderedProminent)
@@ -458,7 +458,7 @@ struct PortCard: View {
                 VStack(alignment: .leading, spacing: 4) {
                     ForEach(summary.bullets, id: \.self) { bullet in
                         HStack(alignment: .top, spacing: 6) {
-                            Text("•").foregroundStyle(.secondary)
+                            Text(verbatim: "•").foregroundStyle(.secondary)
                             Text(bullet).scaledFont(.callout)
                             Spacer()
                         }
@@ -469,10 +469,11 @@ struct PortCard: View {
 
             if !devices.isEmpty {
                 VStack(alignment: .leading, spacing: 4) {
-                    Text("Connected device\(devices.count == 1 ? "" : "s")")
+                    Text(String(localized: "Connected devices", bundle: .module))
                         .scaledFont(.caption).foregroundStyle(.secondary)
                     ForEach(devices) { d in
-                        Text("• \(d.productName ?? "Unknown") - \(d.speedLabel)")
+                        let name = d.productName ?? String(localized: "Unknown", bundle: .module)
+                        Text(verbatim: "• \(name) - \(d.speedLabel)")
                             .scaledFont(.callout)
                     }
                 }
@@ -501,11 +502,11 @@ struct PortCard: View {
                     Button {
                         reportingCable = cable
                     } label: {
-                        Label("Report this cable", systemImage: "exclamationmark.bubble")
+                        Label(String(localized: "Report this cable", bundle: .module), systemImage: "exclamationmark.bubble")
                             .scaledFont(.caption)
                     }
                     .buttonStyle(.borderless)
-                    .help("File a GitHub issue with this cable's e-marker fingerprint")
+                    .help(String(localized: "File a GitHub issue with this cable's e-marker fingerprint", bundle: .module))
                 }
                 .padding(.leading, 48)
             }
@@ -556,7 +557,8 @@ struct PowerSourceList: View {
             ForEach(sources) { src in
                 if !src.options.isEmpty {
                     VStack(alignment: .leading, spacing: 2) {
-                        Text("\(src.name) profiles")
+                        let srcName = src.name
+                        Text(String(localized: "\(srcName) profiles", bundle: .module))
                             .scaledFont(.caption).foregroundStyle(.secondary)
                         ForEach(src.options.sorted(by: { $0.voltageMV < $1.voltageMV }), id: \.self) { opt in
                             let isWinning = opt == src.winning
@@ -564,10 +566,10 @@ struct PowerSourceList: View {
                                 Image(systemName: isWinning ? "checkmark.circle.fill" : "circle")
                                     .foregroundStyle(isWinning ? Color.green : Color.secondary)
                                     .scaledFont(.caption)
-                                Text("\(opt.voltsLabel) @ \(opt.ampsLabel) - \(opt.wattsLabel)")
+                                Text(verbatim: "\(opt.voltsLabel) @ \(opt.ampsLabel) - \(opt.wattsLabel)")
                                     .scaledFont(.callout, monospacedDigit: true)
                                 if isWinning {
-                                    Text("active").scaledFont(.caption2).foregroundStyle(.green)
+                                    Text(String(localized: "active", bundle: .module)).scaledFont(.caption2).foregroundStyle(.green)
                                 }
                                 Spacer()
                             }
@@ -585,23 +587,24 @@ struct AdvancedPortDetails: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
-            group("Connection") {
-                row("Active", bool(port.connectionActive))
-                row("Active cable electronics", bool(port.activeCable))
-                row("Optical", bool(port.opticalCable))
-                row("USB active", bool(port.usbActive))
-                row("SuperSpeed", bool(port.superSpeedActive))
-                row("Plug events", port.plugEventCount.map(String.init) ?? "—")
+            group(String(localized: "Connection", bundle: .module)) {
+                row(String(localized: "Active", bundle: .module), bool(port.connectionActive))
+                row(String(localized: "Active cable electronics", bundle: .module), bool(port.activeCable))
+                row(String(localized: "Optical", bundle: .module), bool(port.opticalCable))
+                row(String(localized: "USB active", bundle: .module), bool(port.usbActive))
+                row(String(localized: "SuperSpeed", bundle: .module), bool(port.superSpeedActive))
+                row(String(localized: "Plug events", bundle: .module), port.plugEventCount.map(String.init) ?? "—")
             }
-            group("Transports") {
-                row("Supported", port.transportsSupported.joined(separator: ", "))
-                row("Provisioned", port.transportsProvisioned.joined(separator: ", "))
-                row("Active", port.transportsActive.isEmpty ? "—" : port.transportsActive.joined(separator: ", "))
+            group(String(localized: "Transports", bundle: .module)) {
+                row(String(localized: "Supported", bundle: .module), port.transportsSupported.joined(separator: ", "))
+                row(String(localized: "Provisioned", bundle: .module), port.transportsProvisioned.joined(separator: ", "))
+                row(String(localized: "Active", bundle: .module), port.transportsActive.isEmpty ? "—" : port.transportsActive.joined(separator: ", "))
             }
             if !thunderboltChain.isEmpty {
                 ThunderboltFabricSection(chain: thunderboltChain)
             }
-            DisclosureGroup("All raw IOKit properties (\(port.rawProperties.count))") {
+            let rawCount = port.rawProperties.count
+            DisclosureGroup(String(localized: "All raw IOKit properties (\(rawCount))", bundle: .module)) {
                 VStack(alignment: .leading, spacing: 2) {
                     ForEach(port.rawProperties.sorted(by: { $0.key < $1.key }), id: \.key) { kv in
                         HStack(alignment: .top) {
@@ -637,7 +640,7 @@ struct AdvancedPortDetails: View {
 
     private func bool(_ v: Bool?) -> String {
         guard let v else { return "—" }
-        return v ? "Yes" : "No"
+        return v ? String(localized: "Yes", bundle: .module) : String(localized: "No", bundle: .module)
     }
 }
 
@@ -650,7 +653,7 @@ struct ThunderboltFabricSection: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
-            Text("Thunderbolt fabric")
+            Text(String(localized: "Thunderbolt fabric", bundle: .module))
                 .scaledFont(.caption, weight: .bold).foregroundStyle(.secondary)
             ForEach(Array(chain.enumerated()), id: \.element.id) { index, sw in
                 hopRow(sw, index: index)
@@ -662,12 +665,12 @@ struct ThunderboltFabricSection: View {
     private func hopRow(_ sw: ThunderboltSwitch, index: Int) -> some View {
         let indent = String(repeating: "  ", count: index)
         let arrow = index == 0 ? "" : "↳ "
-        let name = sw.isHostRoot ? "Host (\(sw.className))" : ThunderboltLabels.deviceName(for: sw)
+        let name = sw.isHostRoot ? String(localized: "Host (\(sw.className))", bundle: .module) : ThunderboltLabels.deviceName(for: sw)
         let port = ThunderboltTopology.activeDownstreamLanePort(sw)
-        let linkLabel = port.flatMap { ThunderboltLabels.linkLabel(for: $0) } ?? "no active link"
+        let linkLabel = port.flatMap { ThunderboltLabels.linkLabel(for: $0) } ?? String(localized: "no active link", bundle: .module)
 
         HStack(alignment: .top) {
-            Text("\(indent)\(arrow)\(name)")
+            Text(verbatim: "\(indent)\(arrow)\(name)")
                 .scaledFont(.caption, design: .monospaced)
             Spacer()
             Text(linkLabel)
@@ -685,7 +688,7 @@ private struct TrustFlagsCard: View {
             HStack(spacing: 6) {
                 Image(systemName: "exclamationmark.triangle.fill")
                     .foregroundStyle(.orange)
-                Text("Cable trust signals")
+                Text(String(localized: "Cable trust signals", bundle: .module))
                     .scaledFont(.caption, weight: .bold)
                     .foregroundStyle(.secondary)
             }

--- a/Sources/WhatCable/NotificationManager.swift
+++ b/Sources/WhatCable/NotificationManager.swift
@@ -76,16 +76,16 @@ final class NotificationManager {
         guard AppSettings.shared.notifyOnChanges else { return }
 
         for device in added {
-            let name = device.productName ?? "USB device"
+            let name = device.productName ?? String(localized: "USB device", bundle: .module)
             postNotification(
-                title: "Connected: \(name)",
+                title: String(localized: "Connected: \(name)", bundle: .module),
                 body: "\(device.speedLabel)\(device.vendorName.map { " · \($0)" } ?? "")"
             )
         }
         if removedCount > 0 {
             postNotification(
-                title: "USB device disconnected",
-                body: removedCount == 1 ? "1 device removed" : "\(removedCount) devices removed"
+                title: String(localized: "USB device disconnected", bundle: .module),
+                body: String(localized: "\(removedCount) devices removed", bundle: .module)
             )
         }
     }
@@ -100,11 +100,11 @@ final class NotificationManager {
         guard AppSettings.shared.notifyOnChanges else { return }
 
         for source in added {
-            let watts = source.winning.map { "\($0.wattsLabel) negotiated" } ?? "PD source"
-            postNotification(title: "Charger connected", body: "\(source.name) · \(watts)")
+            let watts = source.winning.map { String(localized: "\($0.wattsLabel) negotiated", bundle: .module) } ?? String(localized: "PD source", bundle: .module)
+            postNotification(title: String(localized: "Charger connected", bundle: .module), body: "\(source.name) · \(watts)")
         }
         if removedCount > 0 {
-            postNotification(title: "Charger disconnected", body: "")
+            postNotification(title: String(localized: "Charger disconnected", bundle: .module), body: "")
         }
     }
 

--- a/Sources/WhatCable/Resources/Localizable.xcstrings
+++ b/Sources/WhatCable/Resources/Localizable.xcstrings
@@ -1,0 +1,285 @@
+{
+  "sourceLanguage" : "en",
+  "strings" : {
+    "" : {
+
+    },
+    "%@ profiles" : {
+
+    },
+    "%lld USB devices" : {
+      "localizations" : {
+        "en" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld USB device"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld USB devices"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "%lld USB-C ports detected, but nothing is currently plugged in. Turn off \"Hide empty ports\" in Settings to see them." : {
+      "localizations" : {
+        "en" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld USB-C port detected, but nothing is currently plugged in. Turn off \"Hide empty ports\" in Settings to see it."
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld USB-C ports detected, but nothing is currently plugged in. Turn off \"Hide empty ports\" in Settings to see them."
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "%lld devices removed" : {
+      "localizations" : {
+        "en" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld device removed"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld devices removed"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "About %@" : {
+
+    },
+    "Active" : {
+
+    },
+    "Active cable electronics" : {
+
+    },
+    "All raw IOKit properties (%lld)" : {
+
+    },
+    "Behavior" : {
+
+    },
+    "Built by %@." : {
+
+    },
+    "Cable trust signals" : {
+
+    },
+    "Cancel" : {
+
+    },
+    "Charger connected" : {
+
+    },
+    "Charger disconnected" : {
+
+    },
+    "Check for Updates…" : {
+
+    },
+    "Connected devices" : {
+
+    },
+    "Connected: %@" : {
+
+    },
+    "Connection" : {
+
+    },
+    "Display" : {
+
+    },
+    "Done" : {
+
+    },
+    "Downloading…" : {
+
+    },
+    "File a GitHub issue with this cable's e-marker fingerprint" : {
+
+    },
+    "Font size" : {
+
+    },
+    "Helps the maintainer reproduce charger / cable behavior tied to specific hardware." : {
+
+    },
+    "Hide empty ports" : {
+
+    },
+    "Host (%@)" : {
+
+    },
+    "Include Mac model and macOS version" : {
+
+    },
+    "Install failed: %@" : {
+
+    },
+    "Install update" : {
+
+    },
+    "Installing, WhatCable will relaunch" : {
+
+    },
+    "Keep window open" : {
+
+    },
+    "Launch at login" : {
+
+    },
+    "Lives in the menu bar with no Dock icon." : {
+
+    },
+    "No" : {
+
+    },
+    "No USB-C ports detected" : {
+
+    },
+    "Nothing connected" : {
+
+    },
+    "Notifications" : {
+
+    },
+    "Notify on cable changes" : {
+
+    },
+    "Open in GitHub" : {
+
+    },
+    "Opens a pre-filled GitHub issue in your browser. Nothing is sent until you submit there." : {
+
+    },
+    "Optical" : {
+
+    },
+    "PD source" : {
+
+    },
+    "%@ negotiated" : {
+
+    },
+    "Plug events" : {
+
+    },
+    "Preview of what will be included:" : {
+
+    },
+    "Provisioned" : {
+
+    },
+    "Quit" : {
+
+    },
+    "Quit %@" : {
+
+    },
+    "Refresh" : {
+
+    },
+    "Report this cable" : {
+
+    },
+    "Runs as a regular Dock app with a window." : {
+
+    },
+    "Settings" : {
+
+    },
+    "Settings…" : {
+
+    },
+    "Show in menu bar" : {
+
+    },
+    "Show technical details" : {
+
+    },
+    "SuperSpeed" : {
+
+    },
+    "Supported" : {
+
+    },
+    "This Mac doesn't seem to expose its port-controller services. Hit refresh, or check System Information > USB." : {
+
+    },
+    "Thunderbolt fabric" : {
+
+    },
+    "Transports" : {
+
+    },
+    "USB active" : {
+
+    },
+    "USB device" : {
+
+    },
+    "USB device disconnected" : {
+
+    },
+    "Unknown" : {
+
+    },
+    "Verifying signature…" : {
+
+    },
+    "View release" : {
+
+    },
+    "What gets shared?" : {
+
+    },
+    "WhatCable %@ is available" : {
+
+    },
+    "WhatCable on GitHub" : {
+
+    },
+    "Yes" : {
+
+    },
+    "You're on %@" : {
+
+    },
+    "active" : {
+
+    },
+    "no active link" : {
+
+    }
+  },
+  "version" : "1.0"
+}

--- a/Sources/WhatCable/SettingsView.swift
+++ b/Sources/WhatCable/SettingsView.swift
@@ -27,9 +27,9 @@ struct SettingsView: View {
         HStack {
             Image(systemName: "gearshape")
                 .scaledFont(.title2)
-            Text("Settings").scaledFont(.headline, weight: .bold)
+            Text(String(localized: "Settings", bundle: .module)).scaledFont(.headline, weight: .bold)
             Spacer()
-            Button("Done", action: dismiss)
+            Button(String(localized: "Done", bundle: .module), action: dismiss)
                 .keyboardShortcut(.defaultAction)
         }
         .padding(12)
@@ -41,23 +41,23 @@ struct SettingsForm: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 24) {
-            section("Behavior") {
-                Toggle("Launch at login", isOn: $settings.launchAtLogin)
-                Toggle("Show in menu bar", isOn: $settings.useMenuBarMode)
+            section(String(localized: "Behavior", bundle: .module)) {
+                Toggle(String(localized: "Launch at login", bundle: .module), isOn: $settings.launchAtLogin)
+                Toggle(String(localized: "Show in menu bar", bundle: .module), isOn: $settings.useMenuBarMode)
                 Text(settings.useMenuBarMode
-                     ? "Lives in the menu bar with no Dock icon."
-                     : "Runs as a regular Dock app with a window.")
+                     ? String(localized: "Lives in the menu bar with no Dock icon.", bundle: .module)
+                     : String(localized: "Runs as a regular Dock app with a window.", bundle: .module))
                     .scaledFont(.caption)
                     .foregroundStyle(.secondary)
             }
-            section("Display") {
-                Toggle("Show technical details", isOn: $settings.showTechnicalDetails)
-                Toggle("Hide empty ports", isOn: $settings.hideEmptyPorts)
+            section(String(localized: "Display", bundle: .module)) {
+                Toggle(String(localized: "Show technical details", bundle: .module), isOn: $settings.showTechnicalDetails)
+                Toggle(String(localized: "Hide empty ports", bundle: .module), isOn: $settings.hideEmptyPorts)
                 VStack(alignment: .leading, spacing: 4) {
                     HStack {
-                        Text("Font size")
+                        Text(String(localized: "Font size", bundle: .module))
                         Spacer()
-                        Text("\(Int((settings.fontSize * 100).rounded()))%")
+                        Text(verbatim: "\(Int((settings.fontSize * 100).rounded()))%")
                             .foregroundStyle(.secondary)
                             .monospacedDigit()
                     }
@@ -71,8 +71,8 @@ struct SettingsForm: View {
                 }
                 .padding(.top, 4)
             }
-            section("Notifications") {
-                Toggle("Notify on cable changes", isOn: $settings.notifyOnChanges)
+            section(String(localized: "Notifications", bundle: .module)) {
+                Toggle(String(localized: "Notify on cable changes", bundle: .module), isOn: $settings.notifyOnChanges)
             }
         }
     }

--- a/Sources/WhatCableCore/AppInfo.swift
+++ b/Sources/WhatCableCore/AppInfo.swift
@@ -31,7 +31,7 @@ public enum AppInfo {
         return "dev"
     }()
     public static let credit = "Darryl Morley"
-    public static let tagline = "What can this USB-C cable actually do?"
+    public static let tagline = String(localized: "What can this USB-C cable actually do?", bundle: .module)
     public static let copyright = "© \(Calendar.current.component(.year, from: Date())) \(credit)"
     public static let helpURL = URL(string: "https://github.com/darrylmorley/whatcable")!
 

--- a/Sources/WhatCableCore/CableTrustReport.swift
+++ b/Sources/WhatCableCore/CableTrustReport.swift
@@ -121,21 +121,21 @@ public enum TrustFlag: Hashable {
     public var title: String {
         switch self {
         case .zeroVendorID:
-            return "E-marker reports no vendor identity"
+            return String(localized: "E-marker reports no vendor identity", bundle: .module)
         case .reservedSpeedEncoding:
-            return "E-marker uses a reserved data-speed value"
+            return String(localized: "E-marker uses a reserved data-speed value", bundle: .module)
         case .reservedCurrentEncoding:
-            return "E-marker uses a reserved current-rating value"
+            return String(localized: "E-marker uses a reserved current-rating value", bundle: .module)
         case .reservedCableLatencyEncoding:
-            return "E-marker uses a reserved cable-latency value"
+            return String(localized: "E-marker uses a reserved cable-latency value", bundle: .module)
         case .vidNotInUSBIFList:
-            return "Vendor ID isn't in USB-IF's published list"
+            return String(localized: "Vendor ID isn't in USB-IF's published list", bundle: .module)
         case .invalidVDOVersion:
-            return "E-marker uses an invalid VDO version"
+            return String(localized: "E-marker uses an invalid VDO version", bundle: .module)
         case .invalidCableTermination:
-            return "E-marker uses an invalid cable-termination value"
+            return String(localized: "E-marker uses an invalid cable-termination value", bundle: .module)
         case .eprClaimedWithLowMaxVoltage:
-            return "E-marker claims EPR support but reports only 20V max VBUS"
+            return String(localized: "E-marker claims EPR support but reports only 20V max VBUS", bundle: .module)
         }
     }
 
@@ -143,22 +143,22 @@ public enum TrustFlag: Hashable {
     public var detail: String {
         switch self {
         case .zeroVendorID:
-            return "Legitimate USB-IF members ship cables with a non-zero vendor ID. A zeroed VID is a common counterfeit signature."
+            return String(localized: "Legitimate USB-IF members ship cables with a non-zero vendor ID. A zeroed VID is a common counterfeit signature.", bundle: .module)
         case .reservedSpeedEncoding(let bits):
-            return "The cable's e-marker reports speed value \(bits), which is reserved by the USB-PD spec. Real e-marker chips should not emit reserved values."
+            return String(localized: "The cable's e-marker reports speed value \(bits), which is reserved by the USB-PD spec. Real e-marker chips should not emit reserved values.", bundle: .module)
         case .reservedCurrentEncoding(let bits):
-            return "The cable's e-marker reports current value \(bits), which is reserved by the USB-PD spec. Real e-marker chips should not emit reserved values."
+            return String(localized: "The cable's e-marker reports current value \(bits), which is reserved by the USB-PD spec. Real e-marker chips should not emit reserved values.", bundle: .module)
         case .reservedCableLatencyEncoding(let bits):
-            return "The cable's e-marker reports cable-latency value \(bits), which is reserved by the USB-PD spec for this cable type. Real e-marker chips should not emit reserved values."
+            return String(localized: "The cable's e-marker reports cable-latency value \(bits), which is reserved by the USB-PD spec for this cable type. Real e-marker chips should not emit reserved values.", bundle: .module)
         case .vidNotInUSBIFList(let vid):
             let hex = String(format: "0x%04X", vid)
-            return "The cable's e-marker reports vendor \(hex), which isn't in our bundled USB-IF list. The number could be unassigned, copied, or assigned after the bundled list was generated. On its own this isn't proof of a problem, but on a clone cable it often appears alongside other inconsistencies."
+            return String(localized: "The cable's e-marker reports vendor \(hex), which isn't in our bundled USB-IF list. The number could be unassigned, copied, or assigned after the bundled list was generated. On its own this isn't proof of a problem, but on a clone cable it often appears alongside other inconsistencies.", bundle: .module)
         case .invalidVDOVersion(let bits):
-            return "The cable's e-marker reports VDO version \(bits), which is reserved or marked Invalid by the USB-PD spec for this cable type. Real e-marker silicon should not emit Invalid version values."
+            return String(localized: "The cable's e-marker reports VDO version \(bits), which is reserved or marked Invalid by the USB-PD spec for this cable type. Real e-marker silicon should not emit Invalid version values.", bundle: .module)
         case .invalidCableTermination(let bits):
-            return "The cable's e-marker reports cable termination \(bits), which the USB-PD spec marks as Invalid for this cable type. Mis-flashed e-markers commonly disagree with the cable's actual physical wiring here."
+            return String(localized: "The cable's e-marker reports cable termination \(bits), which the USB-PD spec marks as Invalid for this cable type. Mis-flashed e-markers commonly disagree with the cable's actual physical wiring here.", bundle: .module)
         case .eprClaimedWithLowMaxVoltage:
-            return "The cable's e-marker advertises EPR Capable, but reports its Max VBUS Voltage as 20V. EPR operation needs 48V or 50V VBUS, so the two fields contradict each other."
+            return String(localized: "The cable's e-marker advertises EPR Capable, but reports its Max VBUS Voltage as 20V. EPR operation needs 48V or 50V VBUS, so the two fields contradict each other.", bundle: .module)
         }
     }
 }

--- a/Sources/WhatCableCore/ChargingDiagnostic.swift
+++ b/Sources/WhatCableCore/ChargingDiagnostic.swift
@@ -70,21 +70,21 @@ extension ChargingDiagnostic {
         // 3. Otherwise charger is the ceiling.
         if let cableW = cableMaxW, cableW < chargerMaxW {
             self.bottleneck = .cableLimit(cableW: cableW, chargerW: chargerMaxW)
-            self.summary = "Cable is limiting charging speed"
-            self.detail = "Charger can deliver up to \(chargerMaxW)W, but this cable is only rated to carry \(cableW)W. Replace the cable to charge faster."
+            self.summary = String(localized: "Cable is limiting charging speed", bundle: .module)
+            self.detail = String(localized: "Charger can deliver up to \(chargerMaxW)W, but this cable is only rated to carry \(cableW)W. Replace the cable to charge faster.", bundle: .module)
         } else if let n = negotiatedW, n < chargerMaxW - max(5, chargerMaxW / 10),
                   (cableMaxW.map { n < $0 - max(5, $0 / 10) } ?? true) {
             self.bottleneck = .macLimit(negotiatedW: n, chargerW: chargerMaxW, cableW: cableMaxW)
-            self.summary = "Charging at \(n)W (charger can do up to \(chargerMaxW)W)"
-            self.detail = "Both the charger and cable can do more, but the Mac is currently asking for less. This is normal once the battery is mostly full, or when the system is idle."
+            self.summary = String(localized: "Charging at \(n)W (charger can do up to \(chargerMaxW)W)", bundle: .module)
+            self.detail = String(localized: "Both the charger and cable can do more, but the Mac is currently asking for less. This is normal once the battery is mostly full, or when the system is idle.", bundle: .module)
         } else if let n = negotiatedW {
             self.bottleneck = .fine(negotiatedW: n)
-            self.summary = "Charging well at \(n)W"
-            self.detail = "Charger and cable are well-matched."
+            self.summary = String(localized: "Charging well at \(n)W", bundle: .module)
+            self.detail = String(localized: "Charger and cable are well-matched.", bundle: .module)
         } else {
             self.bottleneck = .chargerLimit(chargerW: chargerMaxW)
-            self.summary = "Charger advertises up to \(chargerMaxW)W"
-            self.detail = "Negotiation hasn't completed yet."
+            self.summary = String(localized: "Charger advertises up to \(chargerMaxW)W", bundle: .module)
+            self.detail = String(localized: "Negotiation hasn't completed yet.", bundle: .module)
         }
     }
 }

--- a/Sources/WhatCableCore/PDVDO.swift
+++ b/Sources/WhatCableCore/PDVDO.swift
@@ -19,14 +19,14 @@ public enum PDVDO {
 
         public var label: String {
             switch self {
-            case .undefined: return "Unspecified"
-            case .pdusbHub: return "USB Hub"
-            case .pdusbPeripheral: return "USB Peripheral"
-            case .passiveCable: return "Passive cable"
-            case .activeCable: return "Active cable"
-            case .ama: return "Alternate Mode Adapter"
-            case .vpd: return "VCONN-powered device"
-            case .other: return "Other"
+            case .undefined: return String(localized: "Unspecified", bundle: .module)
+            case .pdusbHub: return String(localized: "USB Hub", bundle: .module)
+            case .pdusbPeripheral: return String(localized: "USB Peripheral", bundle: .module)
+            case .passiveCable: return String(localized: "Passive cable", bundle: .module)
+            case .activeCable: return String(localized: "Active cable", bundle: .module)
+            case .ama: return String(localized: "Alternate Mode Adapter", bundle: .module)
+            case .vpd: return String(localized: "VCONN-powered device", bundle: .module)
+            case .other: return String(localized: "Other", bundle: .module)
             }
         }
     }
@@ -64,11 +64,11 @@ public enum PDVDO {
 
         public var label: String {
             switch self {
-            case .usb20: return "USB 2.0 (480 Mbps)"
-            case .usb32Gen1: return "USB 3.2 Gen 1 (5 Gbps)"
-            case .usb32Gen2: return "USB 3.2 Gen 2 (10 Gbps)"
-            case .usb4Gen3: return "USB4 Gen 3 (20 / 40 Gbps)"
-            case .usb4Gen4: return "USB4 Gen 4 (80 Gbps)"
+            case .usb20: return String(localized: "USB 2.0 (480 Mbps)", bundle: .module)
+            case .usb32Gen1: return String(localized: "USB 3.2 Gen 1 (5 Gbps)", bundle: .module)
+            case .usb32Gen2: return String(localized: "USB 3.2 Gen 2 (10 Gbps)", bundle: .module)
+            case .usb4Gen3: return String(localized: "USB4 Gen 3 (20 / 40 Gbps)", bundle: .module)
+            case .usb4Gen4: return String(localized: "USB4 Gen 4 (80 Gbps)", bundle: .module)
             }
         }
 
@@ -98,9 +98,9 @@ public enum PDVDO {
 
         public var label: String {
             switch self {
-            case .usbDefault: return "USB default"
-            case .threeAmp: return "3 A"
-            case .fiveAmp: return "5 A"
+            case .usbDefault: return String(localized: "USB default", bundle: .module)
+            case .threeAmp: return String(localized: "3 A", bundle: .module)
+            case .fiveAmp: return String(localized: "5 A", bundle: .module)
             }
         }
     }
@@ -306,8 +306,8 @@ public enum PDVDO {
 
         public var label: String {
             switch self {
-            case .copper: return "Copper"
-            case .optical: return "Optical"
+            case .copper: return String(localized: "Copper", bundle: .module)
+            case .optical: return String(localized: "Optical", bundle: .module)
             }
         }
     }
@@ -322,8 +322,8 @@ public enum PDVDO {
 
         public var label: String {
             switch self {
-            case .redriver: return "Re-driver"
-            case .retimer: return "Re-timer"
+            case .redriver: return String(localized: "Re-driver", bundle: .module)
+            case .retimer: return String(localized: "Re-timer", bundle: .module)
             }
         }
     }
@@ -343,14 +343,14 @@ public enum PDVDO {
 
         public var label: String {
             switch self {
-            case .greaterThan10mW: return "> 10 mW"
-            case .fiveTo10mW: return "5-10 mW"
-            case .oneTo5mW: return "1-5 mW"
-            case .halfTo1mW: return "0.5-1 mW"
-            case .fifthToHalfmW: return "0.2-0.5 mW"
-            case .fiftyTo200uW: return "50-200 µW"
-            case .lessThan50uW: return "< 50 µW"
-            case .reserved: return "Reserved"
+            case .greaterThan10mW: return String(localized: "> 10 mW", bundle: .module)
+            case .fiveTo10mW: return String(localized: "5-10 mW", bundle: .module)
+            case .oneTo5mW: return String(localized: "1-5 mW", bundle: .module)
+            case .halfTo1mW: return String(localized: "0.5-1 mW", bundle: .module)
+            case .fifthToHalfmW: return String(localized: "0.2-0.5 mW", bundle: .module)
+            case .fiftyTo200uW: return String(localized: "50-200 µW", bundle: .module)
+            case .lessThan50uW: return String(localized: "< 50 µW", bundle: .module)
+            case .reserved: return String(localized: "Reserved", bundle: .module)
             }
         }
     }

--- a/Sources/WhatCableCore/PortSummary.swift
+++ b/Sources/WhatCableCore/PortSummary.swift
@@ -67,8 +67,8 @@ extension PortSummary {
 
         if !connected {
             self.status = .empty
-            self.headline = "Nothing connected"
-            self.subtitle = "Plug a cable into \(portLabel) to see what it can do."
+            self.headline = String(localized: "Nothing connected", bundle: .module)
+            self.subtitle = String(localized: "Plug a cable into \(portLabel) to see what it can do.", bundle: .module)
             self.bullets = []
             return
         }
@@ -103,25 +103,26 @@ extension PortSummary {
             // "active" line so older paths still work.
             let tbBullets = thunderboltBullets(for: port, switches: thunderboltSwitches)
             if tbBullets.isEmpty {
-                bullets.append("Thunderbolt / USB4 link active")
+                bullets.append(String(localized: "Thunderbolt / USB4 link active", bundle: .module))
             } else {
                 bullets.append(contentsOf: tbBullets)
             }
         } else if hasUSB3 {
-            bullets.append("SuperSpeed USB (5 Gbps or faster)")
+            bullets.append(String(localized: "SuperSpeed USB (5 Gbps or faster)", bundle: .module))
         } else if hasUSB2 {
-            bullets.append("USB 2.0 only (480 Mbps) — no high-speed data")
+            bullets.append(String(localized: "USB 2.0 only (480 Mbps), no high-speed data", bundle: .module))
         }
 
         if hasDP {
-            bullets.append("Carrying DisplayPort video")
+            bullets.append(String(localized: "Carrying DisplayPort video", bundle: .module))
         }
 
         // Partner identity (SOP): what's connected.
         if let partner = identities.first(where: { $0.endpoint == .sop }),
            let header = partner.idHeader {
             let kind = header.ufpProductType != .undefined ? header.ufpProductType.label : header.dfpProductType.label
-            bullets.append("Connected device: \(kind) — \(VendorDB.label(for: partner.vendorID))")
+            let vendor = VendorDB.label(for: partner.vendorID)
+            bullets.append(String(localized: "Connected device: \(kind), \(vendor)", bundle: .module))
         }
 
         // ------------------------------------------------------------
@@ -136,12 +137,12 @@ extension PortSummary {
         // `pdCapable`), so don't emit any "no e-marker" wording there.
         let isMagSafe = port.portTypeDescription?.hasPrefix("MagSafe") == true
         if hasEmarker {
-            bullets.append("Cable has an e-marker chip (advertises its capabilities)")
+            bullets.append(String(localized: "Cable has an e-marker chip (advertises its capabilities)", bundle: .module))
         } else if !active.isEmpty && !isMagSafe {
             if pdCapable {
-                bullets.append("Cable does not advertise an e-marker (basic cable)")
+                bullets.append(String(localized: "Cable does not advertise an e-marker (basic cable)", bundle: .module))
             } else {
-                bullets.append("This port can't read cable details (USB-only port, no Power Delivery)")
+                bullets.append(String(localized: "This port can't read cable details (USB-only port, no Power Delivery)", bundle: .module))
             }
         }
 
@@ -150,23 +151,26 @@ extension PortSummary {
             $0.endpoint == .sopPrime || $0.endpoint == .sopDoublePrime
         })
         if let cable = cableEmarker, let cv = cable.cableVDO {
-            bullets.append("Cable speed: \(cv.speed.label)")
-            bullets.append("Cable rated for \(cv.current.label) at up to \(cv.maxVolts)V (~\(cv.maxWatts)W)")
+            let speedLabel = cv.speed.label
+            bullets.append(String(localized: "Cable speed: \(speedLabel)", bundle: .module))
+            let currentLabel = cv.current.label
+            let maxVolts = cv.maxVolts
+            let maxWatts = cv.maxWatts
+            bullets.append(String(localized: "Cable rated for \(currentLabel) at up to \(maxVolts)V (~\(maxWatts)W)", bundle: .module))
             if cv.cableType == .active {
                 if let v2 = cable.activeCableVDO2 {
-                    // Lead with the most user-relevant facts: medium and
-                    // active element. Optional follow-up for optical
-                    // cables noting whether they're isolated.
-                    bullets.append("Active \(v2.physicalConnection.label.lowercased()) cable, \(v2.activeElement.label.lowercased())")
+                    let medium = v2.physicalConnection.label.lowercased()
+                    let element = v2.activeElement.label.lowercased()
+                    bullets.append(String(localized: "Active \(medium) cable, \(element)", bundle: .module))
                     if v2.physicalConnection == .optical {
                         if v2.opticallyIsolated {
-                            bullets.append("Optical fibres are electrically isolated end-to-end")
+                            bullets.append(String(localized: "Optical fibres are electrically isolated end-to-end", bundle: .module))
                         } else {
-                            bullets.append("Optical cable, not electrically isolated (carries copper alongside the fibres)")
+                            bullets.append(String(localized: "Optical cable, not electrically isolated (carries copper alongside the fibres)", bundle: .module))
                         }
                     }
                 } else {
-                    bullets.append("Active cable (contains signal-conditioning electronics)")
+                    bullets.append(String(localized: "Active cable (contains signal-conditioning electronics)", bundle: .module))
                 }
             }
         }
@@ -174,12 +178,13 @@ extension PortSummary {
         // Port-level optical flag. Independent of the e-marker's claim;
         // kept on its own line for now so users can see both signals.
         if port.opticalCable == true {
-            bullets.append("Optical cable")
+            bullets.append(String(localized: "Optical cable", bundle: .module))
         }
 
         // Cable e-marker vendor (SOP'): who made the cable.
         if let cable = cableEmarker, cable.vendorID != 0 {
-            bullets.append("Cable made by \(VendorDB.label(for: cable.vendorID))")
+            let vendor = VendorDB.label(for: cable.vendorID)
+            bullets.append(String(localized: "Cable made by \(vendor)", bundle: .module))
         }
 
         // ------------------------------------------------------------
@@ -192,10 +197,13 @@ extension PortSummary {
             let maxW = Int((Double(chargingSource.maxPowerMW) / 1000).rounded())
             let hasOptions = !chargingSource.options.isEmpty
             if hasOptions && maxW > 0 {
-                bullets.append("Charger advertises up to \(maxW)W")
+                bullets.append(String(localized: "Charger advertises up to \(maxW)W", bundle: .module))
             }
             if let win = chargingSource.winning {
-                bullets.append("Currently negotiated: \(win.voltsLabel) @ \(win.ampsLabel) (\(win.wattsLabel))")
+                let volts = win.voltsLabel
+                let amps = win.ampsLabel
+                let watts = win.wattsLabel
+                bullets.append(String(localized: "Currently negotiated: \(volts) @ \(amps) (\(watts))", bundle: .module))
             }
         }
 
@@ -207,40 +215,63 @@ extension PortSummary {
             let w = Int((Double(chargingSource.maxPowerMW) / 1000).rounded())
             return w > 0 ? w : nil
         }()
-        let chargerSuffix = chargerW.map { " · \($0)W charger" } ?? ""
 
         if hasTB {
             self.status = .thunderboltCable
-            self.headline = "Thunderbolt / USB4" + chargerSuffix
+            if let w = chargerW {
+                self.headline = String(localized: "Thunderbolt / USB4 · \(w)W charger", bundle: .module)
+            } else {
+                self.headline = String(localized: "Thunderbolt / USB4", bundle: .module)
+            }
             self.subtitle = subtitleForCapabilities(usb3: true, dp: hasDP, emarker: hasEmarker)
         } else if hasUSB3 && hasDP {
             self.status = .displayCable
-            self.headline = "USB-C with video" + chargerSuffix
-            self.subtitle = "Carrying both data and DisplayPort video."
+            if let w = chargerW {
+                self.headline = String(localized: "USB-C with video · \(w)W charger", bundle: .module)
+            } else {
+                self.headline = String(localized: "USB-C with video", bundle: .module)
+            }
+            self.subtitle = String(localized: "Carrying both data and DisplayPort video.", bundle: .module)
         } else if hasDP {
             self.status = .displayCable
-            self.headline = "Display connected" + chargerSuffix
-            self.subtitle = "DisplayPort video over USB-C alt mode."
+            if let w = chargerW {
+                self.headline = String(localized: "Display connected · \(w)W charger", bundle: .module)
+            } else {
+                self.headline = String(localized: "Display connected", bundle: .module)
+            }
+            self.subtitle = String(localized: "DisplayPort video over USB-C alt mode.", bundle: .module)
         } else if hasUSB3 {
             self.status = .dataDevice
-            self.headline = "USB device" + chargerSuffix
-            self.subtitle = "SuperSpeed data link is active."
+            if let w = chargerW {
+                self.headline = String(localized: "USB device · \(w)W charger", bundle: .module)
+            } else {
+                self.headline = String(localized: "USB device", bundle: .module)
+            }
+            self.subtitle = String(localized: "SuperSpeed data link is active.", bundle: .module)
         } else if hasUSB2 && !hasUSB3 {
             self.status = .dataDevice
-            self.headline = "Slow USB device or charge-only cable" + chargerSuffix
-            self.subtitle = "Only USB 2.0 is active. If you expected high speed, the cable may not support it."
+            if let w = chargerW {
+                self.headline = String(localized: "Slow USB device or charge-only cable · \(w)W charger", bundle: .module)
+            } else {
+                self.headline = String(localized: "Slow USB device or charge-only cable", bundle: .module)
+            }
+            self.subtitle = String(localized: "Only USB 2.0 is active. If you expected high speed, the cable may not support it.", bundle: .module)
         } else if chargingSource != nil {
             self.status = .charging
-            self.headline = "Charging" + chargerSuffix
-            self.subtitle = "Power is flowing. No data connection."
+            if let w = chargerW {
+                self.headline = String(localized: "Charging · \(w)W charger", bundle: .module)
+            } else {
+                self.headline = String(localized: "Charging", bundle: .module)
+            }
+            self.subtitle = String(localized: "Power is flowing. No data connection.", bundle: .module)
         } else if active.isEmpty && supported.contains("USB2") {
             self.status = .charging
-            self.headline = "Charging only"
-            self.subtitle = "Power is flowing but no data link is established."
+            self.headline = String(localized: "Charging only", bundle: .module)
+            self.subtitle = String(localized: "Power is flowing but no data link is established.", bundle: .module)
         } else {
             self.status = .unknown
-            self.headline = "Connected"
-            self.subtitle = "Couldn't determine cable type from this port."
+            self.headline = String(localized: "Connected", bundle: .module)
+            self.subtitle = String(localized: "Couldn't determine cable type from this port.", bundle: .module)
         }
 
         self.bullets = bullets
@@ -271,7 +302,8 @@ private func thunderboltBullets(
        let label = ThunderboltLabels.linkLabel(for: hostPort) {
         // label is e.g. "Up to 20 Gb/s × 2" — replace the leading "Up"
         // with "up" for the bullet phrasing without lowercasing units.
-        bullets.append("Linked at " + label.replacingOccurrences(of: "Up to", with: "up to"))
+        let linkSpeed = label.replacingOccurrences(of: "Up to", with: "up to")
+        bullets.append(String(localized: "Linked at \(linkSpeed)", bundle: .module))
     }
 
     // Connected-device line. Only meaningful when there's at least one
@@ -281,8 +313,11 @@ private func thunderboltBullets(
         let names = downstream.map { ThunderboltLabels.deviceName(for: $0) }
         let hops = downstream.count
         let path = names.joined(separator: " → ")
-        let prefix = hops == 1 ? "Connected to" : "Connected via \(hops) hops:"
-        bullets.append("\(prefix) \(path)")
+        if hops == 1 {
+            bullets.append(String(localized: "Connected to \(path)", bundle: .module))
+        } else {
+            bullets.append(String(localized: "Connected via \(hops) hops: \(path)", bundle: .module))
+        }
     }
 
     // Step-down detection: only meaningful on real daisy-chains
@@ -317,14 +352,15 @@ private func stepDownLabel(host: ThunderboltPort, lastLeg: ThunderboltPort) -> S
     if hostLabel == lastLabel { return nil }
     let h = hostLabel.replacingOccurrences(of: "Up to", with: "up to")
     let l = lastLabel.replacingOccurrences(of: "Up to", with: "up to")
-    return "Last leg drops from \(h) to \(l)"
+    return String(localized: "Last leg drops from \(h) to \(l)", bundle: .module)
 }
 
 private func subtitleForCapabilities(usb3: Bool, dp: Bool, emarker: Bool) -> String {
     var parts: [String] = []
-    if usb3 { parts.append("high-speed data") }
-    if dp { parts.append("video") }
-    if emarker { parts.append("smart cable") }
-    if parts.isEmpty { return "Connected." }
-    return "Supports " + parts.joined(separator: ", ") + "."
+    if usb3 { parts.append(String(localized: "high-speed data", bundle: .module)) }
+    if dp { parts.append(String(localized: "video", bundle: .module)) }
+    if emarker { parts.append(String(localized: "smart cable", bundle: .module)) }
+    if parts.isEmpty { return String(localized: "Connected.", bundle: .module) }
+    let capabilities = parts.joined(separator: ", ")
+    return String(localized: "Supports \(capabilities).", bundle: .module)
 }

--- a/Sources/WhatCableCore/Resources/Localizable.xcstrings
+++ b/Sources/WhatCableCore/Resources/Localizable.xcstrings
@@ -1,0 +1,399 @@
+{
+  "sourceLanguage" : "en",
+  "strings" : {
+    "0.2-0.5 mW" : {
+
+    },
+    "0.5-1 mW" : {
+
+    },
+    "1-5 mW" : {
+
+    },
+    "3 A" : {
+
+    },
+    "5 A" : {
+
+    },
+    "5-10 mW" : {
+
+    },
+    "50-200 µW" : {
+
+    },
+    "< 50 µW" : {
+
+    },
+    "> 10 mW" : {
+
+    },
+    "Active %@ cable, %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Active %1$@ cable, %2$@"
+          }
+        }
+      }
+    },
+    "Active cable" : {
+
+    },
+    "Active cable (contains signal-conditioning electronics)" : {
+
+    },
+    "Alternate Mode Adapter" : {
+
+    },
+    "Both the charger and cable can do more, but the Mac is currently asking for less. This is normal once the battery is mostly full, or when the system is idle." : {
+
+    },
+    "Cable does not advertise an e-marker (basic cable)" : {
+
+    },
+    "Cable has an e-marker chip (advertises its capabilities)" : {
+
+    },
+    "Cable is limiting charging speed" : {
+
+    },
+    "Cable made by %@" : {
+
+    },
+    "Cable rated for %@ at up to %lldV (~%lldW)" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Cable rated for %1$@ at up to %2$lldV (~%3$lldW)"
+          }
+        }
+      }
+    },
+    "Cable speed: %@" : {
+
+    },
+    "Cable trust signals:" : {
+
+    },
+    "Carrying DisplayPort video" : {
+
+    },
+    "Carrying both data and DisplayPort video." : {
+
+    },
+    "Charger advertises up to %lldW" : {
+
+    },
+    "Charger and cable are well-matched." : {
+
+    },
+    "Charger can deliver up to %lldW, but this cable is only rated to carry %lldW. Replace the cable to charge faster." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Charger can deliver up to %1$lldW, but this cable is only rated to carry %2$lldW. Replace the cable to charge faster."
+          }
+        }
+      }
+    },
+    "Charging" : {
+
+    },
+    "Charging at %lldW (charger can do up to %lldW)" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Charging at %1$lldW (charger can do up to %2$lldW)"
+          }
+        }
+      }
+    },
+    "Charging only" : {
+
+    },
+    "Charging well at %lldW" : {
+
+    },
+    "Charging · %lldW charger" : {
+
+    },
+    "Charging: " : {
+
+    },
+    "Connected" : {
+
+    },
+    "Connected device: %@, %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Connected device: %1$@, %2$@"
+          }
+        }
+      }
+    },
+    "Connected to %@" : {
+
+    },
+    "Connected via %lld hops: %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Connected via %1$lld hops: %2$@"
+          }
+        }
+      }
+    },
+    "Connected." : {
+
+    },
+    "Copper" : {
+
+    },
+    "Couldn't determine cable type from this port." : {
+
+    },
+    "Currently negotiated: %@ @ %@ (%@)" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Currently negotiated: %1$@ @ %2$@ (%3$@)"
+          }
+        }
+      }
+    },
+    "Display connected" : {
+
+    },
+    "Display connected · %lldW charger" : {
+
+    },
+    "DisplayPort video over USB-C alt mode." : {
+
+    },
+    "E-marker claims EPR support but reports only 20V max VBUS" : {
+
+    },
+    "E-marker reports no vendor identity" : {
+
+    },
+    "E-marker uses a reserved cable-latency value" : {
+
+    },
+    "E-marker uses a reserved current-rating value" : {
+
+    },
+    "E-marker uses a reserved data-speed value" : {
+
+    },
+    "E-marker uses an invalid VDO version" : {
+
+    },
+    "E-marker uses an invalid cable-termination value" : {
+
+    },
+    "Last leg drops from %@ to %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Last leg drops from %1$@ to %2$@"
+          }
+        }
+      }
+    },
+    "Legitimate USB-IF members ship cables with a non-zero vendor ID. A zeroed VID is a common counterfeit signature." : {
+
+    },
+    "Linked at %@" : {
+
+    },
+    "Negotiation hasn't completed yet." : {
+
+    },
+    "No USB-C / MagSafe ports were found on this Mac." : {
+
+    },
+    "Nothing connected" : {
+
+    },
+    "Only USB 2.0 is active. If you expected high speed, the cable may not support it." : {
+
+    },
+    "Optical" : {
+
+    },
+    "Optical cable" : {
+
+    },
+    "Optical cable, not electrically isolated (carries copper alongside the fibres)" : {
+
+    },
+    "Optical fibres are electrically isolated end-to-end" : {
+
+    },
+    "Other" : {
+
+    },
+    "Passive cable" : {
+
+    },
+    "Plug a cable into %@ to see what it can do." : {
+
+    },
+    "Power is flowing but no data link is established." : {
+
+    },
+    "Power is flowing. No data connection." : {
+
+    },
+    "Raw IOKit properties:" : {
+
+    },
+    "Re-driver" : {
+
+    },
+    "Re-timer" : {
+
+    },
+    "Reserved" : {
+
+    },
+    "Slow USB device or charge-only cable" : {
+
+    },
+    "Slow USB device or charge-only cable · %lldW charger" : {
+
+    },
+    "SuperSpeed USB (5 Gbps or faster)" : {
+
+    },
+    "SuperSpeed data link is active." : {
+
+    },
+    "Supports %@." : {
+
+    },
+    "The cable's e-marker advertises EPR Capable, but reports its Max VBUS Voltage as 20V. EPR operation needs 48V or 50V VBUS, so the two fields contradict each other." : {
+
+    },
+    "The cable's e-marker reports VDO version %lld, which is reserved or marked Invalid by the USB-PD spec for this cable type. Real e-marker silicon should not emit Invalid version values." : {
+
+    },
+    "The cable's e-marker reports cable termination %lld, which the USB-PD spec marks as Invalid for this cable type. Mis-flashed e-markers commonly disagree with the cable's actual physical wiring here." : {
+
+    },
+    "The cable's e-marker reports cable-latency value %lld, which is reserved by the USB-PD spec for this cable type. Real e-marker chips should not emit reserved values." : {
+
+    },
+    "The cable's e-marker reports current value %lld, which is reserved by the USB-PD spec. Real e-marker chips should not emit reserved values." : {
+
+    },
+    "The cable's e-marker reports speed value %lld, which is reserved by the USB-PD spec. Real e-marker chips should not emit reserved values." : {
+
+    },
+    "The cable's e-marker reports vendor %@, which isn't in our bundled USB-IF list. The number could be unassigned, copied, or assigned after the bundled list was generated. On its own this isn't proof of a problem, but on a clone cable it often appears alongside other inconsistencies." : {
+
+    },
+    "This port can't read cable details (USB-only port, no Power Delivery)" : {
+
+    },
+    "Thunderbolt / USB4" : {
+
+    },
+    "Thunderbolt / USB4 link active" : {
+
+    },
+    "Thunderbolt / USB4 · %lldW charger" : {
+
+    },
+    "USB 2.0 (480 Mbps)" : {
+
+    },
+    "USB 2.0 only (480 Mbps), no high-speed data" : {
+
+    },
+    "USB 3.2 Gen 1 (5 Gbps)" : {
+
+    },
+    "USB 3.2 Gen 2 (10 Gbps)" : {
+
+    },
+    "USB Hub" : {
+
+    },
+    "USB Peripheral" : {
+
+    },
+    "USB default" : {
+
+    },
+    "USB device" : {
+
+    },
+    "USB device · %lldW charger" : {
+
+    },
+    "USB-C with video" : {
+
+    },
+    "USB-C with video · %lldW charger" : {
+
+    },
+    "USB4 Gen 3 (20 / 40 Gbps)" : {
+
+    },
+    "USB4 Gen 4 (80 Gbps)" : {
+
+    },
+    "Unknown device" : {
+
+    },
+    "Unknown generation (raw speed code 0x%@)" : {
+
+    },
+    "Unknown generation (raw speed code 0x2, inferred TB5)" : {
+
+    },
+    "Unspecified" : {
+
+    },
+    "Up to %lld Gb/s %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Up to %1$lld Gb/s %2$@"
+          }
+        }
+      }
+    },
+    "VCONN-powered device" : {
+
+    },
+    "Vendor ID isn't in USB-IF's published list" : {
+
+    },
+    "What can this USB-C cable actually do?" : {
+
+    },
+    "high-speed data" : {
+
+    },
+    "smart cable" : {
+
+    },
+    "video" : {
+
+    }
+  },
+  "version" : "1.0"
+}

--- a/Sources/WhatCableCore/TextFormatter.swift
+++ b/Sources/WhatCableCore/TextFormatter.swift
@@ -10,7 +10,7 @@ public enum TextFormatter {
         thunderboltSwitches: [ThunderboltSwitch] = []
     ) -> String {
         if ports.isEmpty {
-            return "No USB-C / MagSafe ports were found on this Mac.\n"
+            return String(localized: "No USB-C / MagSafe ports were found on this Mac.", bundle: .module) + "\n"
         }
 
         var out = ""
@@ -61,7 +61,7 @@ public enum TextFormatter {
 
         if let diag = ChargingDiagnostic(port: port, sources: sources, identities: identities, adapter: adapter) {
             let diagColor = diag.isWarning ? ANSI.yellow : ANSI.green
-            out += "\n" + ANSI.wrap(ANSI.bold, "Charging: ") + ANSI.wrap(diagColor, diag.summary) + "\n"
+            out += "\n" + ANSI.wrap(ANSI.bold, String(localized: "Charging: ", bundle: .module)) + ANSI.wrap(diagColor, diag.summary) + "\n"
             out += "  " + ANSI.wrap(ANSI.dim, diag.detail) + "\n"
         }
 
@@ -72,7 +72,7 @@ public enum TextFormatter {
         if let cable = identities.first(where: { $0.endpoint == .sopPrime || $0.endpoint == .sopDoublePrime }) {
             let trust = CableTrustReport(identity: cable)
             if !trust.isEmpty {
-                out += "\n" + ANSI.wrap(ANSI.bold + ANSI.yellow, "Cable trust signals:") + "\n"
+                out += "\n" + ANSI.wrap(ANSI.bold + ANSI.yellow, String(localized: "Cable trust signals:", bundle: .module)) + "\n"
                 for flag in trust.flags {
                     out += "  " + ANSI.wrap(ANSI.yellow, "⚠") + " " + ANSI.wrap(ANSI.bold, flag.title) + "\n"
                     out += "    " + ANSI.wrap(ANSI.dim, flag.detail) + "\n"
@@ -81,7 +81,7 @@ public enum TextFormatter {
         }
 
         if showRaw {
-            out += "\n" + ANSI.wrap(ANSI.bold, "Raw IOKit properties:") + "\n"
+            out += "\n" + ANSI.wrap(ANSI.bold, String(localized: "Raw IOKit properties:", bundle: .module)) + "\n"
             for key in port.rawProperties.keys.sorted() {
                 let value = port.rawProperties[key] ?? ""
                 out += "  " + ANSI.wrap(ANSI.gray, key) + " = \(value)\n"

--- a/Sources/WhatCableCore/ThunderboltLabels.swift
+++ b/Sources/WhatCableCore/ThunderboltLabels.swift
@@ -29,13 +29,12 @@ public enum ThunderboltLabels {
         case .tb3, .usb4Tb4:
             guard let perLane = gen.perLaneGbps else { return nil }
             let lanes = describeLanes(width)
-            return "Up to \(perLane) Gb/s \(lanes)"
+            return String(localized: "Up to \(perLane) Gb/s \(lanes)", bundle: .module)
         case .tb5:
-            // Don't emit a "TB5" or "40 Gb/s" label yet — encoding inferred,
-            // not yet verified against real hardware.
-            return "Unknown generation (raw speed code 0x2, inferred TB5)"
+            return String(localized: "Unknown generation (raw speed code 0x2, inferred TB5)", bundle: .module)
         case .unknown(let raw):
-            return "Unknown generation (raw speed code 0x\(String(raw, radix: 16)))"
+            let hex = String(raw, radix: 16)
+            return String(localized: "Unknown generation (raw speed code 0x\(hex))", bundle: .module)
         }
     }
 
@@ -60,7 +59,7 @@ public enum ThunderboltLabels {
         case (false, false): return "\(vendor) \(model)"
         case (false, true): return vendor
         case (true, false): return model
-        case (true, true): return "Unknown device"
+        case (true, true): return String(localized: "Unknown device", bundle: .module)
         }
     }
 }

--- a/Tests/WhatCableCoreTests/LocalisationTests.swift
+++ b/Tests/WhatCableCoreTests/LocalisationTests.swift
@@ -1,0 +1,28 @@
+import XCTest
+import Foundation
+@testable import WhatCableCore
+
+final class LocalisationTests: XCTestCase {
+
+    func testCoreStringCatalogIsValidJSON() throws {
+        let bundle = Bundle.module
+        let url = try XCTUnwrap(bundle.url(forResource: "Localizable", withExtension: "xcstrings"))
+        let data = try Data(contentsOf: url)
+        let catalog = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        let strings = try XCTUnwrap(catalog?["strings"] as? [String: Any])
+        XCTAssertGreaterThan(strings.count, 50, "Core catalog should have many string keys")
+        XCTAssertEqual(catalog?["sourceLanguage"] as? String, "en")
+    }
+
+    func testEnglishSourceStringsResolveToThemselves() {
+        let bundle = Bundle.module
+        let sample = String(localized: "Nothing connected", bundle: bundle)
+        XCTAssertEqual(sample, "Nothing connected")
+    }
+
+    func testInterpolatedStringsResolve() {
+        let bundle = Bundle.module
+        let result = String(localized: "Cable speed: \("USB 3.2 Gen 2 (10 Gbps)")", bundle: bundle)
+        XCTAssertEqual(result, "Cable speed: USB 3.2 Gen 2 (10 Gbps)")
+    }
+}

--- a/scripts/build-app-mas.sh
+++ b/scripts/build-app-mas.sh
@@ -119,6 +119,15 @@ if [[ -d "${SPM_RESOURCES_SRC}" ]]; then
     cp -R "${SPM_RESOURCES_SRC}/." "${bundle_path}/"
 fi
 
+APP_BUNDLE_NAME="WhatCable_WhatCable.bundle"
+APP_RESOURCES_SRC="Sources/WhatCable/Resources"
+if [[ -d "${APP_RESOURCES_SRC}" ]]; then
+    bundle_path="${RESOURCES_DIR}/${APP_BUNDLE_NAME}"
+    rm -rf "${bundle_path}"
+    mkdir -p "${bundle_path}"
+    cp -R "${APP_RESOURCES_SRC}/." "${bundle_path}/"
+fi
+
 echo "==> Verifying universal binaries"
 lipo -archs "${MACOS_DIR}/${APP_NAME}" | sed 's/^/    app: /'
 lipo -archs "${HELPERS_DIR}/${CLI_BIN_NAME}" | sed 's/^/    cli: /'

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -79,6 +79,16 @@ if [[ -d "${SPM_RESOURCES_SRC}" ]]; then
     cp -R "${SPM_RESOURCES_SRC}/." "${bundle_path}/"
 fi
 
+# The WhatCable app target also has its own string catalog for UI strings.
+APP_BUNDLE_NAME="WhatCable_WhatCable.bundle"
+APP_RESOURCES_SRC="Sources/WhatCable/Resources"
+if [[ -d "${APP_RESOURCES_SRC}" ]]; then
+    bundle_path="${RESOURCES_DIR}/${APP_BUNDLE_NAME}"
+    rm -rf "${bundle_path}"
+    mkdir -p "${bundle_path}"
+    cp -R "${APP_RESOURCES_SRC}/." "${bundle_path}/"
+fi
+
 echo "==> Verifying universal binaries"
 lipo -archs "${MACOS_DIR}/${APP_NAME}" | sed 's/^/    app: /'
 lipo -archs "${HELPERS_DIR}/${CLI_BIN_NAME}" | sed 's/^/    cli: /'


### PR DESCRIPTION
## Summary

- Wrap all user-facing strings in WhatCableCore and WhatCable with `String(localized:bundle:.module)`, backed by `.xcstrings` catalogs in each target.
- Add proper CLDR plural variants for count-dependent strings (`"%lld USB devices"`, `"%lld devices removed"`, port count message).
- Use `Text(verbatim:)` for decorative separators, computed labels, and other non-translatable content.
- Update `smoke-test.sh` and `build-app-mas.sh` to copy the new `WhatCable_WhatCable.bundle` into the app bundle alongside the existing Core bundle.
- Add `LocalisationTests` verifying catalog validity and English string resolution.

CLI output stays English-only. PD spec labels (cable type, speed, connector kind) are included in the translatable surface since they appear in the GUI.

## Test plan

- [x] 248 tests pass
- [x] `smoke-test.sh` passes end-to-end (build, sign, notarise, staple, both binary smoke tests, Gatekeeper)
- [x] MAS build path compiles clean (`WHATCABLE_MAS=1 swift build --product WhatCable`)
- [x] App launches and stays running from `dist/WhatCable.app`
- [x] Codex review: all must-fix issues addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)