### PR TITLE
Soften e-marker wording when macOS hasn't probed the cable

### DIFF
--- a/Sources/WhatCableCore/PortSummary.swift
+++ b/Sources/WhatCableCore/PortSummary.swift
@@ -154,7 +154,7 @@ extension PortSummary {
             bullets.append(String(localized: "Cable has an e-marker chip (advertises its capabilities)", bundle: .module))
         } else if !active.isEmpty && !isMagSafe {
             if pdCapable {
-                bullets.append(String(localized: "Cable does not advertise an e-marker (basic cable)", bundle: .module))
+                bullets.append(String(localized: "No e-marker reported. macOS only asks above 3A.", bundle: .module))
             } else {
                 bullets.append(String(localized: "This port can't read cable details (USB-only port, no Power Delivery)", bundle: .module))
             }
@@ -304,7 +304,7 @@ extension PortSummary {
         } else {
             self.status = .unknown
             self.headline = String(localized: "Connected", bundle: .module)
-            self.subtitle = String(localized: "Couldn't determine cable type from this port.", bundle: .module)
+            self.subtitle = String(localized: "Try a higher-wattage charger to identify the cable.", bundle: .module)
         }
 
         self.bullets = bullets

--- a/Tests/WhatCableCoreTests/JSONFormatterTests.swift
+++ b/Tests/WhatCableCoreTests/JSONFormatterTests.swift
@@ -366,10 +366,10 @@ final class JSONFormatterTests: XCTestCase {
         let obj = parse(json)
         let portJSON = (obj["ports"] as? [[String: Any]])?.first ?? [:]
         XCTAssertEqual(portJSON["pdCapable"] as? Bool, false)
-        // And the port-level bullet should not claim "basic cable".
+        // And the port-level bullet should not claim a missing e-marker.
         let bullets = portJSON["bullets"] as? [String] ?? []
-        XCTAssertFalse(bullets.contains(where: { $0.contains("does not advertise") }),
-                       "no-PD port should not claim 'basic cable', got: \(bullets)")
+        XCTAssertFalse(bullets.contains(where: { $0.contains("No e-marker reported") }),
+                       "no-PD port should not claim a missing e-marker, got: \(bullets)")
         XCTAssertTrue(bullets.contains(where: { $0.contains("can't read cable details") }),
                       "expected 'port can't read cable details' bullet, got: \(bullets)")
     }

--- a/Tests/WhatCableCoreTests/PortSummaryTests.swift
+++ b/Tests/WhatCableCoreTests/PortSummaryTests.swift
@@ -169,13 +169,16 @@ final class PortSummaryTests: XCTestCase {
         )
     }
 
-    func testNoEmarkerCableProducesBasicCableBullet() {
-        // PD-capable port (CC present) with no e-marker: existing wording.
+    func testNoEmarkerCableProducesNoEmarkerBullet() {
+        // PD-capable port (CC present) with no SOP'/SOP'' identity. The
+        // wording deliberately doesn't claim "basic cable" — macOS may
+        // simply not have run Discover Identity SOP' yet (typically only
+        // happens when the link needs to negotiate above 3A).
         let port = makePort(active: ["USB2"], supported: ["CC", "USB2"], emarker: false)
         let summary = PortSummary(port: port)
         XCTAssertTrue(
-            summary.bullets.contains(where: { $0.contains("does not advertise") }),
-            "expected a basic-cable bullet, got: \(summary.bullets)"
+            summary.bullets.contains(where: { $0.contains("No e-marker reported") }),
+            "expected a no-e-marker bullet, got: \(summary.bullets)"
         )
     }
 
@@ -186,8 +189,8 @@ final class PortSummaryTests: XCTestCase {
         let port = makePort(active: ["USB3"], supported: ["USB2", "USB3"], superSpeed: true)
         let summary = PortSummary(port: port)
         XCTAssertFalse(
-            summary.bullets.contains(where: { $0.contains("does not advertise") }),
-            "no-PD port should not claim 'basic cable', got: \(summary.bullets)"
+            summary.bullets.contains(where: { $0.contains("No e-marker reported") }),
+            "no-PD port should not claim a missing e-marker, got: \(summary.bullets)"
         )
         XCTAssertTrue(
             summary.bullets.contains(where: { $0.contains("can't read cable details") }),
@@ -232,8 +235,8 @@ final class PortSummaryTests: XCTestCase {
             "MagSafe must not show the 'can't read cable details' bullet, got: \(summary.bullets)"
         )
         XCTAssertFalse(
-            summary.bullets.contains(where: { $0.contains("does not advertise") }),
-            "MagSafe must not show the 'basic cable' bullet, got: \(summary.bullets)"
+            summary.bullets.contains(where: { $0.contains("No e-marker reported") }),
+            "MagSafe must not show the missing-e-marker bullet, got: \(summary.bullets)"
         )
     }
 


### PR DESCRIPTION
## Summary

macOS only runs Discover Identity SOP' on the cable when the link is negotiating above 3A. Below that threshold (e.g. Apple's 20W charger, an 18W power bank), the cable's e-marker chip is never interrogated by the OS, so IOKit reports no SOP'/SOP'' service for the port. WhatCable was reporting this honestly but with overconfident copy that read as a statement about the cable rather than a statement about what macOS has been told.

Triggered by feedback from a tech journalist evaluating WhatCable for a newsletter recommendation. Four known-good e-marked cables (OWC TB5, Anker 240W, Belkin 240W, Apple USB-C) all read as "basic cable" on his M1 MacBook Pro / M1 mini / MacBook Neo because every charger he tested was below 3A. A Total Phase Advanced Cable Tester reads cables via raw VDM and bypasses macOS, so his ground truth and ours legitimately disagreed.

## Changes

Two strings in `Sources/WhatCableCore/PortSummary.swift`:

| Before | After |
|---|---|
| `Cable does not advertise an e-marker (basic cable)` | `No e-marker reported. macOS only asks above 3A.` |
| `Couldn't determine cable type from this port.` | `Try a higher-wattage charger to identify the cable.` |

Same on-screen length, no layout reflow.

Three test assertions updated in `Tests/WhatCableCoreTests/PortSummaryTests.swift` and `Tests/WhatCableCoreTests/JSONFormatterTests.swift` to match the new wording. The intent of each test (no-PD ports must not blame the cable, MagSafe must not show the missing-e-marker bullet) is preserved.

No behaviour change. Pure copy.

## Test plan

- [x] `swift test` passes (268 tests, 0 failures).
- [ ] Manual: build, plug a known e-marked cable into a 20W charger, confirm the new bullet appears and reads as expected.
- [ ] Manual: same cable, 96W+ charger, confirm e-marker info still populates (regression check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
