### PR TITLE
Traditional Chinese language update

### DIFF
--- a/Sources/WhatCable/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/WhatCable/Resources/zh-Hant.lproj/Localizable.strings
@@ -28,7 +28,7 @@
 "Host (%@)" = "主機（%@）";
 "Include Mac model and macOS version" = "包含 Mac 機型與 macOS 版本";
 "Install failed: %@" = "安裝失敗：%@";
-"This account can't update apps in this location. Download the new version from whatcable.uk, or update with Homebrew." = "此帳戶無法更新此位置的應用程式。請從 whatcable.uk 下載新版本，或使用 Homebrew 更新。";
+"This account can't update apps in this location. Download the new version from whatcable.uk, or update with Homebrew." = "此帳戶無法更新安裝於此位置的應用程式。請從 whatcable.uk 下載新版本，或使用 Homebrew 更新。";
 "Install update" = "安裝更新";
 "Installing, WhatCable will relaunch" = "正在安裝，WhatCable 將重新啟動";
 "Keep window open" = "保持視窗開啟";

--- a/Sources/WhatCable/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/WhatCable/Resources/zh-Hant.lproj/Localizable.strings
@@ -91,7 +91,7 @@
 "Privacy" = "隱私權";
 "Pro" = "Pro";
 "Proceed" = "繼續";
-"Raw IOKit registry properties for each USB-C port, the model and capabilities of any connected display (its EDID, with the serial number removed), your macOS version, and chip type. This is the same data visible in System Information." = "每個 USB-C 連接埠的原始 IOKit 登錄屬性、任何已連接顯示器的型號與功能資訊（其 EDID，已移除序號）、您的 macOS 版本與晶片類型。這些資料與「系統資訊」中可見的內容相同。";
+"Raw IOKit registry properties for each USB-C port, the model and capabilities of any connected display (its EDID, with the serial number removed), your macOS version, and chip type. This is the same data visible in System Information." = "每個 USB-C 連接埠的原始 IOKit 登錄屬性、任何已連接顯示器的型號與規格資訊（其 EDID，已移除序號）、您的 macOS 版本與晶片類型。這些資料與「系統資訊」中可見的內容相同。";
 "What happens" = "會發生什麼";
 "What is collected" = "會收集哪些資料";
 "WhatCable runs 17 IOKit probes that read raw USB-C and Thunderbolt data from your Mac's port controller registers. The results are sent to a secure server to help improve cable and port detection." = "WhatCable 會執行 17 個 IOKit 探測器，從 Mac 的連接埠控制器暫存器讀取原始 USB-C 與 Thunderbolt 資料。結果會傳送至安全伺服器，以協助改善線材與連接埠偵測。";
@@ -108,15 +108,15 @@
 
 /* Onboarding / welcome screen (first launch). */
 "Welcome to WhatCable" = "歡迎使用 WhatCable";
-"See what your USB-C cables, chargers, and devices can actually do." = "查看你的 USB-C 線材、充電器和裝置的實際能力。";
-"How would you like to use WhatCable?" = "你想如何使用 WhatCable？";
+"See what your USB-C cables, chargers, and devices can actually do." = "查看您的 USB-C 線材、充電器和裝置到底能做什麼。";
+"How would you like to use WhatCable?" = "您想如何使用 WhatCable？";
 "Menu bar" = "選單列";
 "Sits in the menu bar at the top of your screen. Click the cable icon any time to check a connection." = "位於螢幕頂部的選單列中。隨時點選線材圖示即可檢查連線。";
 "Recommended" = "推薦";
 "Dock app" = "Dock 應用程式";
 "Opens as a regular window with a Dock icon, like most apps." = "像大多數應用程式一樣，以一般視窗開啟並顯示 Dock 圖示。";
 "Get Started" = "開始使用";
-"You can change this any time in Settings." = "你可以隨時在設定中更改。";
+"You can change this any time in Settings." = "您可以隨時在設定中更改。";
 
 /* Billboard device (display dimension). */
 "Billboard device present" = "偵測到 Billboard 裝置";

--- a/Sources/WhatCableCore/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/WhatCableCore/Resources/zh-Hant.lproj/Localizable.strings
@@ -216,7 +216,7 @@
 "Mode" = "模式";
 "Monitor" = "顯示器";
 "Native" = "原生";
