### PR TITLE
Soften desktop Mac banner after #95 IOKit dumps

### DIFF
--- a/Sources/WhatCable/ContentView.swift
+++ b/Sources/WhatCable/ContentView.swift
@@ -176,7 +176,7 @@ struct ContentView: View {
             if isDesktopMac {
                 HStack(spacing: 4) {
                     Image(systemName: "info.circle")
-                    Text("Desktop Mac: per-port PD diagnostics are not available.")
+                    Text("Desktop Mac: charger identity (FedDetails) is not available.")
                 }
                 .scaledFont(.caption)
                 .foregroundStyle(.secondary)

--- a/Sources/WhatCableCore/TextFormatter.swift
+++ b/Sources/WhatCableCore/TextFormatter.swift
@@ -17,7 +17,7 @@ public enum TextFormatter {
 
         var out = ""
         if isDesktopMac {
-            out += ANSI.wrap(ANSI.dim, "Desktop Mac: per-port PD diagnostics are not available (no battery controller).") + "\n\n"
+            out += ANSI.wrap(ANSI.dim, "Desktop Mac: charger identity (FedDetails) is not available (no battery controller).") + "\n\n"
         }
         for (i, port) in ports.enumerated() {
             if i > 0 { out += "\n" }


### PR DESCRIPTION
## Summary

- Updates the desktop Mac info banner in both the GUI and CLI to say only charger identity (FedDetails) is missing, not all diagnostics.
- @jshier's Mac Studio (M3 Ultra) IOKit dumps on #95 confirmed that desktop Macs expose full port data via `AppleHPMInterfaceType10`. Cable e-markers, device enumeration, and Thunderbolt fabric all work normally.
- The only thing genuinely missing on desktop Macs is FedDetails (charger VID/PID from the battery controller).

Closes #95

## Test plan

- [x] All 261 tests pass
- [ ] CI green

Generated with [Claude Code](https://claude.com/claude-code)