### PR TITLE
Clarify e-marker 3A description wording in zh-Hans/Hant

### DIFF
--- a/Sources/WhatCableCore/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/WhatCableCore/Resources/zh-Hans.lproj/Localizable.strings
@@ -58,7 +58,7 @@
 "Linked at %@" = "链路速度 %@";
 "Negotiation hasn't completed yet." = "协商尚未完成。";
 "No USB-C / MagSafe ports were found on this Mac." = "未找到 USB-C / MagSafe 端口。";
-"No e-marker detected. The cable may have one, but macOS only checks above 3A." = "未检测到 e-marker。线缆可能带有 e-marker，但 macOS 仅在电流超出 3A 时检测。";
+"No e-marker detected. The cable may have one, but macOS only checks above 3A." = "未检测到 e-marker。线缆可能带有 e-marker，但 macOS 仅在超出 3A 时检测。";
 "Nothing connected" = "未连接任何设备";
 "Only USB 2.0 is active. If you expected high speed, the cable may not support it." = "当前仅 USB 2.0 活跃。如果你预期高速连接，线缆可能不支持。";
 "Optical" = "光纤";

--- a/Sources/WhatCableCore/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/WhatCableCore/Resources/zh-Hans.lproj/Localizable.strings
@@ -58,7 +58,7 @@
 "Linked at %@" = "链路速度 %@";
 "Negotiation hasn't completed yet." = "协商尚未完成。";
 "No USB-C / MagSafe ports were found on this Mac." = "未找到 USB-C / MagSafe 端口。";
-"No e-marker detected. The cable may have one, but macOS only checks above 3A." = "未检测到 e-marker。线缆可能带有 e-marker，但 macOS 仅在 3A 以上时检测。";
+"No e-marker detected. The cable may have one, but macOS only checks above 3A." = "未检测到 e-marker。线缆可能带有 e-marker，但 macOS 仅在电流超出 3A 时检测。";
 "Nothing connected" = "未连接任何设备";
 "Only USB 2.0 is active. If you expected high speed, the cable may not support it." = "当前仅 USB 2.0 活跃。如果你预期高速连接，线缆可能不支持。";
 "Optical" = "光纤";

--- a/Sources/WhatCableCore/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/WhatCableCore/Resources/zh-Hant.lproj/Localizable.strings
@@ -58,7 +58,7 @@
 "Linked at %@" = "連線速度 %@";
 "Negotiation hasn't completed yet." = "協商尚未完成。";
 "No USB-C / MagSafe ports were found on this Mac." = "這台 Mac 上找不到 USB-C / MagSafe 連接埠。";
-"No e-marker detected. The cable may have one, but macOS only checks above 3A." = "未偵測到 e-marker。線材可能有 e-marker，但 macOS 只會在 3A 以上時檢查。";
+"No e-marker detected. The cable may have one, but macOS only checks above 3A." = "未偵測到 e-marker。線材可能有 e-marker，但 macOS 只會在電流超出 3A 時檢查。";
 "Nothing connected" = "未連接任何裝置";
 "Only USB 2.0 is active. If you expected high speed, the cable may not support it." = "目前只有 USB 2.0 作用中。如果預期應有高速連線，線材可能不支援。";
 "Optical" = "光纖";

--- a/Sources/WhatCableCore/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/WhatCableCore/Resources/zh-Hant.lproj/Localizable.strings
@@ -58,7 +58,7 @@
 "Linked at %@" = "連線速度 %@";
 "Negotiation hasn't completed yet." = "協商尚未完成。";
 "No USB-C / MagSafe ports were found on this Mac." = "這台 Mac 上找不到 USB-C / MagSafe 連接埠。";
-"No e-marker detected. The cable may have one, but macOS only checks above 3A." = "未偵測到 e-marker。線材可能有 e-marker，但 macOS 只會在電流超出 3A 時檢查。";
+"No e-marker detected. The cable may have one, but macOS only checks above 3A." = "未偵測到 e-marker。線材可能有 e-marker，但 macOS 只會在超出 3A 時檢查。";
 "Nothing connected" = "未連接任何裝置";
 "Only USB 2.0 is active. If you expected high speed, the cable may not support it." = "目前只有 USB 2.0 作用中。如果預期應有高速連線，線材可能不支援。";
 "Optical" = "光纖";


### PR DESCRIPTION
The previous translation used "以上" which could be read as "at or above," slightly ambiguous about whether 3A itself is included. But IIRC, e-maker are not required for 3A.

I suggest uses "超出"  which more precisely conveys "exceeding 3A" — matching the intent of the English source string "above 3A" (i.e., strictly greater than 3A).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved clarity in Chinese (Simplified and Traditional) translations for e-marker detection messaging.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/darrylmorley/whatcable/pull/199?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->