-"Port maximum. Live per-port metering is not available on this hardware." = "連接埠上限。此硬體無法使用各連接埠即時計量。";
+"Port maximum. Live per-port metering is not available on this hardware." = "連接埠上限。此硬體不支援各連接埠即時功率測量。";
 "No" = "否";
 "No PD contract data" = "沒有 PD 協議資料";
 "No PD events" = "沒有 PD 事件";
@@ -387,12 +387,12 @@
 "This estimate assumes standard colour; a display using compression (DSC) may reach more." = "此估算以標準色彩模式為前提；使用影像串流壓縮（DSC）的顯示器可能達到更高規格。";
 "Video is going through a %@ adapter" = "影像訊號正透過 %@ 轉接器傳輸";
 "Your %@ is reached through a USB-C to %@ adapter, and the link isn't currently carrying the monitor's top mode (%@, about %@); it's carrying about %@ (%@). With an adapter in the chain, the adapter's own limit may be the cap rather than the cable. Trying the monitor over native DisplayPort, or a higher-spec adapter, would tell you which." = "您的 %@ 是透過 USB-C 轉 %@ 轉接器連接，而連線尚未達到顯示器的最高模式（%@，約需 %@）；目前約承載 %@（%@）。在有轉接器的情況下，限制因素可能是轉接器本身，而非線材。改用原生 DisplayPort 連接，或使用規格更高的轉接器，有助於判斷原因。";
-"Monitor can do more than the link is carrying" = "顯示器規格高於目前連線承載能力";
+"Monitor can do more than the link is carrying" = "顯示器規格高於目前連線承載";
 "Your %@ can run %@, which needs about %@, but the link is currently carrying about %@ (%@). If you've selected the higher mode and aren't getting it, the cable or adapter is the likely limit; if you haven't tried it, selecting it may retrain the link to a higher rate." = "您的 %@ 可支援 %@，約需 %@，但目前連線僅承載約 %@（%@）。若已選擇較高模式卻無法達成，限制因素可能是線材或轉接器；若尚未嘗試，選擇較高模式可能會讓連線重新協商至更高速率。";
 "Display Diagnostics" = "顯示器診斷";
 "What your monitor can do, and what the link is carrying." = "查看顯示器的規格，以及目前連線實際承載的內容。";
 "No Displays" = "沒有顯示器";
-"Connect a monitor over USB-C or Thunderbolt to see what the link is delivering." = "透過 USB-C 或 Thunderbolt 連接顯示器，即可查看目前連線提供的能力。";
+"Connect a monitor over USB-C or Thunderbolt to see what the link is delivering." = "透過 USB-C 或 Thunderbolt 連接顯示器，即可查看目前連線承載的內容。";
 "%@ port %lld" = "%@ 連接埠 %lld";
 "Display" = "顯示器";
 "%lld × %lld" = "%lld × %lld";
@@ -443,7 +443,7 @@
 
 "Per-Port Metering Unavailable" = "無法取得各連接埠功率讀數";
 "This Mac reports overall power below, but not per-port readings." = "這台 Mac 可回報下方的整體功率，但無法提供各連接埠的功率讀數。";
-"Per-port metering isn't available on this Mac." = "此 Mac 不支援各連接埠功率讀取。";
+"Per-port metering isn't available on this Mac." = "此 Mac 不支援各連接埠功率測量。";
 "macOS can be slow to report per-port power, sometimes up to a minute." = "macOS 回報各連接埠功率可能較慢，有時最多需要一分鐘。";
 "Display connected. No power is being sent out of this port. Incoming power shows in System Power Input below." = "已連接顯示器。此連接埠目前未對外供電。輸入功率會顯示在下方的「系統電源輸入」圖表中。";
 "Connected to %lld Thunderbolt devices: %@" = "已連接 %1$lld 個 Thunderbolt 裝置：%2$@";


### PR DESCRIPTION
Improve translation consistency and refine updated strings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Traditional Chinese (zh-Hant) copy across the app: clarified app-update/install messaging, made onboarding/welcome text more formal and consistent, refined status and diagnostics wording (including per-port live metering availability), and improved technical description phrasing for better clarity to Traditional Chinese-speaking users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->