### PR TITLE
Fix port data correlation for MagSafe and USB-C

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ secrets/
 # Local planning / design / scratch docs (kept uncommitted by convention)
 planning/
 CLAUDE.md
+BUILDING.md
 
 # Release notes are staged here, then copied into the homebrew-whatcable tap
 # repo and used as the GitHub release body. The tap repo is the canonical home.

--- a/Sources/WhatCable/WidgetDataWriter.swift
+++ b/Sources/WhatCable/WidgetDataWriter.swift
@@ -45,9 +45,10 @@ final class WidgetDataWriter {
 
 #if WHATCABLE_PRO
     private let powerTelemetry = PowerTelemetryWatcher()
-    /// Rolling per-port wattage samples keyed by 1-based port index. Each
-    /// buffer holds the last 12 samples (~24s at the watcher's 2s poll rate).
-    private var recentPowerByPort: [Int: [Double]] = [:]
+    /// Rolling per-port wattage samples keyed by portKey (e.g. "2/1",
+    /// "17/1"). Each buffer holds the last 12 samples (~24s at the
+    /// watcher's 2s poll rate).
+    private var recentPowerByPort: [String: [Double]] = [:]
     private let maxRecentSamples = 12
 #endif
 
@@ -171,39 +172,24 @@ final class WidgetDataWriter {
     /// Push a fresh PowerTelemetryWatcher snapshot into the rolling buffers.
     private func appendPower(from snapshot: PowerMonitorSnapshot) {
         var changed = false
-        for (offset, sample) in snapshot.portSamples.enumerated() {
-            let index = sample.portIndex > 0 ? sample.portIndex : offset + 1
+        for sample in snapshot.portSamples {
+            let key = sample.portKey.isEmpty ? "2/\(sample.portIndex)" : sample.portKey
             let watts = Double(sample.watts) / 1000
-            // Only track samples while the port is actively delivering power;
-            // idle ports get their buffer cleared so the widget shows a flat
-            // line rather than stale data.
             guard sample.watts > 0 || sample.current > 0 else {
-                if recentPowerByPort.removeValue(forKey: index) != nil {
+                if recentPowerByPort.removeValue(forKey: key) != nil {
                     changed = true
                 }
                 continue
             }
-            var samples = recentPowerByPort[index, default: []]
+            var samples = recentPowerByPort[key, default: []]
             samples.append((watts * 10).rounded() / 10)
             if samples.count > maxRecentSamples {
                 samples.removeFirst(samples.count - maxRecentSamples)
             }
-            recentPowerByPort[index] = samples
+            recentPowerByPort[key] = samples
             changed = true
         }
         if changed { scheduleWrite() }
-    }
-
-    /// Extract the 1-based port index from "Port-USB-C@N" service names.
-    private func portIndex(for port: USBCPort) -> Int? {
-        let candidates = [port.serviceName, port.portDescription].compactMap { $0 }
-        for name in candidates {
-            if let atRange = name.range(of: "@", options: .backwards) {
-                let suffix = name[atRange.upperBound...]
-                if let value = Int(suffix), value > 0 { return value }
-            }
-        }
-        return nil
     }
 #endif
 
@@ -233,8 +219,8 @@ final class WidgetDataWriter {
 
             var recentPower: [Double] = []
 #if WHATCABLE_PRO
-            if let index = portIndex(for: port) {
-                recentPower = recentPowerByPort[index] ?? []
+            if let key = port.portKey {
+                recentPower = recentPowerByPort[key] ?? []
             }
 #endif
 

--- a/Sources/WhatCableCLI/MonitorCommand.swift
+++ b/Sources/WhatCableCLI/MonitorCommand.swift
@@ -60,18 +60,14 @@ func runPowerMonitor(asJSON: Bool) async {
 
 private func renderPowerMonitor(_ snapshot: PowerMonitorSnapshot) -> String {
     var lines = ["WhatCable Pro -- Power Monitor  (Ctrl-C to stop)", ""]
-    var samplesByPort: [Int: PortPowerSample] = [:]
-    for (offset, sample) in snapshot.portSamples.enumerated() {
-        samplesByPort[displayPortIndex(for: sample, offset: offset)] = sample
+    var activeLines: [String] = []
+    for sample in snapshot.portSamples where isActive(sample) {
+        activeLines.append(renderPortLine(portIndex: sample.portIndex, sample: sample, estimate: snapshot.resistanceEstimate))
     }
-    let highestPort = max(3, samplesByPort.keys.max() ?? 0)
-
-    for port in 1...highestPort {
-        if let sample = samplesByPort[port], isActive(sample) {
-            lines.append(renderPortLine(port: port, sample: sample, estimate: snapshot.resistanceEstimate))
-        } else {
-            lines.append("Port \(port)  --")
-        }
+    if activeLines.isEmpty {
+        lines.append("No active ports")
+    } else {
+        lines.append(contentsOf: activeLines)
     }
 
     lines.append("")
@@ -81,11 +77,11 @@ private func renderPowerMonitor(_ snapshot: PowerMonitorSnapshot) -> String {
     return lines.joined(separator: "\n")
 }
 
-private func renderPortLine(port: Int, sample: PortPowerSample, estimate: CableResistanceEstimate?) -> String {
+private func renderPortLine(portIndex: Int, sample: PortPowerSample, estimate: CableResistanceEstimate?) -> String {
     let voltage = sample.adapterVoltage > 0 ? sample.adapterVoltage : sample.configuredVoltage
     let prefix = String(
         format: "Port %-2d %@  %@  %@",
-        port,
+        portIndex,
         formatVoltage(voltage),
         formatCurrent(sample.current),
         formatPower(sample.watts)
@@ -100,10 +96,6 @@ private func renderSystemLine(_ sample: PowerSample) -> String {
         formatCurrent(sample.systemCurrentIn),
         formatPower(sample.systemPowerIn)
     )
-}
-
-private func displayPortIndex(for sample: PortPowerSample, offset: Int) -> Int {
-    sample.portIndex > 0 ? sample.portIndex : offset + 1
 }
 
 private func isActive(_ sample: PortPowerSample) -> Bool {


### PR DESCRIPTION
## Summary

- **[Pro] Fix MagSafe/USB-C diagnostic data collision.** `PortControllerInfo` entries have no port identifier, so keying by integer caused MagSafe@1 and USB-C@1 to show identical PD Contract, Event Trace, and Port Health data in the Pro diagnostic windows. Now uses `portKey` strings (`"portType/portNumber"`) which include the port type to disambiguate.
- **[Pro] Add `hpmPortKeys()` helper** that walks IOKit HPM services once at watcher startup and maps array offsets to the correct portKey. Cached per session, not per poll.
- **[Pro] Deduplicate PD Event Trace display.** Groups all occurrences of the same event type into one line with a count badge, sorted by frequency.

## Test plan

- [x] `swift build` and `WHATCABLE_PRO=1 swift build` pass
- [x] 261 tests pass
- [x] Built and tested Pro app bundle on M5 Pro
- [x] MagSafe and USB-C diagnostic windows show distinct data
- [x] Event trace shows grouped events with count badges
- [x] Codex review passed (two P2 issues found and fixed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)