### PR TITLE
Flip TB5 hedge to confirmed labels (issue #52)

### DIFF
--- a/Sources/WhatCableCore/JSONFormatter.swift
+++ b/Sources/WhatCableCore/JSONFormatter.swift
@@ -332,13 +332,11 @@ private struct ThunderboltPortDTO: Codable {
         switch gen {
         case .tb3: return "tb3"
         case .usb4Tb4: return "usb4Tb4"
-        // TB5 stays hedged in JSON for the same reason as the text
-        // renderer: the 0x2 -> TB5 mapping is inferred from Linux
-        // register definitions but not yet verified against an Apple
-        // Silicon TB5 paste-back. Machine consumers that want the raw
-        // code can read `rawSpeedCode` directly. The label flips to
-        // `"tb5"` once verified.
-        case .tb5: return "unknown(0x2_inferredTb5)"
+        // TB5 (raw speed code 0x2) was confirmed against a real M5 Pro +
+        // UGreen JHL9580 dock paste-back on issue #52, so the hedge has
+        // been dropped. Machine consumers that want the raw code can
+        // still read `rawSpeedCode` directly.
+        case .tb5: return "tb5"
         case .unknown(let raw): return "unknown(0x\(String(raw, radix: 16)))"
         }
     }

--- a/Sources/WhatCableCore/ThunderboltLabels.swift
+++ b/Sources/WhatCableCore/ThunderboltLabels.swift
@@ -5,17 +5,17 @@ import Foundation
 /// matching Apple's `system_profiler SPThunderboltDataType` output so the
 /// labels line up with what users see in About This Mac → System Information.
 ///
-/// Conservative on TB5: even though the model decodes raw speed code `0x2`
-/// to `LinkGeneration.tb5`, the renderer treats that as unverified and emits
-/// a hedge label until we have a real Apple Silicon TB5 paste-back. See
-/// planning/thunderbolt-fabric.md for the reasoning.
+/// TB5 was confirmed against a real M5 Pro + UGreen JHL9580 dock sample on
+/// issue #52, so the renderer now emits a confirmed TB5 label for raw speed
+/// code `0x2`. See planning/thunderbolt-fabric.md for the reasoning.
 public enum ThunderboltLabels {
     /// Compact human label for an active TB link.
     /// Returns nil if the port has no active link.
     /// Examples:
     /// - `"Up to 20 Gb/s × 2"` (USB4 / TB4 dual-lane)
     /// - `"Up to 10 Gb/s × 1"` (TB3 single-lane)
-    /// - `"Unknown generation (raw speed code 0x2)"` (TB5 inferred but not verified)
+    /// - `"Up to 40 Gb/s × 2"` (TB5 / USB4 v2 dual-lane)
+    /// - `"Up to 40 Gb/s (3 TX / 1 RX)"` (TB5 asymmetric)
     public static func linkLabel(for port: ThunderboltPort) -> String? {
         guard port.hasActiveLink,
               let gen = port.currentSpeed,
@@ -23,15 +23,11 @@ public enum ThunderboltLabels {
             return nil
         }
 
-        // Hedge wording when we don't have a verified label. TB5 is in
-        // this bucket until a real Apple Silicon TB5 sample lands.
         switch gen {
-        case .tb3, .usb4Tb4:
+        case .tb3, .usb4Tb4, .tb5:
             guard let perLane = gen.perLaneGbps else { return nil }
             let lanes = describeLanes(width)
             return String(localized: "Up to \(perLane) Gb/s \(lanes)", bundle: .module)
-        case .tb5:
-            return String(localized: "Unknown generation (raw speed code 0x2, inferred TB5)", bundle: .module)
         case .unknown(let raw):
             let hex = String(raw, radix: 16)
             return String(localized: "Unknown generation (raw speed code 0x\(hex))", bundle: .module)

--- a/Sources/WhatCableCore/ThunderboltLink.swift
+++ b/Sources/WhatCableCore/ThunderboltLink.swift
@@ -7,10 +7,8 @@ import Foundation
 // the same USB4 lane-adapter registers Apple's IOThunderbolt fields appear
 // to mirror. See planning/thunderbolt-fabric.md for the field-by-field
 // reasoning and the contributor samples that confirmed the mapping for
-// TB3 and TB4 / USB4. TB5 (raw speed code 0x2) is supported in the model
-// but the renderer should not produce a TB5 label until we have a real
-// sample — the `LinkGeneration.unknown(rawSpeedCode:)` escape hatch
-// exists for exactly that.
+// TB3, TB4 / USB4, and TB5. TB5 (raw speed code 0x2) was confirmed against
+// an M5 Pro + UGreen JHL9580 dock paste-back on issue #52.
 
 /// Negotiated lane-rate generation for a Thunderbolt link.
 /// Decoded from `Current Link Speed` on a TB-protocol port (Adapter Type = 1).
@@ -22,8 +20,9 @@ public enum LinkGeneration: Hashable {
     /// renderer treats them as one bucket.
     case usb4Tb4
     /// Speed code `0x2`. 40 Gb/s per lane. USB4 v2 / TB5.
-    /// Inferred from Linux register definitions; not yet verified against
-    /// an Apple Silicon TB5 hardware sample.
+    /// Confirmed via M5 Pro + UGreen JHL9580 dock paste-back on issue #52
+    /// (system_profiler reports "Mode: USB4 v2, Speed: 120 Gb/s" for the
+    /// same active link).
     case tb5
     /// Speed code we don't have a mapping for. Forward-compat: future
     /// generations or unexpected encodings won't break the model.

--- a/Sources/WhatCableDarwinBackend/ThunderboltWatcher.swift
+++ b/Sources/WhatCableDarwinBackend/ThunderboltWatcher.swift
@@ -6,8 +6,8 @@ import WhatCableCore
 /// list of `ThunderboltSwitch` models. Modelled on `USBCPortWatcher`:
 ///
 /// - Match notification on the abstract parent class so all subclass variants
-///   come in (we've seen `Type3`, `Type5`, `Type7`, `IntelJHL8440` so far,
-///   and there will be more once TB5 silicon ships).
+///   come in (we've seen `Type3`, `Type5`, `Type7`, `IntelJHL8440`, and
+///   `IntelJHL9580` so far, and there will be more once new silicon ships).
 /// - Per-service interest notifications for property changes (link state
 ///   moves, dock plug/unplug). Mirrors the USB-C watcher's pattern.
 /// - `refresh()` re-walks the registry; `read()`-style consumers can call it
@@ -258,7 +258,7 @@ public final class ThunderboltWatcher: ObservableObject {
             if IOObjectGetClass(current, &classBuf) == KERN_SUCCESS {
                 let name = String(cString: classBuf)
                 // Match the abstract prefix; covers Type3 / Type5 / Type7 /
-                // IntelJHL8440 / future variants.
+                // IntelJHL8440 / IntelJHL9580 / future variants.
                 if name.hasPrefix("IOThunderboltSwitch") {
                     var entryID: UInt64 = 0
                     if IORegistryEntryGetRegistryEntryID(current, &entryID) == KERN_SUCCESS {

--- a/Tests/WhatCableCoreTests/JSONFormatterTests.swift
+++ b/Tests/WhatCableCoreTests/JSONFormatterTests.swift
@@ -454,10 +454,10 @@ final class JSONFormatterTests: XCTestCase {
         XCTAssertEqual(port["txLanes"] as? Int, 2)
     }
 
-    /// Regression: TB5 must stay hedged in JSON the same way it's hedged
-    /// in the text renderer. Otherwise a `--json` consumer that parses
-    /// `generation == "tb5"` would treat the inferred mapping as verified.
-    func testTb5JsonGenerationLabelStaysHedged() throws {
+    /// TB5 was confirmed against a real M5 Pro + UGreen JHL9580 dock
+    /// sample on issue #52, so JSON consumers now get `generation == "tb5"`
+    /// alongside the per-lane label and the raw speed code.
+    func testTb5JsonGenerationLabelIsConfirmed() throws {
         let host = ThunderboltSwitch(
             id: 1, className: "IOThunderboltSwitchType9",
             vendorID: 1452, vendorName: "Apple Inc.", modelName: "iOS",
@@ -482,11 +482,9 @@ final class JSONFormatterTests: XCTestCase {
         let obj = parse(json)
         let port = ((obj["thunderboltSwitches"] as? [[String: Any]])?.first?["ports"] as? [[String: Any]])?.first ?? [:]
         let gen = port["generation"] as? String ?? ""
-        XCTAssertTrue(
-            gen.contains("inferredTb5") || gen.hasPrefix("unknown"),
-            "TB5 must stay hedged in JSON; got generation = \(gen)"
-        )
-        XCTAssertNotEqual(gen, "tb5", "must not promise verified TB5 yet")
+        XCTAssertEqual(gen, "tb5", "TB5 should be reported as confirmed")
+        XCTAssertEqual(port["linkLabel"] as? String, "Up to 40 Gb/s × 2")
+        XCTAssertEqual(port["perLaneGbps"] as? Int, 40)
         // Raw speed code is still exposed for diagnostics consumers.
         XCTAssertEqual(port["rawSpeedCode"] as? Int, 0x2)
     }

--- a/Tests/WhatCableCoreTests/PortSummaryThunderboltTests.swift
+++ b/Tests/WhatCableCoreTests/PortSummaryThunderboltTests.swift
@@ -218,9 +218,9 @@ final class PortSummaryThunderboltTests: XCTestCase {
         )
     }
 
-    // MARK: - TB5 hedging — must NOT promise "TB5"
+    // MARK: - TB5 confirmed (issue #52: M5 Pro + UGreen JHL9580 dock)
 
-    func testTb5LinkRendersAsHedgedLabel() {
+    func testTb5LinkRendersWithPerLaneLabel() {
         let port = tbPort(socket: "1")
         let host = sw(
             uid: 100, depth: 0, parent: nil,
@@ -229,12 +229,12 @@ final class PortSummaryThunderboltTests: XCTestCase {
         )
         let summary = PortSummary(port: port, thunderboltSwitches: [host])
         XCTAssertTrue(
-            summary.bullets.contains { $0.contains("Unknown generation (raw speed code 0x2") },
-            "TB5 must stay hedged until verified; got: \(summary.bullets)"
+            summary.bullets.contains { $0.contains("40 Gb/s") },
+            "TB5 should report per-lane 40 Gb/s; got: \(summary.bullets)"
         )
         XCTAssertFalse(
-            summary.bullets.contains { $0.contains("40 Gb/s") },
-            "must not promise 40 Gb/s yet"
+            summary.bullets.contains { $0.contains("Unknown generation") },
+            "TB5 should no longer be hedged; got: \(summary.bullets)"
         )
     }
 }

--- a/Tests/WhatCableCoreTests/ThunderboltLabelsTests.swift
+++ b/Tests/WhatCableCoreTests/ThunderboltLabelsTests.swift
@@ -4,7 +4,7 @@ import XCTest
 /// Tests for the user-facing label helpers and topology walker.
 /// These cover the rendering convention chosen for Phase 3:
 ///   - per-lane Gb/s × lane count, matching Apple's `system_profiler`
-///   - hedge wording for unknown / TB5 (TB5 stays hedged until verified)
+///   - hedge wording for unknown speed codes
 ///   - daisy-chain detection by `parentSwitchUID`
 final class ThunderboltLabelsTests: XCTestCase {
 
@@ -25,13 +25,19 @@ final class ThunderboltLabelsTests: XCTestCase {
         XCTAssertEqual(ThunderboltLabels.linkLabel(for: port), "Up to 20 Gb/s × 2")
     }
 
-    /// TB5 stays hedged until verified against real hardware. Even though
-    /// the model decodes raw 0x2 to .tb5, the renderer must not promise
-    /// "TB5" or "40 Gb/s" yet.
-    func testLabelForTb5IsHedged() {
+    /// TB5 was confirmed against a real M5 Pro + UGreen JHL9580 dock
+    /// sample on issue #52, so the renderer now emits the same per-lane
+    /// label format as TB3 and TB4 / USB4.
+    func testLabelForTb5DualLane() {
         let port = makeLanePort(speed: .tb5, widthRaw: 0x2)
-        let label = ThunderboltLabels.linkLabel(for: port)
-        XCTAssertEqual(label, "Unknown generation (raw speed code 0x2, inferred TB5)")
+        XCTAssertEqual(ThunderboltLabels.linkLabel(for: port), "Up to 40 Gb/s × 2")
+    }
+
+    /// TB5 asymmetric 3 TX / 1 RX is the 120 Gb/s configuration reported
+    /// by `system_profiler` on the M5 Pro + UGreen dock sample.
+    func testLabelForTb5Asymmetric() {
+        let port = makeLanePort(speed: .tb5, widthRaw: 0x4)
+        XCTAssertEqual(ThunderboltLabels.linkLabel(for: port), "Up to 40 Gb/s (3 TX / 1 RX)")
     }
 
     func testLabelForUnknownGenerationIsHedged() {


### PR DESCRIPTION
## Summary

- Confirms the `Current Link Speed = 0x2` → TB5 mapping against the M5 Pro + UGreen TBT5 Docking Station 17-in-1 (`IOThunderboltSwitchIntelJHL9580`) paste-back from @NoFr1ends on #52, which `system_profiler` cross-checks as "Mode: USB4 v2, Speed: 120 Gb/s".
- Flips the user-facing text label from `"Unknown generation (raw speed code 0x2, inferred TB5)"` to the same per-lane format as TB3 / TB4 / USB4 (`"Up to 40 Gb/s × 2"`, `"Up to 40 Gb/s (3 TX / 1 RX)"` for asymmetric).
- Flips the JSON `generation` value from `"unknown(0x2_inferredTb5)"` to `"tb5"`. `rawSpeedCode` is unchanged.
- Adds `IntelJHL9580` to the doc strings listing known `IOThunderboltSwitch` subclass variants. The watcher already matches on the abstract prefix, so no code-path change was needed.

Refs #52. Leaving the issue open as the broader call for testers.

## Test plan

- [x] `swift test` passes (257 tests).
- [x] `testLabelForTb5DualLane` and `testLabelForTb5Asymmetric` cover the new text label paths.
- [x] `testTb5JsonGenerationLabelIsConfirmed` covers the JSON flip.
- [x] `testTb5LinkRendersWithPerLaneLabel` covers the `PortSummary` rendering path.
- [ ] Manual smoke against a real TB5 link once a release candidate is built.

🤖 Generated with [Claude Code](https://claude.com/claude-code)