### PR TITLE
Traditional Chinese language update

### DIFF
--- a/Sources/WhatCableCore/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/WhatCableCore/Resources/zh-Hant.lproj/Localizable.strings
@@ -204,7 +204,7 @@
 "MagSafe Charger" = "MagSafe 充電器";
 "Manufacturer" = "製造商";
 "Marginal" = "勉強可用";
-"Requested max operating current" = "請求最大運作電流";
+"Requested max operating current" = "要求的最大運作電流";
 "Max power" = "最大功率";
 "Mitigations" = "緩解措施";
 "Mode" = "模式";
@@ -223,7 +223,7 @@
 "No liquid detection data" = "沒有液體偵測資料";
 "None" = "無";
 "Open Pro diagnostics for this port" = "開啟此連接埠的 Pro 診斷";
-"Requested operating current" = "請求運作電流";
+"Requested operating current" = "要求的運作電流";
 "PD protocol engine status changed. Tracks contract state, hard/soft reset counts, and message sequence numbers." = "PD 協定引擎狀態已變更。追蹤合約狀態、硬/軟重置次數和訊息序號。";
 "PD spec revision" = "PD 規範版本";
 "PD state" = "PD 狀態";
@@ -307,7 +307,7 @@
 
 /* Pro plugin strings missing from prior export */
 "Enter Licence Key…" = "輸入授權金鑰…";
-"Negotiated PD contract maximum. Live draw is shown in the System Power Input chart below." = "協商的 PD 合約最大值。實時功耗顯示在下方的「系統電源輸入」圖表中。";
+"Negotiated PD contract maximum. Live draw is shown in the System Power Input chart below." = "已協商的 PD 合約上限。即時耗電量會顯示在下方的「系統電源輸入」圖表中。";
 "No power data for this port right now." = "此連接埠目前沒有電源資料。";
 "Upgrade to WhatCable Pro" = "升級到 WhatCable Pro";
 "not reported in this state" = "此狀態下未回報";
@@ -318,7 +318,7 @@
 "Open WhatCable to start monitoring." = "開啟 WhatCable 以開始監控。";
 "See what your USB-C cables can do at a glance." = "一眼查看 USB-C 線材能做什麼。";
 
-/* Negotiation diagnostics + Pro UX (PR #55). English; non-English to be refined by the community translation flow. */
+/* Negotiation diagnostics + Pro UX (PR #55). */
 "The cable's own e-marker under-reports its speed; the Thunderbolt controller confirms it is faster." = "線材本身的 e-marker 低報了速度；Thunderbolt 控制器確認它其實更快。";
 "Running at %@" = "正在以 %@ 運作";
 "There's no cable e-marker or controller data, and no port or device capability to compare against, so we can't tell whether the cable is the limit." = "沒有線材 e-marker 或控制器資料，也沒有可用來比較的連接埠或裝置規格，因此無法判斷線材是否為限制因素。";

--- a/Sources/WhatCableCore/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/WhatCableCore/Resources/zh-Hant.lproj/Localizable.strings
@@ -115,15 +115,6 @@
 "smart cable" = "帶有 e-marker 的線材";
 "video" = "影像";
 
-/* DisplayPort lane labels, connected-device variants, pin-diagram Data label */
-"2 DP lanes + USB3 data" = "2 條 DP 通道 + USB3 資料";
-"4 DP lanes (no USB3 alongside video)" = "4 條 DP 通道（影像旁沒有 USB3）";
-"Carrying DisplayPort video (%@)" = "正在傳輸 DisplayPort 影像（%@）";
-"Connected device: %@" = "已連接裝置：%@";
-"Connected device: %@, %@ (%@)" = "已連接裝置：%1$@，%2$@（%3$@）";
-"Data" = "資料";
-"DisplayPort alt mode" = "DisplayPort 替代模式";
-
 /* Cable speed / charger status strings (previously missing keys) */
 "20 Gbps capable" = "支援 20 Gbps";
 "40 Gbps capable" = "支援 40 Gbps";
@@ -136,6 +127,15 @@
 "Try a higher-wattage charger to identify the cable." = "嘗試使用更高瓦數的充電器來辨識線材。";
 "USB4 Gen 3 (40 Gbps, Thunderbolt 4 class)" = "USB4 Gen 3（40 Gbps，Thunderbolt 4 等級）";
 "USB4 Gen 4 (80 Gbps, Thunderbolt 5 class)" = "USB4 Gen 4（80 Gbps，Thunderbolt 5 等級）";
