### PR TITLE
Russian language update

### DIFF
--- a/Sources/WhatCableCore/Resources/de.lproj/Localizable.strings
+++ b/Sources/WhatCableCore/Resources/de.lproj/Localizable.strings
@@ -432,6 +432,13 @@
 /* Display dimension: confirmed full quality via CoreGraphics live mode (issue #246 Option B). */
 "Your %@ is running its top mode (%@), and the link is carrying it. Many high-resolution displays use compression (DSC) to fit a mode like this through the link, so the link rate alone can't show it; your display is at full quality." = "Dein %@ läuft im besten Modus (%@) und die Verbindung überträgt ihn. Viele hochauflösende Displays nutzen Komprimierung (DSC), um einen solchen Modus durch die Verbindung zu bringen; die Verbindungsrate allein zeigt das nicht. Dein Display läuft in voller Qualität.";
 
+/* Session monitor verdicts. */
+"Performing as expected" = "Performing as expected";
+"No problems seen while watching this cable." = "No problems seen while watching this cable.";
+"Saw a brief drop or a single high reading. Not conclusive; still watching." = "Saw a brief drop or a single high reading. Not conclusive; still watching.";
+"Not performing as expected" = "Not performing as expected";
+"Isn't performing as expected" = "Isn't performing as expected";
+
 /* Power Monitor system power source indicator. */
 "Battery" = "Batterie";
 "Source" = "Quelle";

--- a/Sources/WhatCableCore/Resources/de.lproj/Localizable.strings
+++ b/Sources/WhatCableCore/Resources/de.lproj/Localizable.strings
@@ -433,6 +433,7 @@
 "Your %@ is running its top mode (%@), and the link is carrying it. Many high-resolution displays use compression (DSC) to fit a mode like this through the link, so the link rate alone can't show it; your display is at full quality." = "Dein %@ läuft im besten Modus (%@) und die Verbindung überträgt ihn. Viele hochauflösende Displays nutzen Komprimierung (DSC), um einen solchen Modus durch die Verbindung zu bringen; die Verbindungsrate allein zeigt das nicht. Dein Display läuft in voller Qualität.";
 
 /* Session monitor verdicts. */
+"Battery full, not drawing power" = "Battery full, not drawing power";
 "Performing as expected" = "Performing as expected";
 "No problems seen while watching this cable." = "No problems seen while watching this cable.";
 "Saw a brief drop or a single high reading. Not conclusive; still watching." = "Saw a brief drop or a single high reading. Not conclusive; still watching.";

--- a/Sources/WhatCableCore/Resources/en.lproj/Localizable.strings
+++ b/Sources/WhatCableCore/Resources/en.lproj/Localizable.strings
@@ -436,6 +436,13 @@
 /* Display dimension: confirmed full quality via CoreGraphics live mode (issue #246 Option B). */
 "Your %@ is running its top mode (%@), and the link is carrying it. Many high-resolution displays use compression (DSC) to fit a mode like this through the link, so the link rate alone can't show it; your display is at full quality." = "Your %@ is running its top mode (%@), and the link is carrying it. Many high-resolution displays use compression (DSC) to fit a mode like this through the link, so the link rate alone can't show it; your display is at full quality.";
 
+/* Session monitor verdicts. */
+"Performing as expected" = "Performing as expected";
+"No problems seen while watching this cable." = "No problems seen while watching this cable.";
+"Saw a brief drop or a single high reading. Not conclusive; still watching." = "Saw a brief drop or a single high reading. Not conclusive; still watching.";
+"Not performing as expected" = "Not performing as expected";
+"Isn't performing as expected" = "Isn't performing as expected";
+
 /* Power Monitor system power source indicator. */
 "Battery" = "Battery";
 "Source" = "Source";

--- a/Sources/WhatCableCore/Resources/en.lproj/Localizable.strings
+++ b/Sources/WhatCableCore/Resources/en.lproj/Localizable.strings
@@ -437,6 +437,7 @@
 "Your %@ is running its top mode (%@), and the link is carrying it. Many high-resolution displays use compression (DSC) to fit a mode like this through the link, so the link rate alone can't show it; your display is at full quality." = "Your %@ is running its top mode (%@), and the link is carrying it. Many high-resolution displays use compression (DSC) to fit a mode like this through the link, so the link rate alone can't show it; your display is at full quality.";
 
 /* Session monitor verdicts. */
+"Battery full, not drawing power" = "Battery full, not drawing power";
 "Performing as expected" = "Performing as expected";
 "No problems seen while watching this cable." = "No problems seen while watching this cable.";
 "Saw a brief drop or a single high reading. Not conclusive; still watching." = "Saw a brief drop or a single high reading. Not conclusive; still watching.";

--- a/Sources/WhatCableCore/Resources/es.lproj/Localizable.strings
+++ b/Sources/WhatCableCore/Resources/es.lproj/Localizable.strings
@@ -432,6 +432,13 @@
 /* Display dimension: confirmed full quality via CoreGraphics live mode (issue #246 Option B). */
 "Your %@ is running its top mode (%@), and the link is carrying it. Many high-resolution displays use compression (DSC) to fit a mode like this through the link, so the link rate alone can't show it; your display is at full quality." = "Tu %@ está funcionando en su modo máximo (%@) y el enlace lo transporta. Muchas pantallas de alta resolución usan compresión (DSC) para hacer caber un modo así en el enlace; la velocidad del enlace por sí sola no puede mostrarlo. Tu pantalla está a plena calidad.";
 
+/* Session monitor verdicts. */
+"Performing as expected" = "Performing as expected";
+"No problems seen while watching this cable." = "No problems seen while watching this cable.";
+"Saw a brief drop or a single high reading. Not conclusive; still watching." = "Saw a brief drop or a single high reading. Not conclusive; still watching.";
+"Not performing as expected" = "Not performing as expected";
+"Isn't performing as expected" = "Isn't performing as expected";
+
 /* Power Monitor system power source indicator. */
 "Battery" = "Batería";
 "Source" = "Fuente";

--- a/Sources/WhatCableCore/Resources/es.lproj/Localizable.strings
+++ b/Sources/WhatCableCore/Resources/es.lproj/Localizable.strings
@@ -433,6 +433,7 @@
 "Your %@ is running its top mode (%@), and the link is carrying it. Many high-resolution displays use compression (DSC) to fit a mode like this through the link, so the link rate alone can't show it; your display is at full quality." = "Tu %@ está funcionando en su modo máximo (%@) y el enlace lo transporta. Muchas pantallas de alta resolución usan compresión (DSC) para hacer caber un modo así en el enlace; la velocidad del enlace por sí sola no puede mostrarlo. Tu pantalla está a plena calidad.";
 
 /* Session monitor verdicts. */
