### PR TITLE
Add Update button to Check for Updates alert

### DIFF
--- a/Sources/WhatCable/UpdateChecker.swift
+++ b/Sources/WhatCable/UpdateChecker.swift
@@ -155,13 +155,19 @@ final class UpdateChecker: ObservableObject {
         alert.messageText = "WhatCable \(update.version) is available"
         alert.informativeText = "You're on \(AppInfo.version). Open the release page to read the notes and download."
         alert.window.level = .floating
+        let hasDownload = update.downloadURL != nil
+        if hasDownload {
+            alert.addButton(withTitle: "Update")
+        }
         alert.addButton(withTitle: "View Release")
         alert.addButton(withTitle: "Later")
         let response = alert.runModal()
 
         NSApp.setActivationPolicy(originalPolicy)
 
-        if response == .alertFirstButtonReturn {
+        if hasDownload && response == .alertFirstButtonReturn {
+            Installer.shared.install(update)
+        } else if response == (hasDownload ? .alertSecondButtonReturn : .alertFirstButtonReturn) {
             NSWorkspace.shared.open(update.url)
         }
     }


### PR DESCRIPTION
## Summary

- The right-click "Check for Updates" alert previously only had "View Release" and "Later" buttons.
- Adds an "Update" button as the primary action, which triggers the in-process installer (download, verify signature, swap bundles).
- Same installer code path the "Install update" button in the menu bar UpdateBanner already uses.
- Falls back to the existing two-button layout if no download URL is available.

## Test plan

- [x] All 261 tests pass
- [ ] CI green
- [ ] Manual: right-click WhatCable, Check for Updates, confirm Update button appears and triggers install

Generated with [Claude Code](https://claude.com/claude-code)