### PR TITLE
Traditional Chinese language update

### DIFF
--- a/Sources/WhatCableCore/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/WhatCableCore/Resources/zh-Hant.lproj/Localizable.strings
@@ -484,9 +484,9 @@
 "Charging on hold (charge limit or Optimized Battery Charging)" = "充電暫停（充電上限或啟用了「最佳化電池充電」）";
 "Connected over Thunderbolt" = "透過 Thunderbolt 連接";
 "Other USB devices" = "其他 USB 裝置";
-"Reached through a Thunderbolt dock or display, so there's no cable, power, or Thunderbolt data for them." = "透過 Thunderbolt Dock 或顯示器連接，因此沒有它們的線材、電源或 Thunderbolt 資料。";
-"Built-in USB ports" = "內建 USB 埠";
-"Plain USB ports behind the Mac's internal hub, so there's no cable, power, or Thunderbolt data for them." = "連接到 Mac 內部集線器的普通 USB 埠，因此沒有它們的線材、電源或 Thunderbolt 資料。";
+"Reached through a Thunderbolt dock or display, so there's no cable, power, or Thunderbolt data for them." = "這些連接埠是透過 Thunderbolt Dock 或顯示器連接，因此沒有可顯示的線材、電源或 Thunderbolt 資料。";
+"Built-in USB ports" = "內建 USB 連接埠";
+"Plain USB ports behind the Mac's internal hub, so there's no cable, power, or Thunderbolt data for them." = "這些是透過 Mac 內部集線器連接的一般 USB 連接埠，因此沒有可顯示的線材、電源或 Thunderbolt 資料。";
 
 /* Cable history (DAR-52) */
 "Add this cable" = "新增此線材";

--- a/Sources/WhatCableCore/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/WhatCableCore/Resources/zh-Hant.lproj/Localizable.strings
@@ -486,7 +486,7 @@
 "Other USB devices" = "其他 USB 裝置";
 "Reached through a Thunderbolt dock or display, so there's no cable, power, or Thunderbolt data for them." = "這些連接埠是透過 Thunderbolt Dock 或顯示器連接，因此沒有可顯示的線材、電源或 Thunderbolt 資料。";
 "Built-in USB ports" = "內建 USB 連接埠";
-"Plain USB ports behind the Mac's internal hub, so there's no cable, power, or Thunderbolt data for them." = "這些是透過 Mac 內部集線器連接的一般 USB 連接埠，因此沒有可顯示的線材、電源或 Thunderbolt 資料。";
+"Plain USB ports behind the Mac's internal hub, so there's no cable, power, or Thunderbolt data for them." = "這些是透過 Mac 內部 Hub 連接的一般 USB 連接埠，因此沒有可顯示的線材、電源或 Thunderbolt 資料。";
 
 /* Cable history (DAR-52) */
 "Add this cable" = "新增此線材";


### PR DESCRIPTION
Improve translation consistency and refine updated strings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Traditional Chinese localization text for port descriptions related to Thunderbolt Dock/display-connected ports and Mac internal hub-connected USB ports.
  * Revised wording to use “沒有可顯示的…” instead of “沒有它們的…”, and improved terminology consistency by using “USB 連接埠”.
  * Adjusted phrasing for the internal hub connection description for clearer meaning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->