+"Battery full, not drawing power" = "Battery full, not drawing power";
 "Performing as expected" = "Performing as expected";
 "No problems seen while watching this cable." = "No problems seen while watching this cable.";
 "Saw a brief drop or a single high reading. Not conclusive; still watching." = "Saw a brief drop or a single high reading. Not conclusive; still watching.";

--- a/Sources/WhatCableCore/Resources/fr.lproj/Localizable.strings
+++ b/Sources/WhatCableCore/Resources/fr.lproj/Localizable.strings
@@ -432,6 +432,13 @@
 /* Display dimension: confirmed full quality via CoreGraphics live mode (issue #246 Option B). */
 "Your %@ is running its top mode (%@), and the link is carrying it. Many high-resolution displays use compression (DSC) to fit a mode like this through the link, so the link rate alone can't show it; your display is at full quality." = "Votre %@ fonctionne en mode maximal (%@) et la liaison le prend en charge. De nombreux écrans haute résolution utilisent la compression (DSC) pour faire passer un tel mode par la liaison ; le débit seul ne peut pas le montrer. Votre écran est à pleine qualité.";
 
+/* Session monitor verdicts. */
+"Performing as expected" = "Performing as expected";
+"No problems seen while watching this cable." = "No problems seen while watching this cable.";
+"Saw a brief drop or a single high reading. Not conclusive; still watching." = "Saw a brief drop or a single high reading. Not conclusive; still watching.";
+"Not performing as expected" = "Not performing as expected";
+"Isn't performing as expected" = "Isn't performing as expected";
+
 /* Power Monitor system power source indicator. */
 "Battery" = "Batterie";
 "Source" = "Source";

--- a/Sources/WhatCableCore/Resources/fr.lproj/Localizable.strings
+++ b/Sources/WhatCableCore/Resources/fr.lproj/Localizable.strings
@@ -433,6 +433,7 @@
 "Your %@ is running its top mode (%@), and the link is carrying it. Many high-resolution displays use compression (DSC) to fit a mode like this through the link, so the link rate alone can't show it; your display is at full quality." = "Votre %@ fonctionne en mode maximal (%@) et la liaison le prend en charge. De nombreux écrans haute résolution utilisent la compression (DSC) pour faire passer un tel mode par la liaison ; le débit seul ne peut pas le montrer. Votre écran est à pleine qualité.";
 
 /* Session monitor verdicts. */
+"Battery full, not drawing power" = "Battery full, not drawing power";
 "Performing as expected" = "Performing as expected";
 "No problems seen while watching this cable." = "No problems seen while watching this cable.";
 "Saw a brief drop or a single high reading. Not conclusive; still watching." = "Saw a brief drop or a single high reading. Not conclusive; still watching.";

--- a/Sources/WhatCableCore/Resources/hi.lproj/Localizable.strings
+++ b/Sources/WhatCableCore/Resources/hi.lproj/Localizable.strings
@@ -431,6 +431,13 @@
 /* Display dimension: confirmed full quality via CoreGraphics live mode (issue #246 Option B). */
 "Your %@ is running its top mode (%@), and the link is carrying it. Many high-resolution displays use compression (DSC) to fit a mode like this through the link, so the link rate alone can't show it; your display is at full quality." = "आपका %@ अपने सर्वोच्च मोड (%@) पर चल रहा है और लिंक इसे ले जा रहा है. कई उच्च-रिज़ॉल्यूशन डिस्प्ले इस तरह के मोड को लिंक से गुज़ारने के लिए संपीड़न (DSC) का उपयोग करते हैं; केवल लिंक दर इसे दिखाने में सक्षम नहीं है. आपका डिस्प्ले पूर्ण गुणवत्ता पर है.";
 
+/* Session monitor verdicts. */
+"Performing as expected" = "Performing as expected";
+"No problems seen while watching this cable." = "No problems seen while watching this cable.";
+"Saw a brief drop or a single high reading. Not conclusive; still watching." = "Saw a brief drop or a single high reading. Not conclusive; still watching.";
+"Not performing as expected" = "Not performing as expected";
+"Isn't performing as expected" = "Isn't performing as expected";
+
 /* Power Monitor system power source indicator. */
 "Battery" = "बैटरी";
 "Source" = "स्रोत";

--- a/Sources/WhatCableCore/Resources/hi.lproj/Localizable.strings
+++ b/Sources/WhatCableCore/Resources/hi.lproj/Localizable.strings
@@ -432,6 +432,7 @@
 "Your %@ is running its top mode (%@), and the link is carrying it. Many high-resolution displays use compression (DSC) to fit a mode like this through the link, so the link rate alone can't show it; your display is at full quality." = "आपका %@ अपने सर्वोच्च मोड (%@) पर चल रहा है और लिंक इसे ले जा रहा है. कई उच्च-रिज़ॉल्यूशन डिस्प्ले इस तरह के मोड को लिंक से गुज़ारने के लिए संपीड़न (DSC) का उपयोग करते हैं; केवल लिंक दर इसे दिखाने में सक्षम नहीं है. आपका डिस्प्ले पूर्ण गुणवत्ता पर है.";
 
 /* Session monitor verdicts. */
+"Battery full, not drawing power" = "Battery full, not drawing power";
 "Performing as expected" = "Performing as expected";
 "No problems seen while watching this cable." = "No problems seen while watching this cable.";
 "Saw a brief drop or a single high reading. Not conclusive; still watching." = "Saw a brief drop or a single high reading. Not conclusive; still watching.";

--- a/Sources/WhatCableCore/Resources/hy.lproj/Localizable.strings
+++ b/Sources/WhatCableCore/Resources/hy.lproj/Localizable.strings
@@ -432,6 +432,13 @@
 /* Display dimension: confirmed full quality via CoreGraphics live mode (issue #246 Option B). */
 "Your %@ is running its top mode (%@), and the link is carrying it. Many high-resolution displays use compression (DSC) to fit a mode like this through the link, so the link rate alone can't show it; your display is at full quality." = "Ձեր %@-ն աշխատում է իր լավագույն ռեժիմով (%@), և կապն այն փոխանցում է: Շատ բարձր լուծաչափի էկրաններ օգտագործում են սեղմում (DSC)՝ նման ռեժիմն այս կապով անցկացնելու համար. կապի արագությունն ինքնին այդ մասին ոչինչ չի ցույց տա: Ձեր էկրանն աշխատում է լիարժեք որակով:";
 
+/* Session monitor verdicts. */
+"Performing as expected" = "Performing as expected";
+"No problems seen while watching this cable." = "No problems seen while watching this cable.";
+"Saw a brief drop or a single high reading. Not conclusive; still watching." = "Saw a brief drop or a single high reading. Not conclusive; still watching.";
+"Not performing as expected" = "Not performing as expected";
+"Isn't performing as expected" = "Isn't performing as expected";
+
 /* Power Monitor system power source indicator. */
 "Battery" = "Մարտկոց";
 "Source" = "Աղբյուր";

