### PR TITLE
Make updater bundle replacement recoverable

### DIFF
--- a/Sources/WhatCable/Installer.swift
+++ b/Sources/WhatCable/Installer.swift
@@ -141,6 +141,7 @@ final class Installer: ObservableObject {
         PID=\(ProcessInfo.processInfo.processIdentifier)
         NEW=\(shellQuote(newApp.path))
         OLD=\(shellQuote(currentApp.path))
+        BACKUP="${OLD}.backup"
 
         # Wait up to 30s for the running app to exit
         for _ in $(seq 1 60); do
@@ -148,9 +149,21 @@ final class Installer: ObservableObject {
             sleep 0.5
         done
 
-        rm -rf "$OLD"
-        mv "$NEW" "$OLD"
-        open "$OLD"
+        # Move old bundle to backup instead of deleting it.
+        # If the swap fails, the user can rename .backup back.
+        rm -rf "$BACKUP"
+        mv "$OLD" "$BACKUP"
+
+        if mv "$NEW" "$OLD"; then
+            open "$OLD"
+            sleep 2
+            rm -rf "$BACKUP"
+        else
+            # Swap failed; remove any partial destination before restoring.
+            rm -rf "$OLD"
+            mv "$BACKUP" "$OLD"
+            open "$OLD"
+        fi
 
         # Clean up this script and the temp directory.
         rm -rf "$(dirname "$0")"


### PR DESCRIPTION
## Summary
- Renames the old app bundle to `.backup` instead of deleting it before the swap, so an interrupted update leaves the original recoverable.
- Restores the backup automatically if the move fails, cleaning up any partial destination first.

Closes #40

## Test plan
- [ ] Trigger an in-app update and confirm the swap completes normally (backup cleaned up after relaunch).
- [ ] Simulate a failed `mv` (e.g. read-only destination) and confirm the original bundle is restored.
- [ ] Confirm no `.backup` bundle lingers after a successful update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)