+
+/* DisplayPort lane labels, connected-device variants, pin-diagram Data label */
+"2 DP lanes + USB3 data" = "2 條 DP 通道 + USB3 資料";
+"4 DP lanes (no USB3 alongside video)" = "4 條 DP 通道（影像旁沒有 USB3）";
+"Carrying DisplayPort video (%@)" = "正在傳輸 DisplayPort 影像（%@）";
+"Connected device: %@" = "已連接裝置：%@";
+"Connected device: %@, %@ (%@)" = "已連接裝置：%1$@，%2$@（%3$@）";
+"Data" = "資料";
+"DisplayPort alt mode" = "DisplayPort 替代模式";
 
 /* Pro plugin UI strings */
 "%@ (spec, not measured)" = "%@（規格值，非實測）";

--- a/Sources/WhatCableCore/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/WhatCableCore/Resources/zh-Hant.lproj/Localizable.strings
@@ -137,7 +137,6 @@
 "USB4 Gen 3 (40 Gbps, Thunderbolt 4 class)" = "USB4 Gen 3（40 Gbps，Thunderbolt 4 等級）";
 "USB4 Gen 4 (80 Gbps, Thunderbolt 5 class)" = "USB4 Gen 4（80 Gbps，Thunderbolt 5 等級）";
 
-
 /* Pro plugin UI strings */
 "%@ (spec, not measured)" = "%@（規格值，非實測）";
 "%@ Diagnostics" = "%@ 診斷";
@@ -319,7 +318,7 @@
 "See what your USB-C cables can do at a glance." = "一眼查看 USB-C 線材能做什麼。";
 
 /* Negotiation diagnostics + Pro UX (PR #55). */
-"The cable's own e-marker under-reports its speed; the Thunderbolt controller confirms it is faster." = "線材本身的 e-marker 低報了速度；Thunderbolt 控制器確認它其實更快。";
+"The cable's e-marker and the Thunderbolt controller disagree on its speed; the controller's reading is treated as authoritative." = "線材的 e-marker 與 Thunderbolt 控制器對速度的判定不一致；會以控制器的讀數為準。";
 "Running at %@" = "正在以 %@ 運作";
 "There's no cable e-marker or controller data, and no port or device capability to compare against, so we can't tell whether the cable is the limit." = "沒有線材 e-marker 或控制器資料，也沒有可用來比較的連接埠或裝置規格，因此無法判斷線材是否為限制因素。";
 "This cable has no e-marker and no controller data, so we can't tell whether it is the limit." = "這條線材沒有 e-marker，也沒有控制器資料，因此無法判斷它是否為限制因素。";
@@ -351,9 +350,7 @@
 "Cable signals disagree" = "線材訊號不一致";
 "an unknown speed" = "未知速度";
 "a higher speed" = "更高速度";
-"The cable's own e-marker reports %@, but the Thunderbolt controller negotiated %@. This is common on active Thunderbolt cables that declare themselves passive. The controller's reading is the one used above." = "線材本身的 e-marker 回報 %@，但 Thunderbolt 控制器協商為 %@。這常見於自稱被動式的主動式 Thunderbolt 線材。上方使用的是控制器讀數。";
-
-
+"The cable's own e-marker reports %@, but the Thunderbolt controller sees %@. This can happen with active Thunderbolt cables that under-report (declaring themselves passive at a low speed) or with suspect cables whose e-markers over-state their capability. The controller's reading is the one used above." = "線材本身的 e-marker 回報 %@，但 Thunderbolt 控制器偵測為 %@。這可能發生在低報速度的主動式 Thunderbolt 線材（以較低速度將自己宣告為被動式），或是 e-marker 高報規格的可疑線材上。上方會以控制器的讀數為準。";
 /* Pro overview screen + footer pill (Pro funnel). */
 "Cable Diagnostics" = "線材診斷";
 "Deep per-port pin maps, plug orientation, and protocol detail." = "深入查看各連接埠的針腳配置、插頭方向與協定詳細資訊。";

--- a/Sources/WhatCableCore/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/WhatCableCore/Resources/zh-Hant.lproj/Localizable.strings
@@ -47,11 +47,11 @@
 "DisplayPort video over USB-C alt mode." = "透過 USB-C alt mode 傳輸 DisplayPort 影像。";
 "E-marker claims EPR support but reports only 20V max VBUS" = "E-marker 聲稱支援 EPR，但回報的最大 VBUS 只有 20V";
 "E-marker reports no vendor identity" = "E-marker 未回報廠商識別資訊";
