### PR TITLE
Guard curated-cable lookup against zeroed VID and PID

### DIFF
--- a/Sources/WhatCableCore/CableDB.swift
+++ b/Sources/WhatCableCore/CableDB.swift
@@ -39,12 +39,21 @@ public enum CableDB {
 
     /// Look up a known cable by its e-marker fingerprint. Returns
     /// nil when the cable isn't in our curated database.
+    ///
+    /// A zeroed VID and PID means the cable advertises no vendor and
+    /// no product identity. The Cable VDO is a capability descriptor
+    /// shared by every cable using the same e-marker chip, not an
+    /// identity, so it cannot tell those cables apart. Matching here
+    /// would confidently mislabel unrelated budget cables as one
+    /// arbitrary product. Refuse any match when VID and PID are both
+    /// zero. See issue #161.
     public static func curatedCable(
         vid: Int,
         pid: Int,
         cableVDO: UInt32
     ) -> CuratedCable? {
-        store.cables[CableKey(vid: vid, pid: pid, cableVDO: cableVDO)]
+        if vid == 0 && pid == 0 { return nil }
+        return store.cables[CableKey(vid: vid, pid: pid, cableVDO: cableVDO)]
     }
 
     /// Number of vendor entries loaded. Exposed for tests.

--- a/Tests/WhatCableCoreTests/USBIFVendorsTests.swift
+++ b/Tests/WhatCableCoreTests/USBIFVendorsTests.swift
@@ -114,21 +114,14 @@ struct CableDBTests {
         #expect(CableDB.cableCount >= 10)
     }
 
-    @Test("VID 0 disambiguation")
-    func vid0Disambiguation() {
-        // Three cables with VID=0/PID=0 but different Cable VDO values
-        // should resolve to different brands.
-        let cuktech = CableDB.curatedCable(vid: 0, pid: 0, cableVDO: 0)
-        let dockcase = CableDB.curatedCable(vid: 0, pid: 0, cableVDO: 0x00082042)
-        let vorodcip = CableDB.curatedCable(vid: 0, pid: 0, cableVDO: 0x000A6642)
-
-        #expect(cuktech != nil)
-        #expect(dockcase != nil)
-        #expect(vorodcip != nil)
-
-        // All three resolve to different brands.
-        #expect(cuktech?.brand != dockcase?.brand)
-        #expect(cuktech?.brand != vorodcip?.brand)
-        #expect(dockcase?.brand != vorodcip?.brand)
+    @Test("zeroed VID and PID never match a curated cable")
+    func curatedCableRejectsZeroedVidPid() {
+        // VID 0 + PID 0 means no vendor and no product identity. The
+        // Cable VDO is a capability descriptor shared by every cable
+        // using the same e-marker chip, not an identity, so it cannot
+        // disambiguate them. Refuse any curated match. See #161.
+        #expect(CableDB.curatedCable(vid: 0, pid: 0, cableVDO: 0) == nil)
+        #expect(CableDB.curatedCable(vid: 0, pid: 0, cableVDO: 0x00082042) == nil)
+        #expect(CableDB.curatedCable(vid: 0, pid: 0, cableVDO: 0x000A6642) == nil)
     }
 }


### PR DESCRIPTION
## Summary

`CableDB.curatedCable` matched on `(vid, pid, cableVDO)` with no guard against a meaningless identity. A zeroed VID + PID carries no vendor or product identity, and the Cable VDO is a capability descriptor shared by every cable using the same e-marker chip, not an identity. The old lookup matched one arbitrary curated row and confidently mislabeled unrelated budget cables.

Surfaced by cable reports #158 (SUNGUY 30cm) and #156 (OnePlus 8T), both shown as "Anker braided cable, bundled with 140W adapter".

## Change

- `CableDB.curatedCable` returns `nil` whenever VID and PID are both zero. One guard, covers all three call sites (`PortSummary`, `CableReport`, `JSONFormatter`).
- The old `vid0Disambiguation` test asserted the buggy match and tried to disambiguate zeroed cables by VDO. Replaced with one test asserting a zeroed VID+PID never matches, any VDO.

## Scope

The secondary weak-key finding in #161 (the `(vid,pid,vdo)` build collisions) was reassessed: cables sharing an e-marker chip legitimately share a fingerprint, so collapsing them to one curated row is correct behavior, not data loss. No Layer B change is needed.

## Test plan

- [x] `swift test` full suite: 377 tests, 24 suites, all pass
- [x] New regression test: `curatedCableRejectsZeroedVidPid` (VDO 0, `0x00082042`, `0x000A6642` all return nil)
- [x] Positive path unaffected: `curatedCableLookup` (real VID/PID) still resolves

Fixes #161.
