### PR TITLE
Add a toggle in settings to let users automatically contribute diagnostic data on a recurring basis.

### DIFF
--- a/Sources/WhatCable/App.swift
+++ b/Sources/WhatCable/App.swift
@@ -100,6 +100,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate, NSW
         NotificationManager.shared.start()
         WidgetDataWriter.shared.start()
         UpdateChecker.shared.start()
+        TestKitRunner.shared.refreshAutoSendSchedule(delayInitialRun: true)
         log.notice("launch: subsystems started")
 
         if AppSettings.shared.needsOnboarding {

--- a/Sources/WhatCable/AppSettings.swift
+++ b/Sources/WhatCable/AppSettings.swift
@@ -19,6 +19,9 @@ final class AppSettings: ObservableObject {
         static let fontSize = "fontSize"
         static let preferredLanguage = "preferredLanguage"
         static let testKitLastRunVersion = "testKitLastRunVersion"
+        static let autoContributeDiagnosticData = "autoContributeDiagnosticData"
+        static let testKitLastAutoRunDate = "testKitLastAutoRunDate"
+        static let testKitAutoConsentGiven = "testKitAutoConsentGiven"
         static let hasCompletedOnboarding = "hasCompletedOnboarding"
     }
 
@@ -91,9 +94,35 @@ final class AppSettings: ObservableObject {
         }
     }
 