--- a/Sources/WhatCableCore/Resources/hy.lproj/Localizable.strings
+++ b/Sources/WhatCableCore/Resources/hy.lproj/Localizable.strings
@@ -433,6 +433,7 @@
 "Your %@ is running its top mode (%@), and the link is carrying it. Many high-resolution displays use compression (DSC) to fit a mode like this through the link, so the link rate alone can't show it; your display is at full quality." = "Ձեր %@-ն աշխատում է իր լավագույն ռեժիմով (%@), և կապն այն փոխանցում է: Շատ բարձր լուծաչափի էկրաններ օգտագործում են սեղմում (DSC)՝ նման ռեժիմն այս կապով անցկացնելու համար. կապի արագությունն ինքնին այդ մասին ոչինչ չի ցույց տա: Ձեր էկրանն աշխատում է լիարժեք որակով:";
 
 /* Session monitor verdicts. */
+"Battery full, not drawing power" = "Battery full, not drawing power";
 "Performing as expected" = "Performing as expected";
 "No problems seen while watching this cable." = "No problems seen while watching this cable.";
 "Saw a brief drop or a single high reading. Not conclusive; still watching." = "Saw a brief drop or a single high reading. Not conclusive; still watching.";

--- a/Sources/WhatCableCore/Resources/it.lproj/Localizable.strings
+++ b/Sources/WhatCableCore/Resources/it.lproj/Localizable.strings
@@ -432,6 +432,7 @@
 "Your %@ is running its top mode (%@), and the link is carrying it. Many high-resolution displays use compression (DSC) to fit a mode like this through the link, so the link rate alone can't show it; your display is at full quality." = "%@ sta funzionando alla modalità massima (%@) e il collegamento la supporta. Molti schermi ad alta risoluzione per abilitare una modalità come questa attraverso il collegamento usano la compressione (DSC); la sola velocità del collegamento non fornisce l'info sulla compressione DSC. Lo schermo sta funzionando alla massima qualità.";
 
 /* Session monitor verdicts. */
+"Battery full, not drawing power" = "Battery full, not drawing power";
 "Performing as expected" = "Performing as expected";
 "No problems seen while watching this cable." = "No problems seen while watching this cable.";
 "Saw a brief drop or a single high reading. Not conclusive; still watching." = "Saw a brief drop or a single high reading. Not conclusive; still watching.";

--- a/Sources/WhatCableCore/Resources/it.lproj/Localizable.strings
+++ b/Sources/WhatCableCore/Resources/it.lproj/Localizable.strings
@@ -431,6 +431,13 @@
 /* Display dimension: confirmed full quality via CoreGraphics live mode (issue #246 Option B). */
 "Your %@ is running its top mode (%@), and the link is carrying it. Many high-resolution displays use compression (DSC) to fit a mode like this through the link, so the link rate alone can't show it; your display is at full quality." = "%@ sta funzionando alla modalità massima (%@) e il collegamento la supporta. Molti schermi ad alta risoluzione per abilitare una modalità come questa attraverso il collegamento usano la compressione (DSC); la sola velocità del collegamento non fornisce l'info sulla compressione DSC. Lo schermo sta funzionando alla massima qualità.";
 
+/* Session monitor verdicts. */
+"Performing as expected" = "Performing as expected";
+"No problems seen while watching this cable." = "No problems seen while watching this cable.";
+"Saw a brief drop or a single high reading. Not conclusive; still watching." = "Saw a brief drop or a single high reading. Not conclusive; still watching.";
+"Not performing as expected" = "Not performing as expected";
+"Isn't performing as expected" = "Isn't performing as expected";
+
 /* Power Monitor system power source indicator. */
 "Battery" = "Batteria";
 "Source" = "Sorgente";

--- a/Sources/WhatCableCore/Resources/ja.lproj/Localizable.strings
+++ b/Sources/WhatCableCore/Resources/ja.lproj/Localizable.strings
@@ -433,6 +433,13 @@
 /* Display dimension: confirmed full quality via CoreGraphics live mode (issue #246 Option B). */
 "Your %@ is running its top mode (%@), and the link is carrying it. Many high-resolution displays use compression (DSC) to fit a mode like this through the link, so the link rate alone can't show it; your display is at full quality." = "%@は最高モード（%@）で動作しており、リンクはそれを伝送しています。多くの高解像度ディスプレイは、このようなモードをリンクで通すために圧縮（DSC）を使用します。リンク速度だけではそれを示すことができません。ディスプレイは最高画質で動作しています。";
 
+/* Session monitor verdicts. */
+"Performing as expected" = "Performing as expected";
+"No problems seen while watching this cable." = "No problems seen while watching this cable.";
+"Saw a brief drop or a single high reading. Not conclusive; still watching." = "Saw a brief drop or a single high reading. Not conclusive; still watching.";
+"Not performing as expected" = "Not performing as expected";
+"Isn't performing as expected" = "Isn't performing as expected";
+
 /* Power Monitor system power source indicator. */
 "Battery" = "バッテリー";
 "Source" = "電源";

--- a/Sources/WhatCableCore/Resources/ja.lproj/Localizable.strings
+++ b/Sources/WhatCableCore/Resources/ja.lproj/Localizable.strings
@@ -434,6 +434,7 @@
 "Your %@ is running its top mode (%@), and the link is carrying it. Many high-resolution displays use compression (DSC) to fit a mode like this through the link, so the link rate alone can't show it; your display is at full quality." = "%@は最高モード（%@）で動作しており、リンクはそれを伝送しています。多くの高解像度ディスプレイは、このようなモードをリンクで通すために圧縮（DSC）を使用します。リンク速度だけではそれを示すことができません。ディスプレイは最高画質で動作しています。";
 
 /* Session monitor verdicts. */
+"Battery full, not drawing power" = "Battery full, not drawing power";
 "Performing as expected" = "Performing as expected";
 "No problems seen while watching this cable." = "No problems seen while watching this cable.";
 "Saw a brief drop or a single high reading. Not conclusive; still watching." = "Saw a brief drop or a single high reading. Not conclusive; still watching.";

--- a/Sources/WhatCableCore/Resources/ko.lproj/Localizable.strings
+++ b/Sources/WhatCableCore/Resources/ko.lproj/Localizable.strings
@@ -431,6 +431,13 @@
 /* Display dimension: confirmed full quality via CoreGraphics live mode (issue #246 Option B). */
 "Your %@ is running its top mode (%@), and the link is carrying it. Many high-resolution displays use compression (DSC) to fit a mode like this through the link, so the link rate alone can't show it; your display is at full quality." = "%@이(가) 최고 모드(%@)로 작동하고 있으며 링크가 이를 전송하고 있어요. 많은 고해상도 디스플레이는 이런 링크로 이런 모드를 전달하기 위해 압축(DSC)을 사용하므로, 링크 속도만으로는 알 수 없어요. 디스플레이는 최고 화질로 작동하고 있어요.";
 
