### PR TITLE
fix(testkit): bound probe output

### DIFF
--- a/Sources/WhatCable/Services/TestKitRunner.swift
+++ b/Sources/WhatCable/Services/TestKitRunner.swift
@@ -290,11 +290,14 @@ final class TestKitRunner: ObservableObject {
                 } catch {
                     didFailReading = true
                     Self.log.error("Failed to read probe output: \(error.localizedDescription)")
+                    if process.isRunning {
+                        process.terminate()
+                    }
                 }
                 process.waitUntilExit()
                 let output = didExceedOutputLimit || didFailReading
                     ? nil
-                    : String(data: data, encoding: .utf8)
+                    : String(decoding: data, as: UTF8.self)
                 continuation.resume(returning: ProbeRunResult(
                     output: output,
                     exitStatus: process.terminationStatus,

--- a/Sources/WhatCable/Services/TestKitRunner.swift
+++ b/Sources/WhatCable/Services/TestKitRunner.swift
@@ -9,6 +9,12 @@ final class TestKitRunner: ObservableObject {
 
     private nonisolated static let log = Logger(subsystem: "uk.whatcable.whatcable", category: "test-kit")
     private static let apiURL = "https://whatcable-test-kit.darrylmorley-uk.workers.dev"
+    // Bound both the retained child output and the encoded network copy. The
+    // higher request limit leaves room for JSON escaping while still imposing
+    // a hard ceiling if an otherwise-valid output expands during serialization.
+    nonisolated static let maxProbeOutputBytes = 4 * 1024 * 1024
+    nonisolated static let maxRequestBodyBytes = 8 * 1024 * 1024
+    private nonisolated static let probeReadChunkBytes = 64 * 1024
 
     enum State: Equatable {
         case idle
@@ -107,6 +113,14 @@ final class TestKitRunner: ObservableObject {
 
             let result = await runProbe(at: binaryURL)
 
+            guard !result.didExceedOutputLimit else {
+                Self.log.warning(
+                    "Probe \(probeName) exceeded the \(Self.maxProbeOutputBytes)-byte output limit; discarding output"
+                )
+                noOutputProbes.append(probeName)
+                continue
+            }
+
             // Accounting decision (audit finding: crashes/empty-output/missing
             // binaries were silently uncounted). A probe lands in the new
             // no-output bucket, and its output (if any) is discarded, unless
@@ -177,11 +191,12 @@ final class TestKitRunner: ObservableObject {
     /// distinguish "our watchdog" from "somebody else's kill" (raw signal 15
     /// is still worth knowing as a sanity check when reading logs, but it is
     /// not what this code branches on).
-    private struct ProbeRunResult {
+    struct ProbeRunResult {
         let output: String?
         let exitStatus: Int32
         let terminationReason: Process.TerminationReason
         let didTimeout: Bool
+        let didExceedOutputLimit: Bool
     }
 
     /// Cross-queue flag: the timer fires on its own queue (`.global()`) and
@@ -208,7 +223,7 @@ final class TestKitRunner: ObservableObject {
         }
     }
 
-    private func runProbe(at binaryURL: URL) async -> ProbeRunResult {
+    func runProbe(at binaryURL: URL, timeout: TimeInterval = 30) async -> ProbeRunResult {
         await withCheckedContinuation { continuation in
             DispatchQueue.global(qos: .utility).async {
                 let process = Process()
@@ -221,7 +236,13 @@ final class TestKitRunner: ObservableObject {
                     try process.run()
                 } catch {
                     Self.log.error("Failed to launch probe: \(error.localizedDescription)")
-                    continuation.resume(returning: ProbeRunResult(output: nil, exitStatus: -1, terminationReason: .exit, didTimeout: false))
+                    continuation.resume(returning: ProbeRunResult(
+                        output: nil,
+                        exitStatus: -1,
+                        terminationReason: .exit,
+                        didTimeout: false,
+                        didExceedOutputLimit: false
+                    ))
                     return
                 }
 
@@ -230,7 +251,7 @@ final class TestKitRunner: ObservableObject {
                 // Timer is created only after process.run() succeeds, so the
                 // catch path above cannot leak a live timer source.
                 let timer = DispatchSource.makeTimerSource(queue: .global())
-                timer.schedule(deadline: .now() + 30)
+                timer.schedule(deadline: .now() + timeout)
                 timer.setEventHandler {
                     if process.isRunning {
                         // Set before terminate() so a read after
@@ -244,16 +265,42 @@ final class TestKitRunner: ObservableObject {
                 defer { timer.cancel() }
 
                 // Drain the pipe while the probe runs; reading after waitUntilExit
-                // deadlocks once output exceeds the 64KB pipe buffer (the child
-                // blocks on write() and nothing is draining the other end).
-                let data = pipe.fileHandleForReading.readDataToEndOfFile()
+                // deadlocks once output exceeds the pipe buffer. Retain at most
+                // maxProbeOutputBytes, but keep draining after the limit so a
+                // child already exiting cannot block on a full pipe. Oversized
+                // output is rejected in full rather than submitted truncated.
+                var data = Data()
+                var didExceedOutputLimit = false
+                var didFailReading = false
+                do {
+                    while let chunk = try pipe.fileHandleForReading.read(upToCount: Self.probeReadChunkBytes),
+                          !chunk.isEmpty {
+                        guard !didExceedOutputLimit else { continue }
+
+                        let remainingCapacity = Self.maxProbeOutputBytes - data.count
+                        guard chunk.count <= remainingCapacity else {
+                            didExceedOutputLimit = true
+                            if process.isRunning {
+                                process.terminate()
+                            }
+                            continue
+                        }
+                        data.append(chunk)
+                    }
+                } catch {
+                    didFailReading = true
+                    Self.log.error("Failed to read probe output: \(error.localizedDescription)")
+                }
                 process.waitUntilExit()
-                let output = String(data: data, encoding: .utf8)
+                let output = didExceedOutputLimit || didFailReading
+                    ? nil
+                    : String(data: data, encoding: .utf8)
                 continuation.resume(returning: ProbeRunResult(
                     output: output,
                     exitStatus: process.terminationStatus,
                     terminationReason: process.terminationReason,
-                    didTimeout: timeoutMarker.didFire
+                    didTimeout: timeoutMarker.didFire,
+                    didExceedOutputLimit: didExceedOutputLimit
                 ))
             }
         }
@@ -313,7 +360,11 @@ final class TestKitRunner: ObservableObject {
         request.timeoutInterval = 10
 
         do {
-            request.httpBody = try JSONSerialization.data(withJSONObject: payload)
+            guard let body = try Self.boundedJSONBody(payload) else {
+                Self.log.warning("Refusing POST to \(urlString): JSON body exceeds \(Self.maxRequestBodyBytes) bytes")
+                return false
+            }
+            request.httpBody = body
             let (_, response) = try await URLSession.shared.data(for: request)
             let status = (response as? HTTPURLResponse)?.statusCode ?? 0
             return status == 200
@@ -321,6 +372,11 @@ final class TestKitRunner: ObservableObject {
             Self.log.error("POST to \(urlString) failed: \(error.localizedDescription)")
             return false
         }
+    }
+
+    static func boundedJSONBody(_ payload: [String: Any]) throws -> Data? {
+        let body = try JSONSerialization.data(withJSONObject: payload)
+        return body.count <= maxRequestBodyBytes ? body : nil
     }
 
     static func probesDirectory() -> URL? {

--- a/Tests/WhatCableDarwinTests/TestKitRunnerOutputLimitTests.swift
+++ b/Tests/WhatCableDarwinTests/TestKitRunnerOutputLimitTests.swift
@@ -62,6 +62,19 @@ struct TestKitRunnerOutputLimitTests {
         #expect(!result.didExceedOutputLimit)
     }
 
+    @Test("An incomplete UTF-8 sequence from the watchdog path is preserved")
+    @MainActor
+    func timeoutIncompleteUTF8IsPreserved() async throws {
+        let fixture = try makeScript(contents: "#!/bin/sh\n/usr/bin/printf '\\303'\n/bin/sleep 5\n")
+        defer { try? FileManager.default.removeItem(at: fixture.deletingLastPathComponent()) }
+
+        let result = await TestKitRunner.shared.runProbe(at: fixture, timeout: 2)
+
+        #expect(result.output == "\u{FFFD}")
+        #expect(result.didTimeout)
+        #expect(!result.didExceedOutputLimit)
+    }
+
     @Test("Oversized JSON request bodies are rejected")
     @MainActor
     func oversizedJSONBodyIsRejected() throws {

--- a/Tests/WhatCableDarwinTests/TestKitRunnerOutputLimitTests.swift
+++ b/Tests/WhatCableDarwinTests/TestKitRunnerOutputLimitTests.swift
@@ -1,0 +1,96 @@
+import Foundation
+import Testing
+@testable import WhatCable
+
+@Suite("Test Kit probe output limit")
+struct TestKitRunnerOutputLimitTests {
+    @Test("Output at the byte limit is preserved")
+    @MainActor
+    func outputAtLimitIsPreserved() async throws {
+        let fixture = try makeOutputFixture(byteCount: TestKitRunner.maxProbeOutputBytes)
+        defer { try? FileManager.default.removeItem(at: fixture.deletingLastPathComponent()) }
+
+        let result = await TestKitRunner.shared.runProbe(at: fixture)
+
+        #expect(result.output?.utf8.count == TestKitRunner.maxProbeOutputBytes)
+        #expect(!result.didExceedOutputLimit)
+    }
+
+    @Test("Output over the byte limit is rejected")
+    @MainActor
+    func outputOverLimitIsRejected() async throws {
+        let fixture = try makeOutputFixture(byteCount: TestKitRunner.maxProbeOutputBytes + 1)
+        defer { try? FileManager.default.removeItem(at: fixture.deletingLastPathComponent()) }
+
+        let result = await TestKitRunner.shared.runProbe(at: fixture)
+
+        let outputWasRejected = result.output == nil
+        #expect(outputWasRejected)
+        #expect(result.didExceedOutputLimit)
+    }
+
+    @Test("An unbounded child is terminated as soon as it exceeds the limit")
+    @MainActor
+    func unboundedChildIsTerminatedAtLimit() async {
+        let clock = ContinuousClock()
+        let started = clock.now
+
+        let result = await TestKitRunner.shared.runProbe(
+            at: URL(fileURLWithPath: "/usr/bin/yes"),
+            timeout: 5
+        )
+
+        let elapsed = started.duration(to: clock.now)
+        #expect(result.output == nil)
+        #expect(result.didExceedOutputLimit)
+        #expect(elapsed < .seconds(3))
+    }
+
+    @Test("Small partial output from the watchdog path is preserved")
+    @MainActor
+    func timeoutPartialOutputIsPreserved() async throws {
+        let fixture = try makeScript(contents: "#!/bin/sh\n/bin/echo partial\n/bin/sleep 1\n")
+        defer { try? FileManager.default.removeItem(at: fixture.deletingLastPathComponent()) }
+
+        let result = await TestKitRunner.shared.runProbe(at: fixture, timeout: 0.5)
+
+        #expect(result.output == "partial\n")
+        #expect(result.didTimeout)
+        #expect(!result.didExceedOutputLimit)
+    }
+
+    @Test("Oversized JSON request bodies are rejected")
+    @MainActor
+    func oversizedJSONBodyIsRejected() throws {
+        let payload = ["output": String(repeating: "x", count: TestKitRunner.maxRequestBodyBytes)]
+
+        let body = try TestKitRunner.boundedJSONBody(payload)
+
+        #expect(body == nil)
+    }
+
+    @Test("Small JSON request bodies are preserved")
+    @MainActor
+    func smallJSONBodyIsPreserved() throws {
+        let payload = ["output": "diagnostic"]
+
+        let body = try TestKitRunner.boundedJSONBody(payload)
+
+        #expect(body != nil)
+    }
+
+    private func makeOutputFixture(byteCount: Int) throws -> URL {
+        try makeScript(contents: "#!/bin/sh\n/usr/bin/yes x | /usr/bin/head -c \(byteCount)\n")
+    }
+
+    private func makeScript(contents: String) throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("whatcable-test-kit-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+
+        let script = directory.appendingPathComponent("emit-output")
+        try Data(contents.utf8).write(to: script)
+        try FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: script.path)
+        return script
+    }
+}

--- a/Tests/WhatCableDarwinTests/TestKitRunnerOutputLimitTests.swift
+++ b/Tests/WhatCableDarwinTests/TestKitRunnerOutputLimitTests.swift
@@ -2,7 +2,10 @@ import Foundation
 import Testing
 @testable import WhatCable
 
-@Suite("Test Kit probe output limit")
+// These tests launch real subprocesses and include an intentional watchdog
+// timeout. Serial execution keeps the timeout test from racing the two
+// concurrent 4 MiB output fixtures on slower CI hosts.
+@Suite("Test Kit probe output limit", .serialized)
 struct TestKitRunnerOutputLimitTests {
     @Test("Output at the byte limit is preserved")
     @MainActor
@@ -49,10 +52,10 @@ struct TestKitRunnerOutputLimitTests {
     @Test("Small partial output from the watchdog path is preserved")
     @MainActor
     func timeoutPartialOutputIsPreserved() async throws {
-        let fixture = try makeScript(contents: "#!/bin/sh\n/bin/echo partial\n/bin/sleep 1\n")
+        let fixture = try makeScript(contents: "#!/bin/sh\n/bin/echo partial\n/bin/sleep 5\n")
         defer { try? FileManager.default.removeItem(at: fixture.deletingLastPathComponent()) }
 
-        let result = await TestKitRunner.shared.runProbe(at: fixture, timeout: 0.5)
+        let result = await TestKitRunner.shared.runProbe(at: fixture, timeout: 2)
 
         #expect(result.output == "partial\n")
         #expect(result.didTimeout)


### PR DESCRIPTION
## Summary

- cap retained probe stdout/stderr at 4 MiB with incremental reads
- terminate and reject over-limit probes; never upload truncated output
- cap encoded JSON request bodies at 8 MiB
- add boundary, unbounded-child, timeout-compatibility, and JSON-size tests

## Root cause

`TestKitRunner` used `readDataToEndOfFile()`, retained all probe output, then copied it into a `String` and JSON request body. The 30-second watchdog bounded runtime but not memory usage.

## Security invariant

No probe can cause the parent to retain more than 4 MiB of output or send more than an 8 MiB encoded request body. Oversized output is rejected rather than truncated and uploaded.

## Validation

- focused Xcode-toolchain test suite: 7 passed; after review fixes, the suite passed 3 consecutive runs (21/21)
- release build for `WhatCable`: passed
- release build for `whatcable-cli`: passed
- repository-wide suite attempted: the candidate tests pass; unrelated corpus suites report 76 fixture issues because `research/customer-probes` and `research/dumps` are absent from this public mirror

## Review

- full-file security diff review completed for both changed files
- incremental reviews completed for the test-stabilization and automated-review response commits
- addressed read-error process cleanup and incomplete UTF-8 partial-output handling raised during automated review
- no reportable security regressions or remaining candidate-introduced bugs found
