### PR TITLE
Restore technical details toggle to footer

### DIFF
--- a/Sources/WhatCable/ContentView.swift
+++ b/Sources/WhatCable/ContentView.swift
@@ -243,10 +243,10 @@ struct ContentView: View {
 
     private var footer: some View {
         HStack {
-            Button(String(localized: "Quit", bundle: .module)) { NSApplication.shared.terminate(nil) }
-                .buttonStyle(.borderless)
+            Toggle(String(localized: "Show technical details", bundle: .module), isOn: $settings.showTechnicalDetails)
+                .toggleStyle(.switch)
+                .controlSize(.mini)
                 .scaledFont(.caption)
-                .foregroundStyle(.secondary)
             Spacer()
             Text(String(localized: "\(deviceWatcher.devices.count) USB devices", bundle: .module))
                 .scaledFont(.caption)
@@ -255,6 +255,11 @@ struct ContentView: View {
             Text(verbatim: "v\(AppInfo.version) · \(AppInfo.credit)")
                 .scaledFont(.caption)
                 .foregroundStyle(.tertiary)
+            Text(verbatim: "·").scaledFont(.caption).foregroundStyle(.secondary)
+            Button(String(localized: "Quit", bundle: .module)) { NSApplication.shared.terminate(nil) }
+                .buttonStyle(.borderless)
+                .scaledFont(.caption)
+                .foregroundStyle(.secondary)
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 8)


### PR DESCRIPTION
## Summary
- Restores the "Show technical details" toggle to the footer for quick access (it was removed when Settings was introduced)
- Moves the Quit button to the right-hand side of the footer

## Test plan
- [ ] Verify the toggle appears in the footer and controls the technical details sections
- [ ] Verify the Quit button works from its new position on the right

🤖 Generated with [Claude Code](https://claude.com/claude-code)