+/* Session monitor verdicts. */
+"Performing as expected" = "Performing as expected";
+"No problems seen while watching this cable." = "No problems seen while watching this cable.";
+"Saw a brief drop or a single high reading. Not conclusive; still watching." = "Saw a brief drop or a single high reading. Not conclusive; still watching.";
+"Not performing as expected" = "Not performing as expected";
+"Isn't performing as expected" = "Isn't performing as expected";
+
 /* Power Monitor system power source indicator. */
 "Battery" = "배터리";
 "Source" = "전원";

--- a/Sources/WhatCableCore/Resources/ko.lproj/Localizable.strings
+++ b/Sources/WhatCableCore/Resources/ko.lproj/Localizable.strings
@@ -432,6 +432,7 @@
 "Your %@ is running its top mode (%@), and the link is carrying it. Many high-resolution displays use compression (DSC) to fit a mode like this through the link, so the link rate alone can't show it; your display is at full quality." = "%@이(가) 최고 모드(%@)로 작동하고 있으며 링크가 이를 전송하고 있어요. 많은 고해상도 디스플레이는 이런 링크로 이런 모드를 전달하기 위해 압축(DSC)을 사용하므로, 링크 속도만으로는 알 수 없어요. 디스플레이는 최고 화질로 작동하고 있어요.";
 
 /* Session monitor verdicts. */
+"Battery full, not drawing power" = "Battery full, not drawing power";
 "Performing as expected" = "Performing as expected";
 "No problems seen while watching this cable." = "No problems seen while watching this cable.";
 "Saw a brief drop or a single high reading. Not conclusive; still watching." = "Saw a brief drop or a single high reading. Not conclusive; still watching.";

--- a/Sources/WhatCableCore/Resources/lv.lproj/Localizable.strings
+++ b/Sources/WhatCableCore/Resources/lv.lproj/Localizable.strings
@@ -431,6 +431,13 @@
 /* Display dimension: confirmed full quality via CoreGraphics live mode (issue #246 Option B). */
 "Your %@ is running its top mode (%@), and the link is carrying it. Many high-resolution displays use compression (DSC) to fit a mode like this through the link, so the link rate alone can't show it; your display is at full quality." = "Jūsu %@ darbojas savā maksimālajā režīmā (%@) un savienojums to pārraida. Daudzi augstas izšķirtspējas displeji izmanto saspiešanu (DSC), lai šādu režīmu pārraidītu caur savienojumu; savienojuma ātrums vien to nevar parādīt. Jūsu displejs darbojas pilnā kvalitātē.";
 
+/* Session monitor verdicts. */
+"Performing as expected" = "Performing as expected";
+"No problems seen while watching this cable." = "No problems seen while watching this cable.";
+"Saw a brief drop or a single high reading. Not conclusive; still watching." = "Saw a brief drop or a single high reading. Not conclusive; still watching.";
+"Not performing as expected" = "Not performing as expected";
+"Isn't performing as expected" = "Isn't performing as expected";
+
 /* Power Monitor system power source indicator. */
 "Battery" = "Akumulators";
 "Source" = "Avots";

--- a/Sources/WhatCableCore/Resources/lv.lproj/Localizable.strings
+++ b/Sources/WhatCableCore/Resources/lv.lproj/Localizable.strings
@@ -432,6 +432,7 @@
 "Your %@ is running its top mode (%@), and the link is carrying it. Many high-resolution displays use compression (DSC) to fit a mode like this through the link, so the link rate alone can't show it; your display is at full quality." = "Jūsu %@ darbojas savā maksimālajā režīmā (%@) un savienojums to pārraida. Daudzi augstas izšķirtspējas displeji izmanto saspiešanu (DSC), lai šādu režīmu pārraidītu caur savienojumu; savienojuma ātrums vien to nevar parādīt. Jūsu displejs darbojas pilnā kvalitātē.";
 
 /* Session monitor verdicts. */
+"Battery full, not drawing power" = "Battery full, not drawing power";
 "Performing as expected" = "Performing as expected";
 "No problems seen while watching this cable." = "No problems seen while watching this cable.";
 "Saw a brief drop or a single high reading. Not conclusive; still watching." = "Saw a brief drop or a single high reading. Not conclusive; still watching.";

--- a/Sources/WhatCableCore/Resources/nb.lproj/Localizable.strings
+++ b/Sources/WhatCableCore/Resources/nb.lproj/Localizable.strings
@@ -432,6 +432,13 @@
 /* Display dimension: confirmed full quality via CoreGraphics live mode (issue #246 Option B). */
 "Your %@ is running its top mode (%@), and the link is carrying it. Many high-resolution displays use compression (DSC) to fit a mode like this through the link, so the link rate alone can't show it; your display is at full quality." = "%@-en din kjører i sitt beste modus (%@) og forbindelsen bærer det. Mange skjermer med høy oppløsning bruker komprimering (DSC) for å få et slikt modus gjennom forbindelsen; forbindelseshastigheten alene kan ikke vise dette. Skjermen din er i full kvalitet.";
 
+/* Session monitor verdicts. */
+"Performing as expected" = "Performing as expected";
+"No problems seen while watching this cable." = "No problems seen while watching this cable.";
+"Saw a brief drop or a single high reading. Not conclusive; still watching." = "Saw a brief drop or a single high reading. Not conclusive; still watching.";
+"Not performing as expected" = "Not performing as expected";
+"Isn't performing as expected" = "Isn't performing as expected";
+
 /* Power Monitor system power source indicator. */
 "Battery" = "Batteri";
 "Source" = "Kilde";

--- a/Sources/WhatCableCore/Resources/nb.lproj/Localizable.strings
+++ b/Sources/WhatCableCore/Resources/nb.lproj/Localizable.strings
@@ -433,6 +433,7 @@
 "Your %@ is running its top mode (%@), and the link is carrying it. Many high-resolution displays use compression (DSC) to fit a mode like this through the link, so the link rate alone can't show it; your display is at full quality." = "%@-en din kjører i sitt beste modus (%@) og forbindelsen bærer det. Mange skjermer med høy oppløsning bruker komprimering (DSC) for å få et slikt modus gjennom forbindelsen; forbindelseshastigheten alene kan ikke vise dette. Skjermen din er i full kvalitet.";
 
 /* Session monitor verdicts. */
