### PR TITLE
Traditional Chinese language update

### DIFF
--- a/Sources/WhatCableCore/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/WhatCableCore/Resources/zh-Hant.lproj/Localizable.strings
@@ -151,7 +151,7 @@
 "A DR_Swap completed successfully. The port changed between DFP (host) and UFP (device) roles." = "DR_Swap 已成功完成。連接埠已在 DFP（主機）和 UFP（裝置）角色之間切換。";
 "A PR_Swap completed successfully. Common when a hub or dock renegotiates which end supplies power." = "PR_Swap 已成功完成。常見於 Hub 或 Dock 重新協商由哪一端供電時。";
 "A USB 2.0 connection was detected on the legacy D+/D- pins." = "在傳統 D+/D- 針腳上偵測到 USB 2.0 連線。";
-"A cable was physically connected or disconnected from the port." = "線材已實際接上或拔離連接埠。";
+"A cable was physically connected or disconnected from the port." = "線材已實際接上或從連接埠拔除。";
 "Activate" = "啟用";
 "Active Cable" = "主動式線材";
 "Active RDO" = "作用中 RDO";
@@ -188,7 +188,7 @@
 "Event Log" = "事件記錄";
 "FET enable failures" = "FET 啟用失敗次數";
 "FET status" = "FET 狀態";
-"Fired by the TPS6598x controller when a cable is physically inserted or removed. Multiple fires during a single plug event are normal." = "在線材實體插入或拔出時，由 TPS6598x 控制器觸發。單次插拔事件中多次觸發是正常現象。";
+"Fired by the TPS6598x controller when a cable is physically inserted or removed. Multiple fires during a single plug event are normal." = "在線材實際接上或拔除時，由 TPS6598x 控制器觸發。單次插拔事件中多次觸發是正常現象。";
 "General port controller status change (connection state, error flags)." = "一般連接埠控制器狀態變更（連線狀態、錯誤旗標）。";
 "Generic controller status register changed. Covers plug state, orientation, and error conditions." = "通用控制器狀態暫存器已變更。涵蓋連接狀態、方向和錯誤情況。";
 "Good" = "良好";
@@ -241,7 +241,7 @@
 "Partner device identity arrived via SOP (the connected device, not the cable)." = "對端裝置識別資訊已透過 SOP 傳入（已連接的裝置，不是線材）。";
 "Passive Cable" = "被動式線材";
 "Pin Diagram" = "針腳圖";
-"Plug inserted or removed" = "連接器已接上或拔出";
+"Plug inserted or removed" = "連接器已接上或拔除";
 "Plug: %@" = "連接器：%@";
 "Port Health" = "連接埠健康狀況";
 "Power" = "功率";
@@ -370,7 +370,7 @@
 "The cable's own e-marker reports %@, but the Thunderbolt controller sees %@. This can happen with active Thunderbolt cables that under-report (declaring themselves passive at a low speed) or with suspect cables whose e-markers over-state their capability. The controller's reading is the one used above." = "線材本身的 e-marker 回報 %@，但 Thunderbolt 控制器偵測為 %@。這可能發生在低報速度的主動式 Thunderbolt 線材（以較低速度將自己宣告為被動式），或是 e-marker 高報規格的可疑線材上。上方會以控制器的讀數為準。";
 /* Pro overview screen + footer pill (Pro funnel). */
 "Cable Diagnostics" = "線材診斷";
-"Deep per-port pin maps, plug orientation, and protocol detail." = "深入查看各連接埠的針腳配置、插頭方向與協定詳細資訊。";
+"Deep per-port pin maps, plug orientation, and protocol detail." = "深入查看各連接埠的針腳配置、連接器方向與協定詳細資訊。";
 "Licence Key" = "授權金鑰";
 "Live MagSafe pin layout for charging and diagnostics." = "即時顯示用於充電與診斷的 MagSafe 針腳配置。";
 "Live multi-port power graphs and event history." = "即時多連接埠功率圖表與事件記錄。";
@@ -443,7 +443,7 @@
 "The cable's e-marker chip reports a blank vendor ID, but the connector identifies the cable as %@ (%@), a USB-IF-registered vendor. A blank e-marker VID by itself is common on genuine passive cables, so it isn't a sign of a problem." = "線材的 e-marker 晶片回報空白的 Vendor ID，但接頭將線材識別為 %1$@（%2$@），這是一家已向 USB-IF 註冊的廠商。e-marker VID 為空白本身在正規的被動式線材上相當常見，因此不代表有任何問題。";
 "Cable note:" = "線材備註：";
 "Vendor is recognised but not in WhatCable's bundled USB-IF list" = "廠商已識別，但不在 WhatCable 內建的 USB-IF 清單中";