+
+    @Published var autoContributeDiagnosticData: Bool {
+        didSet {
+            guard autoContributeDiagnosticData != oldValue else { return }
+            UserDefaults.standard.set(autoContributeDiagnosticData, forKey: Keys.autoContributeDiagnosticData)
+            TestKitRunner.shared.refreshAutoSendSchedule()
+        }
+    }
+
     var testKitLastRunVersion: String? {
         get { UserDefaults.standard.string(forKey: Keys.testKitLastRunVersion) }
         set { UserDefaults.standard.set(newValue, forKey: Keys.testKitLastRunVersion) }
+    }
+
+    /// Timestamp of the last automatic diagnostic contribution.
+    /// Used to catch up on a missed run after the app was closed and to space
+    /// recurring runs apart.
+    var testKitLastAutoRunDate: Date? {
+        get { UserDefaults.standard.object(forKey: Keys.testKitLastAutoRunDate) as? Date }
+        set { UserDefaults.standard.set(newValue, forKey: Keys.testKitLastAutoRunDate) }
+    }
+
+    /// True once the user has accepted the consent sheet for automatic
+    /// contribution at least once. The sheet is a one-time gate: after the
+    /// first Proceed, toggling "Automatically Send Diagnostic Data" off and
+    /// back on enables it directly without re-showing the consent.
+    var testKitAutoConsentGiven: Bool {
+        get { UserDefaults.standard.bool(forKey: Keys.testKitAutoConsentGiven) }
+        set { UserDefaults.standard.set(newValue, forKey: Keys.testKitAutoConsentGiven) }
     }
 
     var hasCompletedOnboarding: Bool {
@@ -116,6 +145,8 @@ final class AppSettings: ObservableObject {
         // Notifications default off — opt in to avoid noise.
         self.notifyOnChanges = UserDefaults.standard.bool(forKey: Keys.notifyOnChanges)
         self.hideEmptyPorts = UserDefaults.standard.bool(forKey: Keys.hideEmptyPorts)
+        // Recurring contribution is opt-in.
+        self.autoContributeDiagnosticData = UserDefaults.standard.bool(forKey: Keys.autoContributeDiagnosticData)
         // Menu bar mode is the default; UserDefaults returns false for unset
         // bool keys, so explicitly check presence.
         if UserDefaults.standard.object(forKey: Keys.useMenuBarMode) == nil {

--- a/Sources/WhatCable/Resources/de.lproj/Localizable.strings
+++ b/Sources/WhatCable/Resources/de.lproj/Localizable.strings
@@ -81,6 +81,8 @@
 "COMMUNITY" = "COMMUNITY";
 "Contribute Diagnostic Data" = "Diagnosedaten beitragen";
 "Contribute Diagnostic Data…" = "Diagnosedaten beitragen…";
+"Automatically Send Diagnostic Data" = "Diagnosedaten automatisch senden";
+"Automatically contributes diagnostic data every 48 hours." = "Trägt alle 48 Stunden automatisch Diagnosedaten bei.";
 "Privacy" = "Datenschutz";
 "Pro" = "Pro";
 "Proceed" = "Fortfahren";

--- a/Sources/WhatCable/Resources/en.lproj/Localizable.strings
+++ b/Sources/WhatCable/Resources/en.lproj/Localizable.strings
@@ -80,6 +80,8 @@
 "COMMUNITY" = "COMMUNITY";
 "Contribute Diagnostic Data" = "Contribute Diagnostic Data";
 "Contribute Diagnostic Data…" = "Contribute Diagnostic Data…";
+"Automatically Send Diagnostic Data" = "Automatically Send Diagnostic Data";
+"Automatically contributes diagnostic data every 48 hours." = "Automatically contributes diagnostic data every 48 hours.";
 "Privacy" = "Privacy";
 "Pro" = "Pro";
 "Proceed" = "Proceed";

--- a/Sources/WhatCable/Resources/es.lproj/Localizable.strings
+++ b/Sources/WhatCable/Resources/es.lproj/Localizable.strings
@@ -81,6 +81,8 @@
 "COMMUNITY" = "COMUNIDAD";
 "Contribute Diagnostic Data" = "Contribuir con datos de diagnóstico";
 "Contribute Diagnostic Data…" = "Contribuir con datos de diagnóstico…";
+"Automatically Send Diagnostic Data" = "Enviar datos de diagnóstico automáticamente"; 
+"Automatically contributes diagnostic data every 48 hours." = "Contribuye con datos de diagnóstico automáticamente cada 48 horas.";
 "Privacy" = "Privacidad";
 "Pro" = "Pro";
 "Proceed" = "Continuar";

--- a/Sources/WhatCable/Resources/fr.lproj/Localizable.strings
+++ b/Sources/WhatCable/Resources/fr.lproj/Localizable.strings
@@ -81,6 +81,8 @@
 "COMMUNITY" = "COMMUNAUTÉ";
 "Contribute Diagnostic Data" = "Contribuer aux données de diagnostic";
 "Contribute Diagnostic Data…" = "Contribuer aux données de diagnostic…";
+"Automatically Send Diagnostic Data" = "Envoyer automatiquement les données de diagnostic";
+"Automatically contributes diagnostic data every 48 hours." = "Contribue automatiquement aux données de diagnostic toutes les 48 heures.";
 "Privacy" = "Confidentialité";
 "Pro" = "Pro";
 "Proceed" = "Continuer";

--- a/Sources/WhatCable/Resources/hi.lproj/Localizable.strings
+++ b/Sources/WhatCable/Resources/hi.lproj/Localizable.strings
@@ -80,6 +80,8 @@
 "COMMUNITY" = "समुदाय";
 "Contribute Diagnostic Data" = "डायग्नोस्टिक डेटा योगदान करें";
 "Contribute Diagnostic Data…" = "डायग्नोस्टिक डेटा योगदान करें…";
+"Automatically Send Diagnostic Data" = "डायग्नोस्टिक डेटा स्वचालित रूप से भेजें";
+"Automatically contributes diagnostic data every 48 hours." = "हर 48 घंटे में स्वचालित रूप से डायग्नोस्टिक डेटा का योगदान करता है।";
 "Privacy" = "गोपनीयता";
 "Pro" = "Pro";
 "Proceed" = "आगे बढ़ें";

--- a/Sources/WhatCable/Resources/hy.lproj/Localizable.strings
+++ b/Sources/WhatCable/Resources/hy.lproj/Localizable.strings
@@ -80,6 +80,8 @@
 "COMMUNITY" = "ՀԱՄԱՅՆՔ";
 "Contribute Diagnostic Data" = "Տրամադրել ախտորոշիչ տվյալներ";
 "Contribute Diagnostic Data…" = "Տրամադրել ախտորոշիչ տվյալներ…";
+"Automatically Send Diagnostic Data" = "Ինքնաշխատ ուղարկել ախտորոշիչ տվյալները";
+"Automatically contributes diagnostic data every 48 hours." = "Ինքնաշխատ տրամադրում է ախտորոշիչ տվյալներ յուրաքանչյուր 48 ժամը մեկ։";
 "Privacy" = "Գաղտնիություն";
 "Pro" = "Pro";
 "Proceed" = "Շարունակել";

--- a/Sources/WhatCable/Resources/it.lproj/Localizable.strings
+++ b/Sources/WhatCable/Resources/it.lproj/Localizable.strings
@@ -80,6 +80,8 @@
 "COMMUNITY" = "COMUNITÀ";
 "Contribute Diagnostic Data" = "Contribuisci con dati diagnostici";
 "Contribute Diagnostic Data…" = "Contribuisci con dati diagnostici…";
+"Automatically Send Diagnostic Data" = "Invia automaticamente i dati diagnostici";
+"Automatically contributes diagnostic data every 48 hours." = "Contribuisce automaticamente con i dati diagnostici ogni 48 ore.";
 "Privacy" = "Privacy";
 "Pro" = "Pro";
 "Proceed" = "Procedi";

--- a/Sources/WhatCable/Resources/ja.lproj/Localizable.strings
+++ b/Sources/WhatCable/Resources/ja.lproj/Localizable.strings
@@ -81,6 +81,8 @@
 "COMMUNITY" = "コミュニティ";
 "Contribute Diagnostic Data" = "診断データを提供";
 "Contribute Diagnostic Data…" = "診断データを提供…";
+"Automatically Send Diagnostic Data" = "診断データを自動的に送信";
+"Automatically contributes diagnostic data every 48 hours." = "48時間ごとに診断データを自動的に提供します。";
 "Privacy" = "プライバシー";
 "Pro" = "Pro";
 "Proceed" = "続行";

--- a/Sources/WhatCable/Resources/lv.lproj/Localizable.strings
+++ b/Sources/WhatCable/Resources/lv.lproj/Localizable.strings
@@ -80,6 +80,8 @@
 "COMMUNITY" = "KOPIENA";
 "Contribute Diagnostic Data" = "Sniegt diagnostikas datus";
 "Contribute Diagnostic Data…" = "Sniegt diagnostikas datus…";
+"Automatically Send Diagnostic Data" = "Automātiski sūtīt diagnostikas datus";
+"Automatically contributes diagnostic data every 48 hours." = "Automātiski sniedz diagnostikas datus ik pēc 48 stundām.";
 "Privacy" = "Privātums";
 "Pro" = "Pro";
 "Proceed" = "Turpināt";

--- a/Sources/WhatCable/Resources/nb.lproj/Localizable.strings
+++ b/Sources/WhatCable/Resources/nb.lproj/Localizable.strings
@@ -81,6 +81,8 @@
 "COMMUNITY" = "FELLESSKAP";
 "Contribute Diagnostic Data" = "Bidra med diagnostikkdata";
 "Contribute Diagnostic Data…" = "Bidra med diagnostikkdata…";
+"Automatically Send Diagnostic Data" = "Send diagnostikkdata automatisk";
+"Automatically contributes diagnostic data every 48 hours." = "Bidrar automatisk med diagnostikkdata hver 48. time.";
 "Privacy" = "Personvern";
 "Pro" = "Pro";
 "Proceed" = "Fortsett";

--- a/Sources/WhatCable/Resources/pl.lproj/Localizable.strings
+++ b/Sources/WhatCable/Resources/pl.lproj/Localizable.strings
@@ -80,6 +80,8 @@
 "COMMUNITY" = "SPOŁECZNOŚĆ";
 "Contribute Diagnostic Data" = "Przekaż dane diagnostyczne";
 "Contribute Diagnostic Data…" = "Przekaż dane diagnostyczne…";
+"Automatically Send Diagnostic Data" = "Automatycznie wysyłaj dane diagnostyczne";
+"Automatically contributes diagnostic data every 48 hours." = "Automatycznie przekazuje dane diagnostyczne co 48 godzin.";
 "Privacy" = "Prywatność";
 "Pro" = "Pro";
 "Proceed" = "Kontynuuj";

--- a/Sources/WhatCable/Resources/pt-BR.lproj/Localizable.strings
+++ b/Sources/WhatCable/Resources/pt-BR.lproj/Localizable.strings
@@ -80,6 +80,8 @@
 "COMMUNITY" = "COMUNIDADE";
 "Contribute Diagnostic Data" = "Contribuir com dados de diagnóstico";
 "Contribute Diagnostic Data…" = "Contribuir com dados de diagnóstico…";
+"Automatically Send Diagnostic Data" = "Enviar dados de diagnóstico automaticamente";
+"Automatically contributes diagnostic data every 48 hours." = "Contribui automaticamente com dados de diagnóstico a cada 48 horas.";
 "Privacy" = "Privacidade";
 "Pro" = "Pro";
 "Proceed" = "Continuar";

--- a/Sources/WhatCable/Resources/ru.lproj/Localizable.strings
+++ b/Sources/WhatCable/Resources/ru.lproj/Localizable.strings
@@ -80,6 +80,8 @@
 "COMMUNITY" = "СООБЩЕСТВО";
 "Contribute Diagnostic Data" = "Передать диагностические данные";
 "Contribute Diagnostic Data…" = "Передать диагностические данные…";
+"Automatically Send Diagnostic Data" = "Автоматически отправлять диагностические данные";
+"Automatically contributes diagnostic data every 48 hours." = "Автоматически передаёт диагностические данные каждые 48 часов.";
 "Privacy" = "Конфиденциальность";
 "Pro" = "Pro";
 "Proceed" = "Продолжить";

--- a/Sources/WhatCable/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/WhatCable/Resources/zh-Hans.lproj/Localizable.strings
@@ -80,6 +80,8 @@
 "COMMUNITY" = "社区";
 "Contribute Diagnostic Data" = "贡献诊断数据";
 "Contribute Diagnostic Data…" = "贡献诊断数据…";
+"Automatically Send Diagnostic Data" = "自动发送诊断数据";
+"Automatically contributes diagnostic data every 48 hours." = "每 48 小时自动贡献诊断数据。";
 "Privacy" = "隐私";
 "Pro" = "Pro";
 "Proceed" = "继续";

--- a/Sources/WhatCable/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/WhatCable/Resources/zh-Hant.lproj/Localizable.strings
@@ -80,6 +80,8 @@
 "COMMUNITY" = "社群";
 "Contribute Diagnostic Data" = "提供診斷資料";
 "Contribute Diagnostic Data…" = "提供診斷資料…";
+"Automatically Send Diagnostic Data" = "自動傳送診斷資料";
+"Automatically contributes diagnostic data every 48 hours." = "每 48 小時自動提供診斷資料。";
 "Privacy" = "隱私權";
 "Pro" = "Pro";
 "Proceed" = "繼續";

--- a/Sources/WhatCable/TestKitRunner.swift
+++ b/Sources/WhatCable/TestKitRunner.swift
@@ -51,6 +51,45 @@ final class TestKitRunner: ObservableObject {
         }
     }
 
+    static let autoSendInterval: TimeInterval = 48 * 60 * 60 // 48hrs
+
+    private var autoSendTimer: Timer?
+    private var autoSendCatchUpTimer: Timer?
+
+
+    func refreshAutoSendSchedule(delayInitialRun: Bool = false) {
+        autoSendTimer?.invalidate()
+        autoSendTimer = nil
+        autoSendCatchUpTimer?.invalidate()
+        autoSendCatchUpTimer = nil
+
+        guard AppSettings.shared.autoContributeDiagnosticData else { return }
+
+        autoSendTimer = Timer.scheduledTimer(withTimeInterval: Self.autoSendInterval, repeats: true) { [weak self] _ in
+            Task { @MainActor in self?.runAutomatic() }
+        }
+
+        let last = AppSettings.shared.testKitLastAutoRunDate
+        let isDue = last.map { Date().timeIntervalSince($0) >= Self.autoSendInterval } ?? true
+        guard isDue else { return }
+
+        if delayInitialRun {
+            autoSendCatchUpTimer = Timer.scheduledTimer(withTimeInterval: 60, repeats: false) { [weak self] _ in
+                Task { @MainActor in self?.runAutomatic() }
+            }
+        } else {
+            runAutomatic()
+        }
+    }
+
+
+    private func runAutomatic() {
+        guard AppSettings.shared.autoContributeDiagnosticData else { return }
+        guard !isRunning else { return }
+        AppSettings.shared.testKitLastAutoRunDate = Date()
+        run()
+    }
+
     private func runAllProbes() async {
         let machineID = await Task.detached { Self.machineID() }.value
         let ver = ProcessInfo.processInfo.operatingSystemVersion

--- a/Sources/WhatCable/TestKitSettingsSection.swift
+++ b/Sources/WhatCable/TestKitSettingsSection.swift
@@ -6,6 +6,7 @@ struct TestKitSettingsSection: View {
     @ObservedObject private var settings = AppSettings.shared
     @ObservedObject private var runner = TestKitRunner.shared
     @State private var showingConsent = false
+    @State private var pendingAutoEnable = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
@@ -14,7 +15,7 @@ struct TestKitSettingsSection: View {
                 .foregroundStyle(.secondary)
             VStack(alignment: .leading, spacing: 8) {
                 HStack(spacing: 8) {
-                    Button(action: { showingConsent = true }) {
+                    Button(action: { pendingAutoEnable = false; showingConsent = true }) {
                         Label(String(localized: "Contribute Diagnostic Data", bundle: _appLocalizedBundle), systemImage: "waveform.path.ecg")
                     }
                     .disabled(runner.isRunning)
@@ -23,6 +24,13 @@ struct TestKitSettingsSection: View {
 
                     statusLabel
                 }
+
+                Toggle(isOn: autoSendBinding) {
+                    Text(String(localized: "Automatically Send Diagnostic Data", bundle: _appLocalizedBundle))
+                }
+                .toggleStyle(.switch)
+                .controlSize(.small)
+                .help(autoSendHelp)
             }
             .scaledFont(.body)
             .controlSize(.small)
@@ -30,17 +38,49 @@ struct TestKitSettingsSection: View {
         .sheet(isPresented: $showingConsent) {
             TestKitConsentView {
                 showingConsent = false
-                runner.run()
+                if pendingAutoEnable {
+                    pendingAutoEnable = false
+                    // Remember the consent so re-toggling never re-prompts.
+                    settings.testKitAutoConsentGiven = true
+                    settings.autoContributeDiagnosticData = true
+                } else {
+                    runner.run()
+                }
             } onCancel: {
                 showingConsent = false
+                pendingAutoEnable = false
             }
         }
         .onReceive(refreshSignal.$showTestKitConsent) { show in
             if show {
+                pendingAutoEnable = false
                 showingConsent = true
                 refreshSignal.showTestKitConsent = false
             }
         }
+    }
+
+    private var autoSendHelp: String {
+        String(localized: "Automatically contributes diagnostic data every 48 hours.", bundle: _appLocalizedBundle)
+    }
+
+    // Saving user preferences
+    private var autoSendBinding: Binding<Bool> {
+        Binding(
+            get: { settings.autoContributeDiagnosticData },
+            set: { isOn in
+                if isOn {
+                    if settings.testKitAutoConsentGiven {
+                        settings.autoContributeDiagnosticData = true
+                    } else {
+                        pendingAutoEnable = true
+                        showingConsent = true
+                    }
+                } else {
+                    settings.autoContributeDiagnosticData = false
+                }
+            }
+        )
     }
 
     @ViewBuilder


### PR DESCRIPTION
PR adds a toggle which automatically sends a request to upload the diagnostic data without having to manually click the button. Great for users who want to contribute more frequently. Currently the set interval is 48 hours but can be changed to whatever is preferred. 

<img width="556" height="582" alt="Screenshot 2026-05-30 at 5 31 50 PM" src="https://github.com/user-attachments/assets/e8b7719e-be8f-485e-b783-fefd90fe227e" />

While building locally, /scripts/smoke-test.sh fails at the swift test step with 3 failures in DataLinkDiagnosticProbeSweepTests because research/customer-probes/ is not present in this repo (the entire research/ directory isn't there). This seems pre-existing and unrelated to my changes. 

Workaround I used: swift test --skip "DataLinkDiagnosticProbeSweepTests", or proceed past the test failure if only validating the app build.

For the new text introduced, I used Google Translate to quickly add support for the other 13 languages. May want to double check the accuracy. 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Automatically Send Diagnostic Data" setting that allows users to enable automatic diagnostic data collection every 48 hours.
  * The app now automatically schedules and runs diagnostic data collection at regular intervals when this feature is enabled.
  * Extended localization support across all supported languages for the new automatic diagnostic data contribution feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->