+"Battery full, not drawing power" = "Battery full, not drawing power";
 "Performing as expected" = "Performing as expected";
 "No problems seen while watching this cable." = "No problems seen while watching this cable.";
 "Saw a brief drop or a single high reading. Not conclusive; still watching." = "Saw a brief drop or a single high reading. Not conclusive; still watching.";

--- a/Sources/WhatCableCore/Resources/nl.lproj/Localizable.strings
+++ b/Sources/WhatCableCore/Resources/nl.lproj/Localizable.strings
@@ -432,6 +432,7 @@
 "Your %@ is running its top mode (%@), and the link is carrying it. Many high-resolution displays use compression (DSC) to fit a mode like this through the link, so the link rate alone can't show it; your display is at full quality." = "Uw %@ draait in de beste modus (%@) en de verbinding ondersteunt dit. Veel hoge-resolutieschermen gebruiken compressie (DSC) om zo'n modus door de verbinding te laten passen; de verbindingssnelheid alleen kan dit niet tonen. Uw scherm werkt op volledige kwaliteit.";
 
 /* Session monitor verdicts. */
+"Battery full, not drawing power" = "Battery full, not drawing power";
 "Performing as expected" = "Performing as expected";
 "No problems seen while watching this cable." = "No problems seen while watching this cable.";
 "Saw a brief drop or a single high reading. Not conclusive; still watching." = "Saw a brief drop or a single high reading. Not conclusive; still watching.";

--- a/Sources/WhatCableCore/Resources/nl.lproj/Localizable.strings
+++ b/Sources/WhatCableCore/Resources/nl.lproj/Localizable.strings
@@ -431,6 +431,13 @@
 /* Display dimension: confirmed full quality via CoreGraphics live mode (issue #246 Option B). */
 "Your %@ is running its top mode (%@), and the link is carrying it. Many high-resolution displays use compression (DSC) to fit a mode like this through the link, so the link rate alone can't show it; your display is at full quality." = "Uw %@ draait in de beste modus (%@) en de verbinding ondersteunt dit. Veel hoge-resolutieschermen gebruiken compressie (DSC) om zo'n modus door de verbinding te laten passen; de verbindingssnelheid alleen kan dit niet tonen. Uw scherm werkt op volledige kwaliteit.";
 
+/* Session monitor verdicts. */
+"Performing as expected" = "Performing as expected";
+"No problems seen while watching this cable." = "No problems seen while watching this cable.";
+"Saw a brief drop or a single high reading. Not conclusive; still watching." = "Saw a brief drop or a single high reading. Not conclusive; still watching.";
+"Not performing as expected" = "Not performing as expected";
+"Isn't performing as expected" = "Isn't performing as expected";
+
 /* Power Monitor system power source indicator. */
 "Battery" = "Batterij";
 "Source" = "Bron";

--- a/Sources/WhatCableCore/Resources/pl.lproj/Localizable.strings
+++ b/Sources/WhatCableCore/Resources/pl.lproj/Localizable.strings
@@ -431,6 +431,13 @@
 /* Display dimension: confirmed full quality via CoreGraphics live mode (issue #246 Option B). */
 "Your %@ is running its top mode (%@), and the link is carrying it. Many high-resolution displays use compression (DSC) to fit a mode like this through the link, so the link rate alone can't show it; your display is at full quality." = "Twój %@ działa w swoim najlepszym trybie (%@) i łącze go obsługuje. Wiele wyświetlaczy o wysokiej rozdzielczości używa kompresji (DSC), aby przepuścić taki tryb przez łącze; sama prędkość łącza tego nie pokaże. Twój wyświetlacz pracuje w pełnej jakości.";
 
+/* Session monitor verdicts. */
+"Performing as expected" = "Performing as expected";
+"No problems seen while watching this cable." = "No problems seen while watching this cable.";
+"Saw a brief drop or a single high reading. Not conclusive; still watching." = "Saw a brief drop or a single high reading. Not conclusive; still watching.";
+"Not performing as expected" = "Not performing as expected";
+"Isn't performing as expected" = "Isn't performing as expected";
+
 /* Power Monitor system power source indicator. */
 "Battery" = "Bateria";
 "Source" = "Źródło";

--- a/Sources/WhatCableCore/Resources/pl.lproj/Localizable.strings
+++ b/Sources/WhatCableCore/Resources/pl.lproj/Localizable.strings
@@ -432,6 +432,7 @@
 "Your %@ is running its top mode (%@), and the link is carrying it. Many high-resolution displays use compression (DSC) to fit a mode like this through the link, so the link rate alone can't show it; your display is at full quality." = "Twój %@ działa w swoim najlepszym trybie (%@) i łącze go obsługuje. Wiele wyświetlaczy o wysokiej rozdzielczości używa kompresji (DSC), aby przepuścić taki tryb przez łącze; sama prędkość łącza tego nie pokaże. Twój wyświetlacz pracuje w pełnej jakości.";
 
 /* Session monitor verdicts. */
+"Battery full, not drawing power" = "Battery full, not drawing power";
 "Performing as expected" = "Performing as expected";
 "No problems seen while watching this cable." = "No problems seen while watching this cable.";
 "Saw a brief drop or a single high reading. Not conclusive; still watching." = "Saw a brief drop or a single high reading. Not conclusive; still watching.";

--- a/Sources/WhatCableCore/Resources/pt-BR.lproj/Localizable.strings
+++ b/Sources/WhatCableCore/Resources/pt-BR.lproj/Localizable.strings
@@ -431,6 +431,13 @@
 /* Display dimension: confirmed full quality via CoreGraphics live mode (issue #246 Option B). */
 "Your %@ is running its top mode (%@), and the link is carrying it. Many high-resolution displays use compression (DSC) to fit a mode like this through the link, so the link rate alone can't show it; your display is at full quality." = "Seu %@ está funcionando em seu modo máximo (%@) e o link está transmitindo isso. Muitas telas de alta resolução usam compressão (DSC) para passar um modo como este pelo link; a velocidade do link sozinha não pode mostrar isso. Sua tela está em qualidade total.";
 
+/* Session monitor verdicts. */
+"Performing as expected" = "Performing as expected";
+"No problems seen while watching this cable." = "No problems seen while watching this cable.";
+"Saw a brief drop or a single high reading. Not conclusive; still watching." = "Saw a brief drop or a single high reading. Not conclusive; still watching.";
+"Not performing as expected" = "Not performing as expected";
+"Isn't performing as expected" = "Isn't performing as expected";
+
 /* Power Monitor system power source indicator. */
 "Battery" = "Bateria";
 "Source" = "Fonte";