-"The vendor ID %@ (%@) is a recognised maker in the community USB vendor list, but not in the USB-IF list WhatCable bundles." = "Vendor ID %@（%@）可在社群維護的 USB 廠商清單中識別，但不在 WhatCable 內建的 USB-IF 清單中。";
+"The vendor ID %@ (%@) is a recognised maker in the community USB vendor list, but not in the USB-IF list WhatCable bundles." = "Vendor ID %@（%@）可在社群維護的 USB 廠商清單中找到，但不在 WhatCable 內建的 USB-IF 清單中。";
 "Cable has an e-marker chip, not read on this connection (needs above 3A or Thunderbolt, or try reconnecting the cable)" = "線材具有 e-marker 晶片，但目前無法透過此連線讀取（需超過 3A 或使用 Thunderbolt，或嘗試重新連接線材）";
 
 /* DFP product type labels (DAR-24) */

--- a/Sources/WhatCableCore/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/WhatCableCore/Resources/zh-Hant.lproj/Localizable.strings
@@ -167,7 +167,7 @@
 "Connector" = "連接器";
 "Controller alert: could indicate overcurrent, overtemperature, or a protocol error. Check Port Health for details." = "控制器警示：可能表示過電流、過熱或協定錯誤。請查看「連接埠健康狀況」了解詳細資訊。";
 "Controller app loaded" = "控制器 App 已載入";
-"Controller firmware finished boot. Appears once per power cycle or hard reset." = "控制器韌體已完成啟動。每次電源循環或硬重置會出現一次。";
+"Controller firmware finished boot. Appears once per power cycle or hard reset." = "控制器韌體已完成啟動。每次重新供電或硬重設會出現一次。";
 "Current" = "電流";
 "Current (A)" = "電流 (A)";
 "Data role swap complete" = "資料角色交換完成";
@@ -192,7 +192,7 @@
 "General port controller status change (connection state, error flags)." = "一般連接埠控制器狀態變更（連線狀態、錯誤旗標）。";
 "Generic controller status register changed. Covers plug state, orientation, and error conditions." = "通用控制器狀態暫存器已變更。涵蓋連接狀態、方向和錯誤情況。";
 "Good" = "良好";
-"Hard reset count" = "硬重置次數";
+"Hard reset count" = "硬重設次數";
 "High" = "高";
 "Could not reach the licence server. Check your internet connection and try again." = "無法連接授權伺服器。請檢查網路連線後再試一次。";
 "I2C error count" = "I2C 錯誤次數";
@@ -233,7 +233,7 @@
 "Requested operating current" = "請求的運作電流";
 "Requested operating power" = "請求的運作功率";
 "Requested output voltage" = "請求的輸出電壓";
-"PD protocol engine status changed. Tracks contract state, hard/soft reset counts, and message sequence numbers." = "PD 協定引擎狀態已變更。追蹤協議狀態、硬/軟重置次數和訊息序號。";
+"PD protocol engine status changed. Tracks contract state, hard/soft reset counts, and message sequence numbers." = "PD 協定引擎狀態已變更。追蹤協議狀態、硬/軟重設次數和訊息序號。";
 "PD spec revision" = "PD 規範版本";
 "PD state" = "PD 狀態";
 "PD status update" = "PD 狀態更新";
@@ -342,9 +342,9 @@
 "The parts we can see all support %@ or more, but the link came up slower. Reseating the cable or trying another port may help." = "目前可見的部分都支援 %@ 或更高速度，但連線建立時速度較低。重新插拔線材或嘗試其他連接埠可能會有幫助。";
 "Running at full data speed (%@)" = "正在以最高資料速度運作（%@）";
 "Nothing is being held back: the parts we can see all support this speed." = "沒有任何限制：目前偵測到的裝置都支援此速度。";
-"Cable is limiting data speed" = "線材限制了資料速度";
+"Cable is limiting data speed" = "線材限制了資料傳輸速度";
 "The Mac and device can do %@, but the cable only carries %@. A faster cable would unlock full speed." = "Mac 和裝置都能達到 %@，但線材只能承載 %@。使用更快的線材即可解鎖最高速度。";
