### PR TITLE
Set www.whatcable.uk as canonical domain

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,1 +1,1 @@
-whatcable.uk
+www.whatcable.uk


### PR DESCRIPTION
## Summary
- Updates the GitHub Pages CNAME from `whatcable.uk` to `www.whatcable.uk`
- Fixes GSC "page with redirect" and "duplicate without user-selected canonical" issues
- GitHub Pages will now 301 redirect `whatcable.uk` to `www.whatcable.uk` instead of the reverse

## Still needed (Cloudflare dashboard)
- Enable "Always Use HTTPS" under SSL/TLS > Edge Certificates to fix HTTP > HTTPS redirects
- Verify `www` DNS record points to GitHub Pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)