-"E-marker uses a reserved cable-latency value" = "E-marker 使用保留的線材延遲值";
-"E-marker uses a reserved current-rating value" = "E-marker 使用保留的額定電流值";
-"E-marker uses a reserved data-speed value" = "E-marker 使用保留的資料速度值";
-"E-marker uses an invalid VDO version" = "E-marker 使用無效的 VDO 版本";
-"E-marker uses an invalid cable-termination value" = "E-marker 使用無效的線材端接值";
+"E-marker uses a reserved cable-latency value" = "E-marker 使用了保留的線材延遲值";
+"E-marker uses a reserved current-rating value" = "E-marker 使用了保留的額定電流值";
+"E-marker uses a reserved data-speed value" = "E-marker 使用了保留的資料速度值";
+"E-marker uses an invalid VDO version" = "E-marker 使用了無效的 VDO 版本";
+"E-marker uses an invalid cable-termination value" = "E-marker 使用了無效的線材端接值";
 "Last leg drops from %@ to %@" = "最後一段從 %1$@ 降到 %2$@";
 "Legitimate USB-IF members ship cables with a non-zero vendor ID. A zeroed VID is a common counterfeit signature." = "合法的 USB-IF 成員通常會在線材中使用非零 vendor ID。全零 VID 是常見的仿冒特徵。";
 "Linked at %@" = "連線速度 %@";
@@ -79,7 +79,7 @@
 "SuperSpeed data link is active." = "SuperSpeed 資料連線作用中。";
 "Supports %@." = "支援 %@。";
 "The cable's e-marker advertises EPR Capable, but reports its Max VBUS Voltage as 20V. EPR operation needs 48V or 50V VBUS, so the two fields contradict each other." = "線材的 e-marker 宣告支援 EPR，但 Max VBUS Voltage 回報為 20V。EPR 運作需要 48V 或 50V VBUS，因此這兩個欄位互相矛盾。";
-"The cable's e-marker reports VDO version %lld, which is reserved or marked Invalid by the USB-PD spec for this cable type. Real e-marker silicon should not emit Invalid version values." = "線材的 e-marker 回報 VDO 版本 %lld；對於此線材類型，USB-PD 規範將該值保留或標示為無效。真正的 e-marker 晶片不應輸出無效的版本值。";
+"The cable's e-marker reports VDO version %lld, which is reserved or marked Invalid by the USB-PD spec for this cable type. Real e-marker silicon should not emit Invalid version values." = "線材的 e-marker 回報 VDO 版本 %lld；對於此線材類型，該值由 USB-PD 規範保留或標示為無效。真正的 e-marker 晶片不應輸出無效的版本值。";
 "The cable's e-marker reports cable termination %lld, which the USB-PD spec marks as Invalid for this cable type. Mis-flashed e-markers commonly disagree with the cable's actual physical wiring here." = "線材的 e-marker 回報線材端接 %lld；USB-PD 規範將其標示為此線材類型的無效值。刷寫錯誤的 e-marker 常會在這裡與線材實際物理接線不一致。";
 "The cable's e-marker reports cable-latency value %lld, which is reserved by the USB-PD spec for this cable type. Real e-marker chips should not emit reserved values." = "線材的 e-marker 回報線材延遲值 %lld；對於此線材類型，該值由 USB-PD 規範保留。真正的 e-marker 晶片不應輸出保留值。";
 "The cable's e-marker reports current value %lld, which is reserved by the USB-PD spec. Real e-marker chips should not emit reserved values." = "線材的 e-marker 回報電流值 %lld；該值由 USB-PD 規範保留。真正的 e-marker 晶片不應輸出保留值。";

--- a/Sources/WhatCableCore/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/WhatCableCore/Resources/zh-Hant.lproj/Localizable.strings
@@ -73,8 +73,8 @@
 "Re-driver" = "Re-driver";
 "Re-timer" = "Re-timer";
 "Reserved" = "保留";
-"Slow USB device or charge-only cable" = "慢速 USB 裝置或僅充電線材";
-"Slow USB device or charge-only cable · %lldW charger" = "慢速 USB 裝置或僅充電線材 · %lldW 充電器";
+"Slow USB device or charge-only cable" = "慢速 USB 裝置或純充電線材";
+"Slow USB device or charge-only cable · %lldW charger" = "慢速 USB 裝置或純充電線材 · %lldW 充電器";
 "SuperSpeed USB (5 Gbps or faster)" = "SuperSpeed USB（5 Gbps 或更快）";
 "SuperSpeed data link is active." = "SuperSpeed 資料連線作用中。";
 "Supports %@." = "支援 %@。";


### PR DESCRIPTION
Retranslate updated strings (commit 80e417c and 4a87991) and remove some comments.
Adjust charge-only cable terminology for better consistency with common USB terminology.
Reorder some translation and align blank lines with the English localization files (both are now 363 lines).

By the way, it looks like some of the newer translators may have accidentally escaped the Contributors list 😄