-"This Mac port limits data speed" = "這個 Mac 連接埠限制了資料速度";
+"This Mac port limits data speed" = "這個 Mac 連接埠限制了資料傳輸速度";
 "The cable and device can do %@, but this port maxes out at %@." = "線材和裝置都能達到 %@，但此連接埠最高只有 %@。";
 "Device runs at %@" = "裝置以 %@ 運作";
 "This is the fastest the connected device supports. It is not a cable problem." = "這是已連接裝置支援的最快速度。這不是線材問題。";
@@ -355,7 +355,7 @@
 "No Connections" = "沒有連線";
 "Plug a cable into a port to see what is limiting it." = "將線材接到連接埠，即可查看限制因素。";
 "Nothing to diagnose on this port yet (no active power or data link)." = "此連接埠目前沒有可診斷的項目（沒有作用中的電源或資料連線）。";
-"Data speed" = "資料速度";
+"Data speed" = "資料傳輸速度";
 "Display links are not analysed yet." = "尚未分析顯示器連線。";
 "Mac port" = "Mac 連接埠";
 "Cable" = "線材";
@@ -385,20 +385,20 @@
 
 /* Display dimension. */
 "A display is connected but its capabilities aren't readable, so there's nothing to compare the link against." = "已連接顯示器，但無法讀取其規格，因此沒有可供比較的連線資訊。";
-"The link is carrying about %@ (%lld of %lld lanes)." = "連線承載約 %@（%lld/%lld 通道）。";
+"The link is carrying about %@ (%lld of %lld lanes)." = "連線承載約 %@（%lld/%lld 條通道）。";
 "display" = "顯示器";
 "Your %@ is connected, but the link rate isn't readable, so there's nothing to compare its capability against." = "您的 %@ 已連接，但無法讀取連線速率，因此沒有可供比較的規格資訊。";
 "Display running at full quality" = "顯示器以最佳畫質運作";
 "Your %@ is connected and the link has the bandwidth for its top mode. Nothing is holding the picture back." = "您的 %@ 已連接，且目前連線頻寬足以支援其最高模式。顯示畫面沒有受到任何限制。";
-"%lld of %lld lanes at %@" = "%lld/%lld 通道（%@）";
-"%lld of %lld lanes" = "%lld/%lld 通道";
+"%lld of %lld lanes at %@" = "%lld/%lld 條通道（%@）";
+"%lld of %lld lanes" = "%lld/%lld 條通道";
 "up to %lldHz" = "最高 %lldHz";
 "a higher mode than the link is carrying" = "比目前連線承載更高的模式";
 "This estimate assumes standard colour; a display using compression (DSC) may reach more." = "此估算以標準色彩模式為前提；使用影像串流壓縮（DSC）的顯示器可能達到更高規格。";
 "Video is going through a %@ adapter" = "影像訊號正透過 %@ 轉接器傳輸";
 "Your %@ is reached through a USB-C to %@ adapter, and the link isn't currently carrying the monitor's top mode (%@, about %@); it's carrying about %@ (%@). With an adapter in the chain, the adapter's own limit may be the cap rather than the cable. Trying the monitor over native DisplayPort, or a higher-spec adapter, would tell you which." = "您的 %@ 是透過 USB-C 轉 %@ 轉接器連接，而連線尚未達到顯示器的最高模式（%@，約需 %@）；目前約承載 %@（%@）。在有轉接器的情況下，限制因素可能是轉接器本身，而非線材。改用原生 DisplayPort 連接，或使用規格更高的轉接器，有助於判斷原因。";
 "Monitor can do more than the link is carrying" = "顯示器規格高於目前連線承載";
