### PR TITLE
Update sitemap URLs to www.whatcable.uk

### DIFF
--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -1,27 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://whatcable.uk/</loc>
+    <loc>https://www.whatcable.uk/</loc>
     <changefreq>monthly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
-    <loc>https://whatcable.uk/cables</loc>
+    <loc>https://www.whatcable.uk/cables</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://whatcable.uk/cli</loc>
+    <loc>https://www.whatcable.uk/cli</loc>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://whatcable.uk/instructions</loc>
+    <loc>https://www.whatcable.uk/instructions</loc>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://whatcable.uk/privacy</loc>
+    <loc>https://www.whatcable.uk/privacy</loc>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>


### PR DESCRIPTION
## Summary
- Updates all sitemap.xml URLs from `whatcable.uk` to `www.whatcable.uk` to match the new canonical domain

🤖 Generated with [Claude Code](https://claude.com/claude-code)