--- a/Sources/WhatCableCore/Resources/pt-BR.lproj/Localizable.strings
+++ b/Sources/WhatCableCore/Resources/pt-BR.lproj/Localizable.strings
@@ -432,6 +432,7 @@
 "Your %@ is running its top mode (%@), and the link is carrying it. Many high-resolution displays use compression (DSC) to fit a mode like this through the link, so the link rate alone can't show it; your display is at full quality." = "Seu %@ está funcionando em seu modo máximo (%@) e o link está transmitindo isso. Muitas telas de alta resolução usam compressão (DSC) para passar um modo como este pelo link; a velocidade do link sozinha não pode mostrar isso. Sua tela está em qualidade total.";
 
 /* Session monitor verdicts. */
+"Battery full, not drawing power" = "Battery full, not drawing power";
 "Performing as expected" = "Performing as expected";
 "No problems seen while watching this cable." = "No problems seen while watching this cable.";
 "Saw a brief drop or a single high reading. Not conclusive; still watching." = "Saw a brief drop or a single high reading. Not conclusive; still watching.";

--- a/Sources/WhatCableCore/Resources/ru.lproj/Localizable.strings
+++ b/Sources/WhatCableCore/Resources/ru.lproj/Localizable.strings
@@ -432,6 +432,7 @@
 "Your %@ is running its top mode (%@), and the link is carrying it. Many high-resolution displays use compression (DSC) to fit a mode like this through the link, so the link rate alone can't show it; your display is at full quality." = "Ваш %@ работает в своём максимальном режиме (%@), и соединение передаёт его. Многие дисплеи высокого разрешения используют сжатие (DSC), чтобы передать подобный режим через соединение; скорость соединения сама по себе не может это показать. Ваш дисплей работает в полном качестве.";
 
 /* Session monitor verdicts. */
+"Battery full, not drawing power" = "Батарея полная, питание не потребляется";
 "Performing as expected" = "Работает как ожидается";
 "No problems seen while watching this cable." = "Проблем при наблюдении за этим кабелем не обнаружено.";
 "Saw a brief drop or a single high reading. Not conclusive; still watching." = "Был кратковременный спад или единичное высокое значение. Это не окончательный вывод; продолжаем наблюдение.";

--- a/Sources/WhatCableCore/Resources/ru.lproj/Localizable.strings
+++ b/Sources/WhatCableCore/Resources/ru.lproj/Localizable.strings
@@ -18,8 +18,8 @@
 "Cable is limiting charging speed" = "Кабель ограничивает скорость зарядки";
 "Cable identified as %@" = "Кабель идентифицирован как %@";
 "Cable made by %@" = "Кабель произведён: %@";
-"Cable rated for %@ at up to %lldV (~%lldW)" = "Кабель рассчитан на %1$@ при до %2$lld В (~%3$lld Вт)";
-"Cable rated to %lldV / %@, delivers up to %lldW (USB-PD caps at 48V)" = "Cable rated to %1$lldV / %2$@, delivers up to %3$lldW (USB-PD caps at 48V)";
+"Cable rated for %@ at up to %lldV (~%lldW)" = "Кабель рассчитан на %1$@ при напряжении до %2$lld В (~%3$lld Вт)";
+"Cable rated to %lldV / %@, delivers up to %lldW (USB-PD caps at 48V)" = "Кабель рассчитан на %1$lld В / %2$@ и передаёт до %3$lld Вт (предел USB-PD — 48 В)";
 "Cable speed: %@" = "Скорость кабеля: %@";
 "Cable trust signals:" = "Признаки доверия к кабелю:";
 "Carrying DisplayPort video" = "Передаётся видео DisplayPort";
@@ -211,7 +211,7 @@
 "Manufacturer" = "Производитель";
 "Marginal" = "На грани";
 "Requested max operating current" = "Запрошенный макс. рабочий ток";
-"Requested max operating power" = "Requested max operating power";
+"Requested max operating power" = "Запрошенная макс. рабочая мощность";
 "Max power" = "Макс. мощность";
 "Mitigations" = "Меры";
 "Mode" = "Режим";
@@ -231,8 +231,8 @@
 "None" = "Нет";
 "Open Pro diagnostics for this port" = "Открыть диагностику Pro для этого порта";
 "Requested operating current" = "Запрошенный рабочий ток";
-"Requested operating power" = "Requested operating power";
-"Requested output voltage" = "Requested output voltage";
+"Requested operating power" = "Запрошенная рабочая мощность";
+"Requested output voltage" = "Запрошенное выходное напряжение";
 "PD protocol engine status changed. Tracks contract state, hard/soft reset counts, and message sequence numbers." = "Изменилось состояние движка протокола PD: контракт, жёсткие/мягкие сбросы, номера сообщений.";
 "PD spec revision" = "Ревизия спецификации PD";
 "PD state" = "Состояние PD";
@@ -308,16 +308,16 @@
 "%@ Port %lld" = "%1$@, порт %2$lld";
 "APDO, %@ to %@ @ %@, %@ max" = "APDO, %1$@…%2$@ @ %3$@, макс. %4$@";
 "Battery, %@ minimum, %@" = "Батарея, минимум %1$@, %2$@";
-"Battery, %@ to %@, %@" = "Battery, %1$@ to %2$@, %3$@";
-"EPR AVS, %@ to %@, %@" = "EPR AVS, %1$@ to %2$@, %3$@";
+"Battery, %@ to %@, %@" = "Батарея, от %1$@ до %2$@, %3$@";
+"EPR AVS, %@ to %@, %@" = "EPR AVS, от %1$@ до %2$@, %3$@";
 "Fixed, %@ @ %@, %@" = "Фиксированный, %1$@ @ %2$@, %3$@";
 "Port" = "Порт";
 "Rate %lld" = "Скорость %lld";
 "Type %lld" = "Тип %lld";
 "Variable, %@ minimum @ %@, %@ minimum" = "Переменный, минимум %1$@ @ %2$@, минимум %3$@";
-"PPS, %@ to %@ @ %@, %@ max" = "PPS, %1$@ to %2$@ @ %3$@, %4$@ max";
-"SPR AVS, %@ at 15V / %@ at 20V" = "SPR AVS, %1$@ at 15V / %2$@ at 20V";
-"Variable, %@ to %@ @ %@" = "Variable, %1$@ to %2$@ @ %3$@";
+"PPS, %@ to %@ @ %@, %@ max" = "PPS, от %1$@ до %2$@ @ %3$@, макс. %4$@";
+"SPR AVS, %@ at 15V / %@ at 20V" = "SPR AVS, %1$@ при 15 В / %2$@ при 20 В";
+"Variable, %@ to %@ @ %@" = "Переменный, от %1$@ до %2$@ @ %3$@";
 
 /* Pro plugin strings missing from prior export */
 "Enter Licence Key…" = "Ввести ключ лицензии…";