-"Your %@ can run %@, which needs about %@, but the link is currently carrying about %@ (%@). If you've selected the higher mode and aren't getting it, the cable or adapter is the likely limit; if you haven't tried it, selecting it may retrain the link to a higher rate." = "您的 %@ 可支援 %@，約需 %@，但目前連線僅承載約 %@（%@）。若已選擇較高模式卻無法達成，限制因素可能是線材或轉接器；若尚未嘗試，選擇較高模式可能會讓連線重新協商至更高速率。";
+"Your %@ can run %@, which needs about %@, but the link is currently carrying about %@ (%@). If you've selected the higher mode and aren't getting it, the cable or adapter is the likely limit; if you haven't tried it, selecting it may retrain the link to a higher rate." = "您的 %@ 可支援 %@，約需 %@，但目前連線僅承載約 %@（%@）。若已選擇較高模式卻無法生效，限制因素可能是線材或轉接器；若尚未嘗試，選擇較高模式可能會讓連線重新協商至更高速率。";
 "Display Diagnostics" = "顯示器診斷";
 "What your monitor can do, and what the link is carrying." = "查看顯示器的規格，以及目前連線實際承載的內容。";
 "No Displays" = "沒有顯示器";

--- a/Sources/WhatCableCore/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/WhatCableCore/Resources/zh-Hant.lproj/Localizable.strings
@@ -12,14 +12,14 @@
 "Active cable (contains signal-conditioning electronics)" = "主動式線材（包含訊號調節電子元件）";
 "Active cable (VDO 2):" = "主動式線材（VDO 2）：";
 "Alternate Mode Adapter" = "Alternate Mode 轉接器";
-"Both the charger and cable can do more, but the Mac is currently asking for less. This is normal once the battery is mostly full, or when the system is idle." = "充電器和線材都能提供更高功率，但 Mac 目前要求的功率較低。電池接近充滿或系統閒置時，這是正常現象。";
+"Both the charger and cable can do more, but the Mac is currently asking for less. This is normal once the battery is mostly full, or when the system is idle." = "充電器和線材都能提供更高功率，但 Mac 目前請求的功率較低。電池接近充滿或系統閒置時，這是正常現象。";
 "Cable does not advertise an e-marker (basic cable)" = "線材未宣告 e-marker（基本線材）";
 "Cable has an e-marker chip (advertises its capabilities)" = "線材有 e-marker 晶片（會宣告自身規格）";
 "Cable is limiting charging speed" = "線材限制了充電速度";
 "Cable identified as %@" = "線材已識別為 %@";
 "Cable made by %@" = "線材製造商：%@";
 "Cable rated for %@ at up to %lldV (~%lldW)" = "線材額定 %1$@，最高 %2$lldV（約 %3$lldW）";
-"Cable rated to %lldV / %@, delivers up to %lldW (USB-PD caps at 48V)" = "線材額定規格為 %1$lldV / %2$@，最高可傳輸 %3$lldW（USB-PD 上限為 48V）";
+"Cable rated to %lldV / %@, delivers up to %lldW (USB-PD caps at 48V)" = "線材額定規格為 %1$lldV / %2$@，最高可承載 %3$lldW（USB-PD 上限為 48V）";
 "Cable speed: %@" = "線材速度：%@";
 "Cable trust signals:" = "線材驗證資訊：";
 "Carrying DisplayPort video" = "正在傳輸 DisplayPort 影像";
@@ -53,18 +53,18 @@
 "E-marker reports no vendor identity" = "E-marker 未回報廠商識別資訊";
 "E-marker uses a reserved cable-latency value" = "E-marker 使用了保留的線材延遲值";
 "E-marker uses a reserved current-rating value" = "E-marker 使用了保留的額定電流值";
-"E-marker uses a reserved data-speed value" = "E-marker 使用了保留的資料速度值";
+"E-marker uses a reserved data-speed value" = "E-marker 使用了保留的資料傳輸速度值";
 "E-marker uses an invalid VDO version" = "E-marker 使用了無效的 VDO 版本";
 "E-marker uses an invalid cable-termination value" = "E-marker 使用了無效的線材端接值";
 "Last leg drops from %@ to %@" = "最後一段從 %1$@ 降到 %2$@";
 "This cable's e-marker doesn't report a vendor ID, which is common on genuine cables. It's only worth a closer look if the cable's other capability data is also inconsistent." = "此線材的 e-marker 未回報 Vendor ID，這在正規線材上相當常見。只有當線材的其它規格資料也出現不一致時，才值得進一步留意。";
-"Linked at %@" = "連線速率 %@";
+"Linked at %@" = "已以 %@ 連線";
 "Negotiation hasn't completed yet." = "協商尚未完成。";
 "Charger on standby" = "充電器待命中";
 "Another charger is powering the Mac right now. macOS draws from one charger at a time, so this charger stays on standby until the other is unplugged." = "目前有另一個充電器正在為 Mac 供電。macOS 一次只會從一個充電器取電，因此此充電器會維持待命狀態，直到另一個充電器中斷連接。";
 "No USB-C / MagSafe ports were found on this Mac." = "這台 Mac 上找不到 USB-C / MagSafe 連接埠。";
 "No e-marker detected. This cable doesn't advertise its capabilities." = "未偵測到 e-marker。此線材未宣告自身規格。";
