### PR TITLE
feat(ui): display USB device power allocation

### DIFF
--- a/Sources/WhatCable/Views/ContentView.swift
+++ b/Sources/WhatCable/Views/ContentView.swift
@@ -400,6 +400,12 @@ struct ContentView: View {
     private func matchingDevices(for port: AppleHPMInterface) -> [USBDevice] {
         port.matchingDevices(from: deviceWatcher.devices)
     }
+
+}
+
+private func powerLabel(for device: USBDevice) -> String {
+    guard let req = device.currentMA, let avail = device.busPowerMA else { return "" }
+    return " [\(req)mA / \(avail)mA]"
 }
 
 struct UpdateBanner: View {
@@ -531,7 +537,7 @@ struct OtherUSBDevicesCard: View {
             ForEach(tree) { node in
                 let name = node.device.productName ?? String(localized: "Unknown", bundle: _appLocalizedBundle)
                 let prefix = node.depth > 0 ? "\u{21B3} " : "\u{2022} "
-                Text(verbatim: "\(prefix)\(name) - \(node.device.speedLabel)")
+                Text(verbatim: "\(prefix)\(name) - \(node.device.speedLabel)\(powerLabel(for: node.device))")
                     .scaledFont(.callout)
                     .padding(.leading, CGFloat(node.depth) * 16)
             }
@@ -631,7 +637,7 @@ struct PortCard: View {
             ForEach(tree) { node in
                 let name = node.device.productName ?? String(localized: "Unknown", bundle: _appLocalizedBundle)
                 let prefix = node.depth > 0 ? "\u{21B3} " : "\u{2022} "
-                Text(verbatim: "\(prefix)\(name) - \(node.device.speedLabel)")
+                Text(verbatim: "\(prefix)\(name) - \(node.device.speedLabel)\(powerLabel(for: node.device))")
                     .scaledFont(.callout)
                     .padding(.leading, CGFloat(node.depth) * 16)
             }


### PR DESCRIPTION
🎯 **What:** Appends the USB device power allocation (Requested/Available) to the device label in both the main view and the Pro Cable Diagnostics view.
💡 **Why:** To make it easier for users to identify under-powered USB devices directly from WhatCable, dynamically reflecting the current allocation.
✅ **Verification:** Verified locally that the code compiles successfully (`swift build`).
✨ **Result:** Users will now see power allocation inline with device speed information.

Fixes #354

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * USB device details now show requested vs. available bus power when that information is available.
  * Device tree entries now include this power readout alongside the existing speed display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->