### PR TITLE
Surface e-marker explanation in the no-emarker state

### DIFF
--- a/Sources/WhatCableCore/PortSummary.swift
+++ b/Sources/WhatCableCore/PortSummary.swift
@@ -143,6 +143,10 @@ extension PortSummary {
         // B. The cable
         // ------------------------------------------------------------
 
+        // Hoist the charging source lookup so the e-marker guard can
+        // use it to decide whether something is on the other end.
+        let chargingSource = PowerSource.preferredChargingSource(in: sources)
+
         // E-marker presence. The whole cable-details bullet only makes
         // sense on USB-C, where the user can swap cables and might wonder
         // why details are missing. On MagSafe the cable is part of the
@@ -150,11 +154,21 @@ extension PortSummary {
         // just over its own pins, not the CC line we test for
         // `pdCapable`), so don't emit any "no e-marker" wording there.
         let isMagSafe = port.portTypeDescription?.hasPrefix("MagSafe") == true
+
+        // Show the "no e-marker" explanation when there's evidence
+        // something is connected (active transport, charger, SOP partner,
+        // or USB device), not just when transports are active. Without
+        // this, the .unknown state (empty active) never shows the bullet.
+        let hasPartner = chargingSource != nil
+            || identities.contains(where: { $0.endpoint == .sop })
+            || !devices.isEmpty
+        let hasPayload = !active.isEmpty || hasPartner
+
         if hasEmarker {
             bullets.append(String(localized: "Cable has an e-marker chip (advertises its capabilities)", bundle: .module))
-        } else if !active.isEmpty && !isMagSafe {
+        } else if hasPayload && !isMagSafe {
             if pdCapable {
-                bullets.append(String(localized: "No e-marker reported. macOS only asks above 3A.", bundle: .module))
+                bullets.append(String(localized: "No e-marker detected. The cable may have one, but macOS only checks above 3A.", bundle: .module))
             } else {
                 bullets.append(String(localized: "This port can't read cable details (USB-only port, no Power Delivery)", bundle: .module))
             }
@@ -211,7 +225,6 @@ extension PortSummary {
         // ------------------------------------------------------------
 
         // Power summary from PD or MagSafe power sources.
-        let chargingSource = PowerSource.preferredChargingSource(in: sources)
         if let chargingSource {
             let maxW = Int((Double(chargingSource.maxPowerMW) / 1000).rounded())
             let hasOptions = !chargingSource.options.isEmpty

--- a/Tests/WhatCableCoreTests/PortSummaryTests.swift
+++ b/Tests/WhatCableCoreTests/PortSummaryTests.swift
@@ -177,7 +177,7 @@ final class PortSummaryTests: XCTestCase {
         let port = makePort(active: ["USB2"], supported: ["CC", "USB2"], emarker: false)
         let summary = PortSummary(port: port)
         XCTAssertTrue(
-            summary.bullets.contains(where: { $0.contains("No e-marker reported") }),
+            summary.bullets.contains(where: { $0.contains("No e-marker detected") }),
             "expected a no-e-marker bullet, got: \(summary.bullets)"
         )
     }
@@ -189,7 +189,7 @@ final class PortSummaryTests: XCTestCase {
         let port = makePort(active: ["USB3"], supported: ["USB2", "USB3"], superSpeed: true)
         let summary = PortSummary(port: port)
         XCTAssertFalse(
-            summary.bullets.contains(where: { $0.contains("No e-marker reported") }),
+            summary.bullets.contains(where: { $0.contains("No e-marker detected") }),
             "no-PD port should not claim a missing e-marker, got: \(summary.bullets)"
         )
         XCTAssertTrue(
@@ -235,7 +235,7 @@ final class PortSummaryTests: XCTestCase {
             "MagSafe must not show the 'can't read cable details' bullet, got: \(summary.bullets)"
         )
         XCTAssertFalse(
-            summary.bullets.contains(where: { $0.contains("No e-marker reported") }),
+            summary.bullets.contains(where: { $0.contains("No e-marker detected") }),
             "MagSafe must not show the missing-e-marker bullet, got: \(summary.bullets)"
         )
     }
@@ -477,5 +477,50 @@ final class PortSummaryTests: XCTestCase {
         let deviceBullet = summary.bullets.first { $0.contains("Connected device") }
         XCTAssertNotNil(deviceBullet)
         XCTAssertFalse(deviceBullet!.contains("PD"), "Should not show PD revision when unknown")
+    }
+
+    // MARK: - Unknown state enrichment
+
+    func testUnknownWithSOPPartnerShowsEmarkerBullet() {
+        // Connected, PD-capable, no transports active, no charger,
+        // but a partner SOP identity exists. The e-marker explanation
+        // bullet should appear because we know something is on the
+        // other end.
+        let port = makePort(connected: true, active: [], supported: ["CC"])
+        let partner = PDIdentity(
+            id: 50, endpoint: .sop,
+            parentPortType: 2, parentPortNumber: 1,
+            vendorID: 0x05AC, productID: 0x1234, bcdDevice: 0,
+            vdos: [0x6C00_05AC], specRevision: 3
+        )
+        let summary = PortSummary(port: port, identities: [partner])
+        XCTAssertEqual(summary.status, .unknown)
+        XCTAssertTrue(
+            summary.bullets.contains(where: { $0.contains("No e-marker detected") }),
+            "Expected e-marker explanation bullet in .unknown with SOP partner, got: \(summary.bullets)"
+        )
+    }
+
+    func testUnknownWithChargerHitsChargingNotUnknown() {
+        // A charger on the port should hit .charging, not .unknown,
+        // even when no transports are active. Pin this so a future
+        // refactor doesn't accidentally drop charger-only connections
+        // into .unknown.
+        let port = makePort(connected: true, active: [], supported: ["CC"])
+        let source = usbPD(maxW: 20, winningW: 20)
+        let summary = PortSummary(port: port, sources: [source])
+        XCTAssertEqual(summary.status, .charging,
+            "Charger present with no active transports should be .charging, not .unknown")
+    }
+
+    func testPureUnknownHasNoBullets() {
+        // Connected but truly zero data: no transports, no charger,
+        // no identities, no USB2 in supported. Should be .unknown
+        // with empty bullets (no false "basic cable" claim).
+        let port = makePort(connected: true, active: [], supported: [])
+        let summary = PortSummary(port: port)
+        XCTAssertEqual(summary.status, .unknown)
+        XCTAssertTrue(summary.bullets.isEmpty,
+            "Pure .unknown with no data should have empty bullets, got: \(summary.bullets)")
     }
 }


### PR DESCRIPTION
## Summary

- The e-marker bullet ("No e-marker detected...") was guarded by `!active.isEmpty`, which never fires in the `.unknown` state since it has empty active transports by definition. This left the card nearly bare when a cable was connected to a low-wattage charger that doesn't trigger Discover Identity.
- Hoists the `chargingSource` lookup earlier so the e-marker block can use it. Replaces the guard with `hasPayload`, which also fires when a charger, SOP partner identity, or USB device is present.
- Softens the bullet copy from #122: "The cable may have one, but macOS only checks above 3A" instead of a flat statement.

Follows up on #122 (wording-only). This is the structural fix so the bullet actually appears in the states where it was being suppressed.

## Test plan

- [x] All 322 tests pass (`swift test`)
- [x] 3 new tests pin `.unknown` state behaviour: with SOP partner, with charger, and pure empty
- [ ] Manual: connect a low-wattage charger (<3A), verify the e-marker explanation bullet appears instead of an empty bullet list

Generated with [Claude Code](https://claude.com/claude-code)