-"No e-marker detected. The cable may have one, but macOS only reads it above 3A or with Thunderbolt." = "未偵測到 e-marker。線材可能有 e-marker，但 macOS 只會在超出 3A 或使用 Thunderbolt 時讀取。";
+"No e-marker detected. The cable may have one, but macOS only reads it above 3A or with Thunderbolt." = "未偵測到 e-marker。線材可能有 e-marker，但 macOS 只會在超過 3A 或使用 Thunderbolt 時讀取。";
 "Nothing connected" = "未連接任何裝置";
 "Only USB 2.0 is active. If you expected high speed, the cable may not support it." = "目前只有 USB 2.0 作用中。如果預期應有高速連線，線材可能不支援。";
 "Optical" = "光纖";
@@ -73,7 +73,7 @@
 "Optical fibres are electrically isolated end-to-end" = "光纖端到端電氣隔離";
 "Other" = "其他";
 "Passive cable" = "被動式線材";
-"Plug a cable into %@ to see what it can do." = "將線材接入 %@，即可查看它能做什麼。";
+"Plug a cable into %@ to see what it can do." = "將線材接到 %@，即可查看它能做什麼。";
 "Power is flowing but no data link is established." = "正在供電，但未建立資料連線。";
 "Power is flowing. No data connection." = "正在供電。沒有資料連線。";
 "Raw IOKit properties:" = "原始 IOKit 屬性：";
@@ -91,8 +91,8 @@
 "The cable's e-marker reports cable-latency value %lld, which is reserved by the USB-PD spec for this cable type. Real e-marker chips should not emit reserved values." = "線材的 e-marker 回報線材延遲值 %lld；對於此線材類型，該值由 USB-PD 規範保留。真正的 e-marker 晶片不應輸出保留值。";
 "The cable's e-marker reports current value %lld, which is reserved by the USB-PD spec. Real e-marker chips should not emit reserved values." = "線材的 e-marker 回報電流值 %lld；該值由 USB-PD 規範保留。真正的 e-marker 晶片不應輸出保留值。";
 "The cable's e-marker reports speed value %lld, which is reserved by the USB-PD spec. Real e-marker chips should not emit reserved values." = "線材的 e-marker 回報速度值 %lld；該值由 USB-PD 規範保留。真正的 e-marker 晶片不應輸出保留值。";
-"The cable's e-marker reports vendor %@, which isn't in our bundled USB-IF list. The number could be unassigned, copied, or assigned after the bundled list was generated. On its own this isn't proof of a problem, but on a clone cable it often appears alongside other inconsistencies." = "線材的 e-marker 回報廠商 %@，但它不在內建 USB-IF 清單中。這個編號可能尚未分配、遭到複製，或是在內建清單產生後才分配。單獨來看這不能證明有問題，但在複製線材上常會與其他不一致同時出現。";
-"This port can't read cable details (USB-only port, no Power Delivery)" = "此連接埠無法讀取線材詳細資訊（僅 USB，沒有 Power Delivery）";
+"The cable's e-marker reports vendor %@, which isn't in our bundled USB-IF list. The number could be unassigned, copied, or assigned after the bundled list was generated. On its own this isn't proof of a problem, but on a clone cable it often appears alongside other inconsistencies." = "線材的 e-marker 回報廠商 %@，但它不在內建 USB-IF 清單中。這個編號可能尚未分配、遭到複製，或是在內建清單產生後才分配。單獨來看這不能證明有問題，但在疑似仿冒線材上常會與其他不一致同時出現。";
+"This port can't read cable details (USB-only port, no Power Delivery)" = "此連接埠無法讀取線材詳細資訊（僅支援 USB，沒有 Power Delivery）";
 "Thunderbolt / USB4" = "Thunderbolt / USB4";
 "Thunderbolt / USB4 link active" = "Thunderbolt / USB4 連線作用中";
 "Thunderbolt / USB4 · %lldW charger" = "Thunderbolt / USB4 · %lldW 充電器";