@@ -467,10 +467,10 @@
 "Thunderbolt fabric:" = "Сеть Thunderbolt:";
 
 /* Active-layout contradiction note (DAR-30) - placeholder, see en.lproj */
-"E-marker reports passive, but carries active-cable structure (may be a mis-programmed e-marker)" = "E-marker reports passive, but carries active-cable structure (may be a mis-programmed e-marker)";
+"E-marker reports passive, but carries active-cable structure (may be a mis-programmed e-marker)" = "E-marker сообщает пассивный кабель, но содержит структуру данных активного кабеля (возможно, e-marker запрограммирован неверно)";
 
 "Plugged in, charging on hold" = "Подключено, зарядка приостановлена";
 "Charger and cable are fine. macOS has paused charging for now, usually a battery charge limit or Optimized Battery Charging. The Mac still draws power from the charger." = "Зарядное устройство и кабель в порядке. macOS временно приостановила зарядку, обычно из-за ограничения заряда или оптимизированной зарядки аккумулятора. Mac по-прежнему получает питание от зарядного устройства.";
-"Plugged in · %lldW charger" = "Подключено · зарядное устройство %lldW";
+"Plugged in · %lldW charger" = "Подключено · зарядное устройство %lld Вт";
 "Plugged in" = "Подключено";
 "Charging on hold (charge limit or Optimized Battery Charging)" = "Зарядка приостановлена (ограничение заряда или оптимизированная зарядка)";

--- a/Sources/WhatCableCore/Resources/ru.lproj/Localizable.strings
+++ b/Sources/WhatCableCore/Resources/ru.lproj/Localizable.strings
@@ -431,6 +431,13 @@
 /* Display dimension: confirmed full quality via CoreGraphics live mode (issue #246 Option B). */
 "Your %@ is running its top mode (%@), and the link is carrying it. Many high-resolution displays use compression (DSC) to fit a mode like this through the link, so the link rate alone can't show it; your display is at full quality." = "Ваш %@ работает в своём максимальном режиме (%@), и соединение передаёт его. Многие дисплеи высокого разрешения используют сжатие (DSC), чтобы передать подобный режим через соединение; скорость соединения сама по себе не может это показать. Ваш дисплей работает в полном качестве.";
 
+/* Session monitor verdicts. */
+"Performing as expected" = "Работает как ожидается";
+"No problems seen while watching this cable." = "Проблем при наблюдении за этим кабелем не обнаружено.";
+"Saw a brief drop or a single high reading. Not conclusive; still watching." = "Был кратковременный спад или единичное высокое значение. Это не окончательный вывод; продолжаем наблюдение.";
+"Not performing as expected" = "Работает не так, как ожидалось";
+"Isn't performing as expected" = "Работает не так, как ожидалось";
+
 /* Power Monitor system power source indicator. */
 "Battery" = "Аккумулятор";
 "Source" = "Источник";

--- a/Sources/WhatCableCore/Resources/tr.lproj/Localizable.strings
+++ b/Sources/WhatCableCore/Resources/tr.lproj/Localizable.strings
@@ -432,6 +432,7 @@
 "Your %@ is running its top mode (%@), and the link is carrying it. Many high-resolution displays use compression (DSC) to fit a mode like this through the link, so the link rate alone can't show it; your display is at full quality." = "%1$@'nız en yüksek modunda (%2$@) çalışıyor ve bağlantı bunu taşıyor. Yüksek çözünürlüklü pek çok ekran, böyle bir modu bağlantı üzerinden iletmek için sıkıştırma (DSC) kullanır; bağlantı hızı tek başına bunu gösteremez. Ekranınız tam kalitede çalışıyor.";
 
 /* Session monitor verdicts. */
+"Battery full, not drawing power" = "Battery full, not drawing power";
 "Performing as expected" = "Performing as expected";
 "No problems seen while watching this cable." = "No problems seen while watching this cable.";
 "Saw a brief drop or a single high reading. Not conclusive; still watching." = "Saw a brief drop or a single high reading. Not conclusive; still watching.";

--- a/Sources/WhatCableCore/Resources/tr.lproj/Localizable.strings
+++ b/Sources/WhatCableCore/Resources/tr.lproj/Localizable.strings
@@ -431,6 +431,13 @@
 /* Display dimension: confirmed full quality via CoreGraphics live mode (issue #246 Option B). */
 "Your %@ is running its top mode (%@), and the link is carrying it. Many high-resolution displays use compression (DSC) to fit a mode like this through the link, so the link rate alone can't show it; your display is at full quality." = "%1$@'nız en yüksek modunda (%2$@) çalışıyor ve bağlantı bunu taşıyor. Yüksek çözünürlüklü pek çok ekran, böyle bir modu bağlantı üzerinden iletmek için sıkıştırma (DSC) kullanır; bağlantı hızı tek başına bunu gösteremez. Ekranınız tam kalitede çalışıyor.";
 
+/* Session monitor verdicts. */
+"Performing as expected" = "Performing as expected";
+"No problems seen while watching this cable." = "No problems seen while watching this cable.";
+"Saw a brief drop or a single high reading. Not conclusive; still watching." = "Saw a brief drop or a single high reading. Not conclusive; still watching.";
+"Not performing as expected" = "Not performing as expected";
+"Isn't performing as expected" = "Isn't performing as expected";
+
 /* Power Monitor system power source indicator. */
 "Battery" = "Pil";
 "Source" = "Kaynak";

--- a/Sources/WhatCableCore/Resources/uk.lproj/Localizable.strings
+++ b/Sources/WhatCableCore/Resources/uk.lproj/Localizable.strings
@@ -431,6 +431,13 @@
 /* Display dimension: confirmed full quality via CoreGraphics live mode (issue #246 Option B). */
 "Your %@ is running its top mode (%@), and the link is carrying it. Many high-resolution displays use compression (DSC) to fit a mode like this through the link, so the link rate alone can't show it; your display is at full quality." = "Ваш %@ працює в найкращому режимі (%@) і канал передає його. Багато дисплеїв з високою роздільною здатністю використовують стиснення (DSC) для передачі такого режиму через канал; швидкість каналу сама по собі не може це показати. Ваш дисплей працює в повній якості.";
 
+/* Session monitor verdicts. */
+"Performing as expected" = "Performing as expected";
+"No problems seen while watching this cable." = "No problems seen while watching this cable.";
+"Saw a brief drop or a single high reading. Not conclusive; still watching." = "Saw a brief drop or a single high reading. Not conclusive; still watching.";
+"Not performing as expected" = "Not performing as expected";
+"Isn't performing as expected" = "Isn't performing as expected";
+
 /* Power Monitor system power source indicator. */
 "Battery" = "Акумулятор";
 "Source" = "Джерело";

