### PR TITLE
feat(ui): display device connection uptime

### DIFF
--- a/Sources/WhatCable/Views/ContentView.swift
+++ b/Sources/WhatCable/Views/ContentView.swift
@@ -400,6 +400,13 @@ struct ContentView: View {
     private func matchingDevices(for port: AppleHPMInterface) -> [USBDevice] {
         port.matchingDevices(from: deviceWatcher.devices)
     }
+
+    private func uptimeLabel(for device: USBDevice) -> String {
+        guard let firstSeen = device.firstSeenAt else { return "" }
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .abbreviated
+        return " (" + formatter.localizedString(for: firstSeen, relativeTo: Date()) + ")"
+    }
 }
 
 struct UpdateBanner: View {
@@ -531,9 +538,18 @@ struct OtherUSBDevicesCard: View {
             ForEach(tree) { node in
                 let name = node.device.productName ?? String(localized: "Unknown", bundle: _appLocalizedBundle)
                 let prefix = node.depth > 0 ? "\u{21B3} " : "\u{2022} "
-                Text(verbatim: "\(prefix)\(name) - \(node.device.speedLabel)")
+                
+                let uptime: String = {
+                    guard let firstSeen = node.device.firstSeenAt else { return "" }
+                    let formatter = RelativeDateTimeFormatter()
+                    formatter.unitsStyle = .abbreviated
+                    return " (" + formatter.localizedString(for: firstSeen, relativeTo: Date()) + ")"
+                }()
+                
+                Text(verbatim: "\(prefix)\(name) - \(node.device.speedLabel)\(uptime)")
                     .scaledFont(.callout)
                     .padding(.leading, CGFloat(node.depth) * 16)
+                    .fontWeight(node.device.firstSeenAt.map { Date().timeIntervalSince($0) < 60 } == true ? .bold : .regular)
             }
             Text(footer)
                 .scaledFont(.caption)
@@ -631,9 +647,18 @@ struct PortCard: View {
             ForEach(tree) { node in
                 let name = node.device.productName ?? String(localized: "Unknown", bundle: _appLocalizedBundle)
                 let prefix = node.depth > 0 ? "\u{21B3} " : "\u{2022} "
-                Text(verbatim: "\(prefix)\(name) - \(node.device.speedLabel)")
+                
+                let uptime: String = {
+                    guard let firstSeen = node.device.firstSeenAt else { return "" }
+                    let formatter = RelativeDateTimeFormatter()
+                    formatter.unitsStyle = .abbreviated
+                    return " (" + formatter.localizedString(for: firstSeen, relativeTo: Date()) + ")"
+                }()
+                
+                Text(verbatim: "\(prefix)\(name) - \(node.device.speedLabel)\(uptime)")
                     .scaledFont(.callout)
                     .padding(.leading, CGFloat(node.depth) * 16)
+                    .fontWeight(node.device.firstSeenAt.map { Date().timeIntervalSince($0) < 60 } == true ? .bold : .regular)
             }
             if let note {
                 Text(note)

--- a/Sources/WhatCable/Views/ContentView.swift
+++ b/Sources/WhatCable/Views/ContentView.swift
@@ -401,12 +401,6 @@ struct ContentView: View {
         port.matchingDevices(from: deviceWatcher.devices)
     }
 
-    private func uptimeLabel(for device: USBDevice) -> String {
-        guard let firstSeen = device.firstSeenAt else { return "" }
-        let formatter = RelativeDateTimeFormatter()
-        formatter.unitsStyle = .abbreviated
-        return " (" + formatter.localizedString(for: firstSeen, relativeTo: Date()) + ")"
-    }
 }
 
 struct UpdateBanner: View {
@@ -536,20 +530,7 @@ struct OtherUSBDevicesCard: View {
                     .scaledFont(.headline, weight: .semibold)
             }
             ForEach(tree) { node in
-                let name = node.device.productName ?? String(localized: "Unknown", bundle: _appLocalizedBundle)
-                let prefix = node.depth > 0 ? "\u{21B3} " : "\u{2022} "
-                
-                let uptime: String = {
-                    guard let firstSeen = node.device.firstSeenAt else { return "" }
-                    let formatter = RelativeDateTimeFormatter()
-                    formatter.unitsStyle = .abbreviated
-                    return " (" + formatter.localizedString(for: firstSeen, relativeTo: Date()) + ")"
-                }()
-                
-                Text(verbatim: "\(prefix)\(name) - \(node.device.speedLabel)\(uptime)")
-                    .scaledFont(.callout)
-                    .padding(.leading, CGFloat(node.depth) * 16)
-                    .fontWeight(node.device.firstSeenAt.map { Date().timeIntervalSince($0) < 60 } == true ? .bold : .regular)
+                USBDeviceRowView(node: node)
             }
             Text(footer)
                 .scaledFont(.caption)
@@ -645,20 +626,7 @@ struct PortCard: View {
                 .scaledFont(.subheadline, weight: .semibold)
                 .foregroundStyle(.secondary)
             ForEach(tree) { node in
-                let name = node.device.productName ?? String(localized: "Unknown", bundle: _appLocalizedBundle)
-                let prefix = node.depth > 0 ? "\u{21B3} " : "\u{2022} "
-                
-                let uptime: String = {
-                    guard let firstSeen = node.device.firstSeenAt else { return "" }
-                    let formatter = RelativeDateTimeFormatter()
-                    formatter.unitsStyle = .abbreviated
-                    return " (" + formatter.localizedString(for: firstSeen, relativeTo: Date()) + ")"
-                }()
-                
-                Text(verbatim: "\(prefix)\(name) - \(node.device.speedLabel)\(uptime)")
-                    .scaledFont(.callout)
-                    .padding(.leading, CGFloat(node.depth) * 16)
-                    .fontWeight(node.device.firstSeenAt.map { Date().timeIntervalSince($0) < 60 } == true ? .bold : .regular)
+                USBDeviceRowView(node: node)
             }
             if let note {
                 Text(note)
@@ -1315,5 +1283,33 @@ private struct TrustFlagsCard: View {
             Spacer(minLength: 0)
         }
         .calloutChrome(role: role)
+    }
+}
+
+struct USBDeviceRowView: View {
+    let node: USBDeviceNode
+    
+    var body: some View {
+        TimelineView(.periodic(from: .now, by: 1)) { context in
+            let name = node.device.productName ?? String(localized: "Unknown", bundle: _appLocalizedBundle)
+            let prefix = node.depth > 0 ? "\u{21B3} " : "\u{2022} "
+            
+            Text(verbatim: "\(prefix)\(name) - \(node.device.speedLabel)\(uptimeLabel(for: node.device, now: context.date))")
+                .scaledFont(.callout)
+                .padding(.leading, CGFloat(node.depth) * 16)
+                .fontWeight(isNewlyPlugged(node.device, now: context.date) ? .bold : .regular)
+        }
+    }
+    
+    private func uptimeLabel(for device: USBDevice, now: Date) -> String {
+        guard let firstSeen = device.firstSeenAt else { return "" }
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .abbreviated
+        return " (" + formatter.localizedString(for: firstSeen, relativeTo: now) + ")"
+    }
+    
+    private func isNewlyPlugged(_ device: USBDevice, now: Date) -> Bool {
+        guard let firstSeen = device.firstSeenAt else { return false }
+        return now.timeIntervalSince(firstSeen) < 60
     }
 }

--- a/Sources/WhatCableCore/USB/USBDevice.swift
+++ b/Sources/WhatCableCore/USB/USBDevice.swift
@@ -56,6 +56,7 @@ public struct USBDevice: Identifiable, Hashable {
     /// `nil` when the device has no Billboard capability or the BOS read failed.
     public let billboard: BillboardCapability?
     public let rawProperties: [String: String]
+    public let firstSeenAt: Date?
 
     public init(
         id: UInt64,
@@ -76,7 +77,8 @@ public struct USBDevice: Identifiable, Hashable {
         deviceClass: UInt8? = nil,
         ioClassName: String? = nil,
         billboard: BillboardCapability? = nil,
-        rawProperties: [String: String]
+        rawProperties: [String: String],
+        firstSeenAt: Date? = nil
     ) {
         self.id = id
         self.locationID = locationID
@@ -97,6 +99,7 @@ public struct USBDevice: Identifiable, Hashable {
         self.ioClassName = ioClassName
         self.billboard = billboard
         self.rawProperties = rawProperties
+        self.firstSeenAt = firstSeenAt
     }
 
     /// A USB Billboard device. The USB-C spec uses one to report the Alternate

--- a/Sources/WhatCableDarwinBackend/Watchers/USBWatcher.swift
+++ b/Sources/WhatCableDarwinBackend/Watchers/USBWatcher.swift
@@ -173,7 +173,8 @@ public final class USBWatcher: ObservableObject {
             deviceClass: deviceClass,
             ioClassName: ioClassName,
             billboard: billboard,
-            rawProperties: raw
+            rawProperties: raw,
+            firstSeenAt: Date()
         )
     }
 

--- a/Sources/WhatCableDarwinBackend/Watchers/USBWatcher.swift
+++ b/Sources/WhatCableDarwinBackend/Watchers/USBWatcher.swift
@@ -49,7 +49,7 @@ public final class USBWatcher: ObservableObject {
             selfPtr,
             &addedIter
         ) == KERN_SUCCESS {
-            handleAdded(iterator: addedIter)
+            handleAdded(iterator: addedIter, isInitialScan: true)
         }
 
         if IOServiceAddMatchingNotification(
@@ -74,9 +74,9 @@ public final class USBWatcher: ObservableObject {
         devices.removeAll()
     }
 
-    private func handleAdded(iterator: io_iterator_t) {
+    private func handleAdded(iterator: io_iterator_t, isInitialScan: Bool = false) {
         while case let service = IOIteratorNext(iterator), service != 0 {
-            if let device = makeDevice(from: service) {
+            if let device = makeDevice(from: service, firstSeenAt: isInitialScan ? nil : Date()) {
                 if !devices.contains(where: { $0.id == device.id }) {
                     devices.append(device)
                 }
@@ -96,7 +96,7 @@ public final class USBWatcher: ObservableObject {
         }
     }
 
-    private func makeDevice(from service: io_service_t) -> USBDevice? {
+    private func makeDevice(from service: io_service_t, firstSeenAt: Date?) -> USBDevice? {
         var entryID: UInt64 = 0
         guard IORegistryEntryGetRegistryEntryID(service, &entryID) == KERN_SUCCESS else { return nil }
 
@@ -174,7 +174,7 @@ public final class USBWatcher: ObservableObject {
             ioClassName: ioClassName,
             billboard: billboard,
             rawProperties: raw,
-            firstSeenAt: Date()
+            firstSeenAt: firstSeenAt
         )
     }
 


### PR DESCRIPTION
🎯 **What:** Adds connection uptime for newly plugged USB devices, addressing #364.
💡 **Why:** To make it easier for users to identify which devices they just plugged in, especially when the UI is crowded.
✅ **Verification:** Bypassed testing because `swift test` fails out of the box on main in my macOS environment (`error: no such module 'Testing'`).
✨ **Result:** Users will now see an abbreviated uptime label next to the device speed label. Devices connected less than a minute ago will have their label bolded for extra visibility.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * USB devices now show a relative “first seen” timestamp next to each device entry (when available).
  * Devices detected within the last 60 seconds are visually emphasized with bolder text.
* **Bug Fixes**
  * “First seen” timing is now captured at device creation and remains consistent across USB device views when navigating or switching contexts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->