@@ -137,7 +137,7 @@
 
 /* DisplayPort lane labels, connected-device variants, pin-diagram Data label */
 "2 DP lanes + USB3 data" = "2 條 DP 通道 + USB3 資料";
-"4 DP lanes (no USB3 alongside video)" = "4 條 DP 通道（影像旁沒有 USB3）";
+"4 DP lanes (no USB3 alongside video)" = "4 條 DP 通道（不與 USB3 資料並行）";
 "Carrying DisplayPort video (%@)" = "正在傳輸 DisplayPort 影像（%@）";
 "Connected device: %@" = "已連接裝置：%@";
 "Connected device: %@, %@ (%@)" = "已連接裝置：%1$@，%2$@（%3$@）";
@@ -151,7 +151,7 @@
 "A DR_Swap completed successfully. The port changed between DFP (host) and UFP (device) roles." = "DR_Swap 已成功完成。連接埠已在 DFP（主機）和 UFP（裝置）角色之間切換。";
 "A PR_Swap completed successfully. Common when a hub or dock renegotiates which end supplies power." = "PR_Swap 已成功完成。常見於 Hub 或 Dock 重新協商由哪一端供電時。";
 "A USB 2.0 connection was detected on the legacy D+/D- pins." = "在傳統 D+/D- 針腳上偵測到 USB 2.0 連線。";
-"A cable was physically connected or disconnected from the port." = "有線材從連接埠實體連接或中斷連接。";
+"A cable was physically connected or disconnected from the port." = "線材已實際接上或拔離連接埠。";
 "Activate" = "啟用";
 "Active Cable" = "主動式線材";
 "Active RDO" = "作用中 RDO";
@@ -171,7 +171,7 @@
 "Current" = "電流";
 "Current (A)" = "電流 (A)";
 "Data role swap complete" = "資料角色交換完成";
-"Data role swaps" = "資料角色交換";
+"Data role swaps" = "資料角色交換次數";
 "Deactivate" = "停用";
 "Deactivate Licence" = "停用授權";
 "Deactivate WhatCable Pro?" = "要停用 WhatCable Pro 嗎？";
@@ -196,7 +196,7 @@
 "High" = "高";
 "Could not reach the licence server. Check your internet connection and try again." = "無法連接授權伺服器。請檢查網路連線後再試一次。";
 "I2C error count" = "I2C 錯誤次數";
-"Inactive" = "未作用";
+"Inactive" = "未作用中";
 "Invalid licence key. Check the key and try again." = "授權金鑰無效。請檢查金鑰後再試一次。";
 "Lanes" = "通道數";
 "Legacy USB 2.0 data lines (D+/D-) detected a partner. Separate from the CC-based PD connection." = "傳統 USB 2.0 資料線（D+/D-）偵測到對端。這與基於 CC 的 PD 連線彼此獨立。";
@@ -210,7 +210,7 @@
 "MagSafe Charger" = "MagSafe 充電器";
 "Manufacturer" = "製造商";
 "Marginal" = "勉強可用";
-"Requested max operating current" = "要求的最大運作電流";
+"Requested max operating current" = "請求的最大運作電流";
 "Requested max operating power" = "請求的最大運作功率";
 "Max power" = "最大功率";
 "Mitigations" = "緩解措施";
@@ -230,7 +230,7 @@
 "No liquid detection data" = "沒有液體偵測資料";
 "None" = "無";
 "Open Pro diagnostics for this port" = "開啟此連接埠的 Pro 診斷";
-"Requested operating current" = "要求的運作電流";
+"Requested operating current" = "請求的運作電流";
 "Requested operating power" = "請求的運作功率";
 "Requested output voltage" = "請求的輸出電壓";
 "PD protocol engine status changed. Tracks contract state, hard/soft reset counts, and message sequence numbers." = "PD 協定引擎狀態已變更。追蹤協議狀態、硬/軟重置次數和訊息序號。";
@@ -241,7 +241,7 @@
 "Partner device identity arrived via SOP (the connected device, not the cable)." = "對端裝置識別資訊已透過 SOP 傳入（已連接的裝置，不是線材）。";
 "Passive Cable" = "被動式線材";
 "Pin Diagram" = "針腳圖";
-"Plug inserted or removed" = "連接器已插入或拔出";
+"Plug inserted or removed" = "連接器已接上或拔出";
 "Plug: %@" = "連接器：%@";
 "Port Health" = "連接埠健康狀況";
 "Power" = "功率";