--- a/Sources/WhatCableCore/Resources/uk.lproj/Localizable.strings
+++ b/Sources/WhatCableCore/Resources/uk.lproj/Localizable.strings
@@ -432,6 +432,7 @@
 "Your %@ is running its top mode (%@), and the link is carrying it. Many high-resolution displays use compression (DSC) to fit a mode like this through the link, so the link rate alone can't show it; your display is at full quality." = "Ваш %@ працює в найкращому режимі (%@) і канал передає його. Багато дисплеїв з високою роздільною здатністю використовують стиснення (DSC) для передачі такого режиму через канал; швидкість каналу сама по собі не може це показати. Ваш дисплей працює в повній якості.";
 
 /* Session monitor verdicts. */
+"Battery full, not drawing power" = "Battery full, not drawing power";
 "Performing as expected" = "Performing as expected";
 "No problems seen while watching this cable." = "No problems seen while watching this cable.";
 "Saw a brief drop or a single high reading. Not conclusive; still watching." = "Saw a brief drop or a single high reading. Not conclusive; still watching.";

--- a/Sources/WhatCableCore/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/WhatCableCore/Resources/zh-Hans.lproj/Localizable.strings
@@ -432,6 +432,13 @@
 /* Display dimension: confirmed full quality via CoreGraphics live mode (issue #246 Option B). */
 "Your %@ is running its top mode (%@), and the link is carrying it. Many high-resolution displays use compression (DSC) to fit a mode like this through the link, so the link rate alone can't show it; your display is at full quality." = "您的 %@ 正在以最高模式（%@）运行，链路正在传输它。许多高分辨率显示器使用压缩（DSC）让这样的模式通过链路传输；仅凭链路速率无法显示这一点。您的显示器正以全质量运行。";
 
+/* Session monitor verdicts. */
+"Performing as expected" = "Performing as expected";
+"No problems seen while watching this cable." = "No problems seen while watching this cable.";
+"Saw a brief drop or a single high reading. Not conclusive; still watching." = "Saw a brief drop or a single high reading. Not conclusive; still watching.";
+"Not performing as expected" = "Not performing as expected";
+"Isn't performing as expected" = "Isn't performing as expected";
+
 /* Power Monitor system power source indicator. */
 "Battery" = "电池";
 "Source" = "电源";

--- a/Sources/WhatCableCore/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/WhatCableCore/Resources/zh-Hans.lproj/Localizable.strings
@@ -433,6 +433,7 @@
 "Your %@ is running its top mode (%@), and the link is carrying it. Many high-resolution displays use compression (DSC) to fit a mode like this through the link, so the link rate alone can't show it; your display is at full quality." = "您的 %@ 正在以最高模式（%@）运行，链路正在传输它。许多高分辨率显示器使用压缩（DSC）让这样的模式通过链路传输；仅凭链路速率无法显示这一点。您的显示器正以全质量运行。";
 
 /* Session monitor verdicts. */
+"Battery full, not drawing power" = "Battery full, not drawing power";
 "Performing as expected" = "Performing as expected";
 "No problems seen while watching this cable." = "No problems seen while watching this cable.";
 "Saw a brief drop or a single high reading. Not conclusive; still watching." = "Saw a brief drop or a single high reading. Not conclusive; still watching.";

--- a/Sources/WhatCableCore/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/WhatCableCore/Resources/zh-Hant.lproj/Localizable.strings
@@ -431,6 +431,13 @@
 /* Display dimension: confirmed full quality via CoreGraphics live mode (issue #246 Option B). */
 "Your %@ is running its top mode (%@), and the link is carrying it. Many high-resolution displays use compression (DSC) to fit a mode like this through the link, so the link rate alone can't show it; your display is at full quality." = "您的 %@ 正以最高模式（%@）運作，且連線已承載此模式。許多高解析度顯示器會使用影像串流壓縮（DSC），讓這類模式能透過連線傳輸，因此僅憑連線速率無法判斷這一點；您的顯示器正以最佳畫質運作。";
 
+/* Session monitor verdicts. */
+"Performing as expected" = "Performing as expected";
+"No problems seen while watching this cable." = "No problems seen while watching this cable.";
+"Saw a brief drop or a single high reading. Not conclusive; still watching." = "Saw a brief drop or a single high reading. Not conclusive; still watching.";
+"Not performing as expected" = "Not performing as expected";
+"Isn't performing as expected" = "Isn't performing as expected";
+
 /* Power Monitor system power source indicator. */
 "Battery" = "電池";
 "Source" = "電源";

--- a/Sources/WhatCableCore/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/WhatCableCore/Resources/zh-Hant.lproj/Localizable.strings
@@ -432,6 +432,7 @@
 "Your %@ is running its top mode (%@), and the link is carrying it. Many high-resolution displays use compression (DSC) to fit a mode like this through the link, so the link rate alone can't show it; your display is at full quality." = "您的 %@ 正以最高模式（%@）運作，且連線已承載此模式。許多高解析度顯示器會使用影像串流壓縮（DSC），讓這類模式能透過連線傳輸，因此僅憑連線速率無法判斷這一點；您的顯示器正以最佳畫質運作。";
 
 /* Session monitor verdicts. */
+"Battery full, not drawing power" = "Battery full, not drawing power";
 "Performing as expected" = "Performing as expected";
 "No problems seen while watching this cable." = "No problems seen while watching this cable.";
 "Saw a brief drop or a single high reading. Not conclusive; still watching." = "Saw a brief drop or a single high reading. Not conclusive; still watching.";


### PR DESCRIPTION
## What changed

- Refined remaining Russian localisation placeholders in `Sources/WhatCableCore/Resources/ru.lproj/Localizable.strings`.
- Added missing session monitor verdict keys so the Power Monitor status card can localise messages such as `Performing as expected`.
- Added the missing `Battery full, not drawing power` status string used in Pro diagnostics.
- Kept protocol and diagnostic labels such as `USB-PD`, `E-marker`, `PPS`, `EPR AVS`, and `SPR AVS` in English per `TRANSLATIONS.md`.
- Added English placeholders for the newly discovered keys in the other Core locales to keep localisation parity intact.

## Validation

- `plutil -lint Sources/WhatCableCore/Resources/*.lproj/Localizable.strings`
- `plutil -lint Sources/WhatCable/Resources/ru.lproj/Localizable.strings`
- Independent key/specifier parity check: Core `442/442`, App `136/136`, missing `0`, extra `0`
- `git diff --check`

`swift test --filter Localisation` was attempted locally but this machine's Swift toolchain cannot compile the test target because `Testing` is unavailable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Russian translations for power specifications, cable ratings, capability wording, and charging status messages (including correct wattage formatting).
* **Localization**
  * Added “Session monitor verdicts” strings across multiple languages so session outcome text displays consistently; several locales currently fall back to English values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->