@@ -251,7 +251,7 @@
 "Power delivery parameters changed (voltage, current, or power role)." = "供電參數已變更（電壓、電流或電源角色）。";
 "Power path status changed. Covers VBUS voltage, current draw, and source/sink transitions." = "電源路徑狀態已變更。涵蓋 VBUS 電壓、電流取用，以及 source/sink 轉換。";
 "Power role swap complete" = "電源角色交換完成";
-"Power role swaps" = "電源角色交換";
+"Power role swaps" = "電源角色交換次數";
 "Power status update" = "電源狀態更新";
 "Pro features unlocked." = "Pro 功能已解鎖。";
 "Pro features will be locked until you enter your key again." = "在再次輸入金鑰前，Pro 功能將保持鎖定。";
@@ -264,7 +264,7 @@
 "Rp resistor" = "Rp 電阻";
 "SOP identity received" = "已收到 SOP 識別資訊";
 "Short detect count" = "短路偵測次數";
-"Signal Routing" = "訊號路由";
+"Signal Routing" = "訊號路徑";
 "Sleep/wake" = "睡眠/喚醒";
 "Source PDOs" = "Source PDOs";
 "Source capabilities received" = "已收到 Source Capabilities";
@@ -275,10 +275,10 @@
 "System sleep/wake transition. The port controller state is saved and restored across sleep boundaries." = "系統睡眠/喚醒轉換。連接埠控制器狀態會在睡眠前後儲存並還原。";
 "The Mac entered or exited sleep, causing port controller state changes." = "Mac 進入或結束睡眠，導致連接埠控制器狀態變更。";
 "The charger or power source advertised what voltages and currents it can provide." = "充電器或電源宣告了可提供的電壓和電流。";
-"The data role flipped: the port switched between host and device mode." = "資料角色已翻轉：連接埠在主機和裝置模式之間切換。";
+"The data role flipped: the port switched between host and device mode." = "資料角色已切換：連接埠在主機和裝置模式之間切換。";
 "The port controller firmware finished initialising and is ready." = "連接埠控制器韌體已完成初始化並準備就緒。";
 "The port controller raised an alert (overcurrent, overtemperature, or similar fault)." = "連接埠控制器發出警示（過電流、過熱或類似故障）。";
-"The power direction flipped: the port switched between providing and receiving power." = "電源方向已翻轉：連接埠在供電和受電之間切換。";
+"The power direction flipped: the port switched between providing and receiving power." = "電源方向已切換：連接埠在供電與受電之間切換。";
 "This event code is not in the known TPS6598x interrupt table. May be firmware-specific." = "此事件代碼不在已知的 TPS6598x 中斷表中。可能是韌體特定事件。";
 "Tunneled" = "封裝傳輸";
 "UVDM discovery started. The controller is probing for vendor-specific capabilities on the cable or partner." = "UVDM 探索已開始。控制器正在探測線材或對端上的廠商特定規格。";
@@ -353,7 +353,7 @@
 "Negotiation Diagnostics" = "協商診斷";
 "What each link can do, and where the bottleneck is." = "查看每個連線能做什麼，以及瓶頸在哪裡。";
 "No Connections" = "沒有連線";
-"Plug a cable into a port to see what is limiting it." = "將線材接入連接埠，即可查看限制因素。";
+"Plug a cable into a port to see what is limiting it." = "將線材接到連接埠，即可查看限制因素。";
 "Nothing to diagnose on this port yet (no active power or data link)." = "此連接埠目前沒有可診斷的項目（沒有作用中的電源或資料連線）。";
 "Data speed" = "資料速度";
 "Display links are not analysed yet." = "尚未分析顯示器連線。";

--- a/Sources/WhatCableCore/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/WhatCableCore/Resources/zh-Hant.lproj/Localizable.strings
@@ -10,7 +10,7 @@
 "Active %@ cable, %@" = "主動式 %1$@ 線材，%2$@";
 "Active cable" = "主動式線材";
 "Active cable (contains signal-conditioning electronics)" = "主動式線材（包含訊號調節電子元件）";
-"Active cable (VDO 2):" = "主動式線材（VDO 2）：";
+"Active cable (VDO 2):" = "主動式線材 (VDO 2)：";
 "Alternate Mode Adapter" = "Alternate Mode 轉接器";
 "Both the charger and cable can do more, but the Mac is currently asking for less. This is normal once the battery is mostly full, or when the system is idle." = "充電器和線材都能提供更高功率，但 Mac 目前請求的功率較低。電池接近充滿或系統閒置時，這是正常現象。";
 "Cable does not advertise an e-marker (basic cable)" = "線材未宣告 e-marker（基本線材）";
@@ -96,10 +96,10 @@
 "Thunderbolt / USB4" = "Thunderbolt / USB4";
 "Thunderbolt / USB4 link active" = "Thunderbolt / USB4 連線作用中";
 "Thunderbolt / USB4 · %lldW charger" = "Thunderbolt / USB4 · %lldW 充電器";
-"USB 2.0 (480 Mbps)" = "USB 2.0（480 Mbps）";
-"USB 2.0 only (480 Mbps), no high-speed data" = "僅 USB 2.0（480 Mbps），沒有高速資料傳輸";
-"USB 3.2 Gen 1 (5 Gbps)" = "USB 3.2 Gen 1（5 Gbps）";
-"USB 3.2 Gen 2 (10 Gbps)" = "USB 3.2 Gen 2（10 Gbps）";
+"USB 2.0 (480 Mbps)" = "USB 2.0 (480 Mbps)";
+"USB 2.0 only (480 Mbps), no high-speed data" = "僅 USB 2.0 (480 Mbps)，沒有高速資料傳輸";
+"USB 3.2 Gen 1 (5 Gbps)" = "USB 3.2 Gen 1 (5 Gbps)";
+"USB 3.2 Gen 2 (10 Gbps)" = "USB 3.2 Gen 2 (10 Gbps)";
 "USB Hub" = "USB Hub";
 "USB Peripheral" = "USB 周邊裝置";
 "USB default" = "USB 預設";
@@ -107,8 +107,8 @@
 "USB device · %lldW charger" = "USB 裝置 · %lldW 充電器";
 "USB-C with video" = "支援影像的 USB-C";
 "USB-C with video · %lldW charger" = "支援影像的 USB-C · %lldW 充電器";
-"USB4 Gen 3 (20 / 40 Gbps)" = "USB4 Gen 3（20 / 40 Gbps）";
-"USB4 Gen 4 (80 Gbps)" = "USB4 Gen 4（80 Gbps）";
+"USB4 Gen 3 (20 / 40 Gbps)" = "USB4 Gen 3 (20 / 40 Gbps)";
+"USB4 Gen 4 (80 Gbps)" = "USB4 Gen 4 (80 Gbps)";
 "Unknown device" = "未知裝置";
 "Unknown generation (raw speed code 0x%@)" = "未知世代（原始速度代碼 0x%@）";
 "Unknown generation (raw speed code 0x2, inferred TB5)" = "未知世代（原始速度代碼 0x2，推測為 TB5）";
@@ -175,7 +175,7 @@
 "Deactivate" = "停用";
 "Deactivate Licence" = "停用授權";
 "Deactivate WhatCable Pro?" = "要停用 WhatCable Pro 嗎？";
-"Default USB (500/900 mA)" = "USB 預設（500/900 mA）";
+"Default USB (500/900 mA)" = "USB 預設 (500/900 mA)";
 "Detach count" = "中斷連接次數";
 "Device Identity" = "裝置識別資訊";
 "Diagnostics" = "診斷";


### PR DESCRIPTION
Reviewed the changes from PR #325 and applied the parts that fit the current Traditional Chinese terminology.

This update adjusts the translations line by line for consistency with the existing zh-Hant localization, especially around USB-C / USB-PD technical terms.

If anything was missed, or if there are different opinions on specific wording, please feel free to open another PR or discuss it there.

This PR also reviewed the changes proposed in #325 and selectively applied the parts that fit the current Traditional Chinese terminology and UI context. Thanks to @PeterDaveHello for the suggestions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Traditional Chinese (zh‑Hant) localization: clarified USB‑C/USB‑PD power wording and “requested” phrasing, refined e‑marker messages and vendor‑ID wording, adjusted connect/disconnect and role‑swap labels (added 次數), changed “Inactive” translation, standardized “Signal Routing” term, revised diagnostics/display wording (資料傳輸速度、條通道、DisplayPort lane labels) and normalized USB/USB4 speed label formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->