### PR TITLE
fix(cli): sanitize hardware-controlled terminal output

### DIFF
--- a/Sources/WhatCableCore/Output/ANSI.swift
+++ b/Sources/WhatCableCore/Output/ANSI.swift
@@ -55,7 +55,13 @@ public enum ANSI {
     public static let gray = "\u{1B}[90m"
 
     public static func wrap(_ codes: String, _ text: String) -> String {
-        guard isEnabled else { return text }
+        wrap(codes, text, enabled: isEnabled)
+    }
+
+    /// Pure rendering seam for tests. Production callers use `wrap(_:_:)`,
+    /// which supplies the live TTY/NO_COLOR decision.
+    static func wrap(_ codes: String, _ text: String, enabled: Bool) -> String {
+        guard enabled else { return text }
         return codes + text + reset
     }
 }

--- a/Sources/WhatCableCore/Output/ANSI.swift
+++ b/Sources/WhatCableCore/Output/ANSI.swift
@@ -35,6 +35,7 @@ public enum ANSI {
         return isTTY
     }
 
+    /// Reports whether formatter-owned ANSI sequences may be emitted.
     public static var isEnabled: Bool {
         shouldEnable(
             isTTY: configuredIsTTY,
@@ -54,6 +55,7 @@ public enum ANSI {
     public static let cyan = "\u{1B}[36m"
     public static let gray = "\u{1B}[90m"
 
+    /// Wraps text in the supplied ANSI codes when colored output is enabled.
     public static func wrap(_ codes: String, _ text: String) -> String {
         wrap(codes, text, enabled: isEnabled)
     }

--- a/Sources/WhatCableCore/Output/TerminalFieldEncoder.swift
+++ b/Sources/WhatCableCore/Output/TerminalFieldEncoder.swift
@@ -6,6 +6,7 @@
 /// Formatter-owned ANSI sequences and newlines must be added after this
 /// encoder runs. Structured JSON deliberately does not use this representation.
 public enum TerminalFieldEncoder {
+    /// Replaces C0/C1 control scalars with visible Unicode escape sequences.
     public static func encode(_ value: String) -> String {
         var encoded = ""
         encoded.reserveCapacity(value.utf8.count)

--- a/Sources/WhatCableCore/Output/TerminalFieldEncoder.swift
+++ b/Sources/WhatCableCore/Output/TerminalFieldEncoder.swift
@@ -1,0 +1,25 @@
+/// Encodes untrusted, single-field text before it is embedded in terminal
+/// output. Hardware descriptors and IOKit properties can contain C0/C1
+/// controls, including ESC/OSC sequences and embedded line breaks. Rendering
+/// those bytes verbatim lets a device alter terminal state or forge rows.
+///
+/// Formatter-owned ANSI sequences and newlines must be added after this
+/// encoder runs. Structured JSON deliberately does not use this representation.
+public enum TerminalFieldEncoder {
+    public static func encode(_ value: String) -> String {
+        var encoded = ""
+        encoded.reserveCapacity(value.utf8.count)
+
+        for scalar in value.unicodeScalars {
+            switch scalar.value {
+            case 0x00...0x1F, 0x7F...0x9F:
+                let hex = String(scalar.value, radix: 16, uppercase: true)
+                encoded += "\\u{\(hex)}"
+            default:
+                encoded.unicodeScalars.append(scalar)
+            }
+        }
+
+        return encoded
+    }
+}

--- a/Sources/WhatCableCore/Output/TextFormatter.swift
+++ b/Sources/WhatCableCore/Output/TextFormatter.swift
@@ -1,6 +1,8 @@
 import Foundation
 
+/// Renders WhatCable diagnostics as human-readable, terminal-safe text.
 public enum TextFormatter {
+    /// Builds a complete report for the supplied ports and connected hardware.
     public static func render(
         ports: [AppleHPMInterface],
         sources: [PowerSource],
@@ -162,6 +164,7 @@ public enum TextFormatter {
         return out
     }
 
+    /// Renders one physical port and its diagnostics, devices, and trust signals.
     private static func renderPort(
         _ port: AppleHPMInterface,
         sources: [PowerSource],
@@ -366,14 +369,17 @@ public enum TextFormatter {
         return out
     }
 
+    /// Formats one raw key-value field after applying terminal-field encoding.
     private static func rawRow(_ key: String, _ value: String) -> String {
         "  " + ANSI.wrap(ANSI.gray, terminalField(key)) + " = \(terminalField(value))\n"
     }
 
+    /// Encodes one external field without changing formatter-owned separators.
     private static func terminalField(_ value: String) -> String {
         TerminalFieldEncoder.encode(value)
     }
 
+    /// Converts a Boolean diagnostic value to the CLI's stable text form.
     private static func yesNo(_ v: Bool) -> String { v ? "Yes" : "No" }
 
     /// 0 in the temperature fields means "not specified" per the spec.
@@ -381,6 +387,7 @@ public enum TextFormatter {
         v == 0 ? "—" : "\(v)°C"
     }
 
+    /// Selects the ANSI color associated with a port's diagnostic status.
     private static func color(for status: PortSummary.Status) -> String {
         switch status {
         case .empty: return ANSI.gray
@@ -393,10 +400,12 @@ public enum TextFormatter {
         }
     }
 
+    /// Returns power sources canonically associated with the given port.
     private static func filterSources(_ port: AppleHPMInterface, all: [PowerSource]) -> [PowerSource] {
         return all.filter { $0.canonicallyMatches(port: port) }
     }
 
+    /// Returns USB-PD identities canonically associated with the given port.
     private static func filterIdentities(_ port: AppleHPMInterface, all: [USBPDSOP]) -> [USBPDSOP] {
         all.filter { $0.canonicallyMatches(port: port) }
     }

--- a/Sources/WhatCableCore/Output/TextFormatter.swift
+++ b/Sources/WhatCableCore/Output/TextFormatter.swift
@@ -98,8 +98,9 @@ public enum TextFormatter {
     /// shape so terminal output stays scannable, then a Display block per
     /// attached monitor.
     private static func renderBuiltInDisplayPort(_ port: BuiltInDisplayPort) -> String {
-        let label = port.serviceName
-        let header = "=== \(label) (\(port.portType)) ==="
+        let label = terminalField(port.serviceName)
+        let portType = terminalField(port.portType)
+        let header = "=== \(label) (\(portType)) ==="
         var out = ANSI.wrap(ANSI.bold + ANSI.cyan, header) + "\n"
         // `BuiltInDisplayPort.group` filters inactive DP nodes, so the entity
         // here always carries at least one display; the empty case is
@@ -108,12 +109,12 @@ public enum TextFormatter {
             ? String(localized: "Display connected", bundle: _coreLocalizedBundle)
             : String(localized: "\(port.displays.count) displays connected", bundle: _coreLocalizedBundle)
         out += ANSI.wrap(ANSI.bold, headline) + "\n"
-        out += ANSI.wrap(ANSI.dim, String(localized: "Built-in \(port.portType) port \(port.portNumber)", bundle: _coreLocalizedBundle)) + "\n"
+        out += ANSI.wrap(ANSI.dim, terminalField(String(localized: "Built-in \(port.portType) port \(port.portNumber)", bundle: _coreLocalizedBundle))) + "\n"
         for displayPort in port.displays {
             guard let diag = DisplayDiagnostic(dp: displayPort, cable: nil) else { continue }
             let displayColor = diag.isWarning ? ANSI.yellow : ANSI.green
-            out += "\n" + ANSI.wrap(ANSI.bold, "Display: ") + ANSI.wrap(displayColor, diag.summary) + "\n"
-            out += "  " + ANSI.wrap(ANSI.dim, diag.detail) + "\n"
+            out += "\n" + ANSI.wrap(ANSI.bold, "Display: ") + ANSI.wrap(displayColor, terminalField(diag.summary)) + "\n"
+            out += "  " + ANSI.wrap(ANSI.dim, terminalField(diag.detail)) + "\n"
         }
         return out
     }
@@ -132,7 +133,7 @@ public enum TextFormatter {
         let tree = USBDeviceNode.flatten(USBDeviceNode.buildTree(from: devices))
         for node in tree {
             let indent = String(repeating: "  ", count: node.depth + 1)
-            let name = node.device.productName ?? String(localized: "Unknown", bundle: _coreLocalizedBundle)
+            let name = terminalField(node.device.productName ?? String(localized: "Unknown", bundle: _coreLocalizedBundle))
             let prefix = node.depth > 0 ? "\u{21B3}" : ANSI.wrap(ANSI.gray, "\u{2022}")
             out += "\(indent)\(prefix) \(name) - \(node.device.speedLabel)\n"
         }
@@ -153,7 +154,7 @@ public enum TextFormatter {
         let tree = USBDeviceNode.flatten(USBDeviceNode.buildTree(from: devices))
         for node in tree {
             let indent = String(repeating: "  ", count: node.depth + 1)
-            let name = node.device.productName ?? String(localized: "Unknown", bundle: _coreLocalizedBundle)
+            let name = terminalField(node.device.productName ?? String(localized: "Unknown", bundle: _coreLocalizedBundle))
             let prefix = node.depth > 0 ? "\u{21B3}" : ANSI.wrap(ANSI.gray, "\u{2022}")
             out += "\(indent)\(prefix) \(name) - \(node.device.speedLabel)\n"
         }
@@ -192,29 +193,29 @@ public enum TextFormatter {
             batteryIsCharging: batteryIsCharging,
             adapter: adapter
         )
-        let label = port.portDescription ?? port.serviceName
-        let typeSuffix = port.portTypeDescription.map { " (\($0))" } ?? ""
+        let label = terminalField(port.portDescription ?? port.serviceName)
+        let typeSuffix = port.portTypeDescription.map { " (\(terminalField($0)))" } ?? ""
 
         let header = "=== \(label)\(typeSuffix) ==="
         var out = ANSI.wrap(ANSI.bold + ANSI.cyan, header) + "\n"
 
         let headlineColor = color(for: summary.status)
-        out += ANSI.wrap(ANSI.bold + headlineColor, summary.headline) + "\n"
+        out += ANSI.wrap(ANSI.bold + headlineColor, terminalField(summary.headline)) + "\n"
         if !summary.subtitle.isEmpty {
-            out += ANSI.wrap(ANSI.dim, summary.subtitle) + "\n"
+            out += ANSI.wrap(ANSI.dim, terminalField(summary.subtitle)) + "\n"
         }
 
         if !summary.bullets.isEmpty {
             out += "\n"
             for bullet in summary.bullets {
-                out += "  " + ANSI.wrap(ANSI.gray, "•") + " \(bullet)\n"
+                out += "  " + ANSI.wrap(ANSI.gray, "•") + " \(terminalField(bullet))\n"
             }
         }
 
         if let diag = ChargingDiagnostic(port: port, sources: sources, identities: identities, adapter: adapter, wattageSource: chargerWattageSource, batteryFullyCharged: batteryFullyCharged, batteryIsCharging: batteryIsCharging, anotherPortActivelyCharging: anotherPortActivelyCharging) {
             let diagColor = diag.isWarning ? ANSI.yellow : ANSI.green
-            out += "\n" + ANSI.wrap(ANSI.bold, String(localized: "Charging: ", bundle: _coreLocalizedBundle)) + ANSI.wrap(diagColor, diag.summary) + "\n"
-            out += "  " + ANSI.wrap(ANSI.dim, diag.detail) + "\n"
+            out += "\n" + ANSI.wrap(ANSI.bold, String(localized: "Charging: ", bundle: _coreLocalizedBundle)) + ANSI.wrap(diagColor, terminalField(diag.summary)) + "\n"
+            out += "  " + ANSI.wrap(ANSI.dim, terminalField(diag.detail)) + "\n"
         }
 
         if let dataDiag = DataLinkDiagnostic(
@@ -226,8 +227,8 @@ public enum TextFormatter {
             thunderboltSwitches: thunderboltSwitches
         ) {
             let dataColor = dataDiag.isWarning ? ANSI.yellow : ANSI.green
-            out += "\n" + ANSI.wrap(ANSI.bold, "Data: ") + ANSI.wrap(dataColor, dataDiag.summary) + "\n"
-            out += "  " + ANSI.wrap(ANSI.dim, dataDiag.detail) + "\n"
+            out += "\n" + ANSI.wrap(ANSI.bold, "Data: ") + ANSI.wrap(dataColor, terminalField(dataDiag.summary)) + "\n"
+            out += "  " + ANSI.wrap(ANSI.dim, terminalField(dataDiag.detail)) + "\n"
         }
 
         // Display verdict, one block per connected monitor (a dock can drive
@@ -238,15 +239,15 @@ public enum TextFormatter {
         for displayPort in displayPorts {
             guard let displayDiag = DisplayDiagnostic(dp: displayPort, cable: displayCable) else { continue }
             let displayColor = displayDiag.isWarning ? ANSI.yellow : ANSI.green
-            out += "\n" + ANSI.wrap(ANSI.bold, "Display: ") + ANSI.wrap(displayColor, displayDiag.summary) + "\n"
-            out += "  " + ANSI.wrap(ANSI.dim, displayDiag.detail) + "\n"
+            out += "\n" + ANSI.wrap(ANSI.bold, "Display: ") + ANSI.wrap(displayColor, terminalField(displayDiag.summary)) + "\n"
+            out += "  " + ANSI.wrap(ANSI.dim, terminalField(displayDiag.detail)) + "\n"
         }
 
         // Name only, no diagnosis (a Billboard device is often benign). The
         // Alt-Mode inference is reserved for the Pro Display screen. Show the
         // device's own name when it adds information, else the generic phrase.
         if let billboard = port.billboardDevice(among: usbDevices) {
-            let label = billboard.billboardPresenceLabel(bundle: _coreLocalizedBundle)
+            let label = terminalField(billboard.billboardPresenceLabel(bundle: _coreLocalizedBundle))
             out += "  " + ANSI.wrap(ANSI.gray, "\u{2022}") + " " + label + "\n"
         }
 
@@ -264,10 +265,10 @@ public enum TextFormatter {
                 for node in fabric {
                     let indent = String(repeating: "  ", count: node.depth + 1)
                     let prefix = node.depth > 0 ? "\u{21B3}" : ANSI.wrap(ANSI.gray, "\u{2022}")
-                    let name = ThunderboltLabels.deviceName(for: node.sw)
+                    let name = terminalField(ThunderboltLabels.deviceName(for: node.sw))
                     let link = ThunderboltTopology.connectionLanePort(node.sw)
                         .flatMap { ThunderboltLabels.linkLabel(for: $0) }
-                    let suffix = link.map { " - \($0)" } ?? ""
+                    let suffix = link.map { " - \(terminalField($0))" } ?? ""
                     out += "\(indent)\(prefix) \(name)\(suffix)\n"
                 }
             }
@@ -281,7 +282,7 @@ public enum TextFormatter {
             if !tunnelLines.isEmpty {
                 out += "\n" + ANSI.wrap(ANSI.bold, String(localized: "Active tunnels:", bundle: _coreLocalizedBundle)) + "\n"
                 for line in tunnelLines {
-                    out += "  " + ANSI.wrap(ANSI.gray, "•") + " \(line)\n"
+                    out += "  " + ANSI.wrap(ANSI.gray, "•") + " \(terminalField(line))\n"
                 }
             }
         }
@@ -302,7 +303,7 @@ public enum TextFormatter {
             for row in connectedRows {
                 let indent = String(repeating: "  ", count: row.depth + 1)
                 let prefix = row.depth > 0 ? "\u{21B3}" : ANSI.wrap(ANSI.gray, "\u{2022}")
-                out += "\(indent)\(prefix) \(row.label)\n"
+                out += "\(indent)\(prefix) \(terminalField(row.label))\n"
             }
         }
 
@@ -328,8 +329,8 @@ public enum TextFormatter {
                     let marker = flag.severity == .warning
                         ? ANSI.wrap(ANSI.yellow, "⚠")
                         : ANSI.wrap(ANSI.gray, "•")
-                    out += "  " + marker + " " + ANSI.wrap(ANSI.bold, flag.title) + "\n"
-                    out += "    " + ANSI.wrap(ANSI.dim, flag.detail) + "\n"
+                    out += "  " + marker + " " + ANSI.wrap(ANSI.bold, terminalField(flag.title)) + "\n"
+                    out += "    " + ANSI.wrap(ANSI.dim, terminalField(flag.detail)) + "\n"
                 }
             }
         }
@@ -358,7 +359,7 @@ public enum TextFormatter {
             out += "\n" + ANSI.wrap(ANSI.bold, String(localized: "Raw IOKit properties:", bundle: _coreLocalizedBundle)) + "\n"
             for key in port.redactedRawProperties.keys.sorted() {
                 let value = port.redactedRawProperties[key] ?? ""
-                out += "  " + ANSI.wrap(ANSI.gray, key) + " = \(value)\n"
+                out += "  " + ANSI.wrap(ANSI.gray, terminalField(key)) + " = \(terminalField(value))\n"
             }
         }
 
@@ -366,7 +367,11 @@ public enum TextFormatter {
     }
 
     private static func rawRow(_ key: String, _ value: String) -> String {
-        "  " + ANSI.wrap(ANSI.gray, key) + " = \(value)\n"
+        "  " + ANSI.wrap(ANSI.gray, terminalField(key)) + " = \(terminalField(value))\n"
+    }
+
+    private static func terminalField(_ value: String) -> String {
+        TerminalFieldEncoder.encode(value)
     }
 
     private static func yesNo(_ v: Bool) -> String { v ? "Yes" : "No" }

--- a/Sources/WhatCableDarwinBackend/Debug/ThunderboltProbe.swift
+++ b/Sources/WhatCableDarwinBackend/Debug/ThunderboltProbe.swift
@@ -55,7 +55,7 @@ public enum ThunderboltProbe {
 
     private static func dumpSwitch(_ service: io_service_t, index: Int) -> String {
         var output = ""
-        let className = ioClassName(service) ?? "<unknown class>"
+        let className = TerminalFieldEncoder.encode(ioClassName(service) ?? "<unknown class>")
         output += "## Switch #\(index): \(className)\n"
 
         if let props = ioProperties(service) {
@@ -80,7 +80,7 @@ public enum ThunderboltProbe {
             // matches, not link-state carriers.
             guard childClass.contains("Port") else { continue }
             portIndex += 1
-            output += "\n  ### Port @\(portIndex): \(childClass)\n"
+            output += "\n  ### Port @\(portIndex): \(TerminalFieldEncoder.encode(childClass))\n"
             if let props = ioProperties(child) {
                 output += renderProperties(props, indent: "    ")
             }
@@ -107,7 +107,7 @@ public enum ThunderboltProbe {
         return dict as? [String: Any]
     }
 
-    private static func renderProperties(_ props: [String: Any], indent: String) -> String {
+    static func renderProperties(_ props: [String: Any], indent: String) -> String {
         // Sort keys for stable, paste-friendly output. Skip noisy fields that
         // don't help with the design (IOPowerManagement dict, large binary blobs
         // that aren't useful without decoding).
@@ -115,7 +115,7 @@ public enum ThunderboltProbe {
         var output = ""
         for key in props.keys.sorted() where !skip.contains(key) {
             let value = props[key]!
-            output += "\(indent)\(key) = \(renderValue(value))\n"
+            output += "\(indent)\(TerminalFieldEncoder.encode(key)) = \(renderValue(value))\n"
         }
         return output
     }
@@ -123,7 +123,7 @@ public enum ThunderboltProbe {
     private static func renderValue(_ value: Any) -> String {
         switch value {
         case let s as String:
-            return "\"\(s)\""
+            return "\"\(TerminalFieldEncoder.encode(s))\""
         case let n as NSNumber:
             return n.stringValue
         case let b as Bool:
@@ -137,10 +137,12 @@ public enum ThunderboltProbe {
             let parts = arr.map { renderValue($0) }
             return "[\(parts.joined(separator: ", "))]"
         case let dict as [String: Any]:
-            let parts = dict.keys.sorted().map { "\($0)=\(renderValue(dict[$0]!))" }
+            let parts = dict.keys.sorted().map {
+                "\(TerminalFieldEncoder.encode($0))=\(renderValue(dict[$0]!))"
+            }
             return "{\(parts.joined(separator: ", "))}"
         default:
-            return "\(value)"
+            return TerminalFieldEncoder.encode("\(value)")
         }
     }
 }

--- a/Sources/WhatCableDarwinBackend/Debug/ThunderboltProbe.swift
+++ b/Sources/WhatCableDarwinBackend/Debug/ThunderboltProbe.swift
@@ -8,6 +8,7 @@ import WhatCableCore
 /// rather than guesses. No interpretation, no rendering, just a paste-ready
 /// dump of every property on every switch and port.
 public enum ThunderboltProbe {
+    /// Dumps the discovered Thunderbolt switch tree as paste-ready text.
     public static func dump() -> String {
         var output = ""
         output += "# WhatCable Thunderbolt probe\n"
@@ -53,6 +54,7 @@ public enum ThunderboltProbe {
         return output
     }
 
+    /// Renders one Thunderbolt switch and its port children.
     private static func dumpSwitch(_ service: io_service_t, index: Int) -> String {
         var output = ""
         let className = TerminalFieldEncoder.encode(ioClassName(service) ?? "<unknown class>")
@@ -88,6 +90,7 @@ public enum ThunderboltProbe {
         return output
     }
 
+    /// Reads the IOKit class name for a service, if available.
     private static func ioClassName(_ service: io_service_t) -> String? {
         var buf = [CChar](repeating: 0, count: 128)
         let kr = IOObjectGetClass(service, &buf)
@@ -95,6 +98,7 @@ public enum ThunderboltProbe {
         return String(cString: buf)
     }
 
+    /// Copies the service's IOKit properties into a Swift dictionary.
     private static func ioProperties(_ service: io_service_t) -> [String: Any]? {
         // ThunderboltProbe is a diagnostic helper (`--tb-debug`). It intentionally
         // reads the entire property dict so it can render all keys verbatim.
@@ -107,6 +111,7 @@ public enum ThunderboltProbe {
         return dict as? [String: Any]
     }
 
+    /// Renders sorted, terminal-safe property keys and recursively formatted values.
     static func renderProperties(_ props: [String: Any], indent: String) -> String {
         // Sort keys for stable, paste-friendly output. Skip noisy fields that
         // don't help with the design (IOPowerManagement dict, large binary blobs
@@ -120,6 +125,7 @@ public enum ThunderboltProbe {
         return output
     }
 
+    /// Formats a scalar, collection, or data property for diagnostic output.
     private static func renderValue(_ value: Any) -> String {
         switch value {
         case let s as String:

--- a/Tests/WhatCableCoreTests/ANSITests.swift
+++ b/Tests/WhatCableCoreTests/ANSITests.swift
@@ -29,4 +29,17 @@ struct ANSITests {
     func colorOffWhenNeitherTrue() {
         #expect(ANSI.shouldEnable(isTTY: false, noColorSet: true) == false)
     }
+
+    @Test("Encoded hardware fields remain safe with and without formatter ANSI")
+    func encodedFieldsRemainSafeAcrossTTYModes() {
+        let unsafe = "Dock\u{1B}]0;forged\u{7}\n显示器"
+        let encoded = TerminalFieldEncoder.encode(unsafe)
+        let expected = #"Dock\u{1B}]0;forged\u{7}\u{A}显示器"#
+
+        #expect(ANSI.wrap(ANSI.red, encoded, enabled: false) == expected)
+        #expect(
+            ANSI.wrap(ANSI.red, encoded, enabled: true)
+                == ANSI.red + expected + ANSI.reset
+        )
+    }
 }

--- a/Tests/WhatCableCoreTests/JSONFormatterTests.swift
+++ b/Tests/WhatCableCoreTests/JSONFormatterTests.swift
@@ -99,6 +99,27 @@ struct JSONFormatterTests {
         #expect(without["otherUSBDevices"] == nil)
     }
 
+    @Test("Terminal field encoding does not alter structured JSON strings")
+    func terminalEncodingDoesNotAlterJSON() throws {
+        let hardwareName = "显示器 🚀\u{1B}]0;title\u{7}\nrow"
+        let device = USBDevice(
+            id: 42, locationID: 0x2011_0000, vendorID: 0x05AC, productID: 0x0202,
+            vendorName: "Apple", productName: hardwareName,
+            serialNumber: nil, usbVersion: nil, speedRaw: 1,
+            busPowerMA: nil, currentMA: nil, isThunderboltTunnelled: true,
+            rawProperties: [:]
+        )
+
+        let json = parse(try JSONFormatter.render(
+            ports: [makePort()], sources: [], identities: [], showRaw: false,
+            usbDevices: [device]
+        ))
+        let other = try #require(json["otherUSBDevices"] as? [String: Any])
+        let devices = try #require(other["devices"] as? [[String: Any]])
+
+        #expect(devices.first?["name"] as? String == hardwareName)
+    }
+
     // MARK: - Built-in USB ports (issue #348)
 
     @Test("builtInUSBDevices appears only on a desktop Mac with front-port devices")

--- a/Tests/WhatCableCoreTests/TerminalFieldEncoderTests.swift
+++ b/Tests/WhatCableCoreTests/TerminalFieldEncoderTests.swift
@@ -1,0 +1,30 @@
+import Testing
+@testable import WhatCableCore
+
+@Suite("Terminal field encoder")
+struct TerminalFieldEncoderTests {
+    @Test("C0, DEL, and C1 controls become visible text")
+    func controlRangesBecomeVisibleText() {
+        var controls = ""
+        for value in Array(0x00...0x1F) + Array(0x7F...0x9F) {
+            controls.unicodeScalars.append(UnicodeScalar(value)!)
+        }
+
+        let encoded = TerminalFieldEncoder.encode(controls)
+        let remainingControls = encoded.unicodeScalars.filter {
+            (0x00...0x1F).contains($0.value) || (0x7F...0x9F).contains($0.value)
+        }
+
+        #expect(remainingControls.isEmpty)
+        #expect(encoded.contains(#"\u{0}\u{1}"#))
+        #expect(encoded.contains(#"\u{1B}"#))
+        #expect(encoded.contains(#"\u{7F}\u{80}"#))
+        #expect(encoded.hasSuffix(#"\u{9F}"#))
+    }
+
+    @Test("Ordinary Unicode is preserved verbatim")
+    func ordinaryUnicodeIsPreserved() {
+        let value = "Café 显示器 🚀 e\u{301}"
+        #expect(TerminalFieldEncoder.encode(value) == value)
+    }
+}

--- a/Tests/WhatCableCoreTests/TextFormatterTests.swift
+++ b/Tests/WhatCableCoreTests/TextFormatterTests.swift
@@ -6,7 +6,10 @@ struct TextFormatterTests {
 
     // MARK: - Fixtures
 
-    private func makePort(connected: Bool = true) -> USBCPort {
+    private func makePort(
+        connected: Bool = true,
+        rawProperties: [String: String] = ["PortType": "2"]
+    ) -> USBCPort {
         USBCPort(
             id: 1,
             serviceName: "Port-USB-C@1",
@@ -32,7 +35,7 @@ struct TextFormatterTests {
             powerCurrentLimits: [],
             firmwareVersion: nil,
             bootFlagsHex: nil,
-            rawProperties: ["PortType": "2"]
+            rawProperties: rawProperties
         )
     }
 
@@ -105,6 +108,36 @@ struct TextFormatterTests {
             output.contains("\u{1B}[") == false,
             "ANSI escape sequences should not appear when stdout is not a TTY"
         )
+    }
+
+    // MARK: - Terminal-safe external fields
+
+    @Test("Hardware-controlled device names cannot inject terminal controls or lines")
+    func hardwareDeviceNamesAreTerminalSafe() {
+        let maliciousName = "显示器 🚀\u{1B}]0;forged title\u{7}\nforged row"
+        let output = TextFormatter.render(
+            ports: [makePort()], sources: [], identities: [], showRaw: false,
+            usbDevices: [tunnelledDevice(name: maliciousName)]
+        )
+
+        #expect(!output.contains("\u{1B}]0;forged title"))
+        #expect(!output.contains("\u{7}"))
+        #expect(output.contains(#"显示器 🚀\u{1B}]0;forged title\u{7}\u{A}forged row"#))
+    }
+
+    @Test("--raw terminal output encodes control characters in IOKit keys and values")
+    func rawIOKitFieldsAreTerminalSafe() {
+        let port = makePort(rawProperties: [
+            "Unsafe\u{1B}]key\u{7}": "value\u{9B}31m\rforged",
+        ])
+        let output = TextFormatter.render(
+            ports: [port], sources: [], identities: [], showRaw: true
+        )
+
+        #expect(!output.contains("\u{1B}]key"))
+        #expect(!output.contains("\u{7}"))
+        #expect(!output.contains("\u{9B}"))
+        #expect(output.contains(#"Unsafe\u{1B}]key\u{7} = value\u{9B}31m\u{D}forged"#))
     }
 
     // MARK: - Thunderbolt fabric tree (issue #280)
@@ -195,6 +228,28 @@ struct TextFormatterTests {
         // Studio Display (depth 3) sits deeper than the OWC (depth 2).
         #expect(output.contains("      ↳ Apple Inc. Studio Display"), "Studio Display indent wrong; got:\n\(output)")
         #expect(output.contains("    ↳ OWC Express 1M2"), "OWC indent wrong; got:\n\(output)")
+    }
+
+    @Test("CLI encodes terminal controls in Thunderbolt device names")
+    func cliEncodesThunderboltDeviceNames() {
+        let switches = [
+            fabricSwitch(
+                uid: 100, depth: 0, parent: nil,
+                vendor: "Apple Inc.", model: "Host", lane: 1, socketID: "1"
+            ),
+            fabricSwitch(
+                uid: 200, depth: 1, parent: 100,
+                vendor: "Dock\u{1B}]0;forged\u{7}", model: "Model\nrow",
+                lane: 2, socketID: nil
+            ),
+        ]
+        let output = TextFormatter.render(
+            ports: [tbFabricPort()], sources: [], identities: [],
+            showRaw: false, thunderboltSwitches: switches
+        )
+
+        #expect(!output.contains("\u{1B}]0;forged"))
+        #expect(output.contains(#"Dock\u{1B}]0;forged\u{7} Model\u{A}row"#))
     }
 
     // MARK: - Cable trust signals

--- a/Tests/WhatCableDarwinTests/ThunderboltProbeTerminalSafetyTests.swift
+++ b/Tests/WhatCableDarwinTests/ThunderboltProbeTerminalSafetyTests.swift
@@ -1,0 +1,26 @@
+import Testing
+@testable import WhatCableDarwinBackend
+
+@Suite("Thunderbolt probe terminal safety")
+struct ThunderboltProbeTerminalSafetyTests {
+    @Test("--tb-debug property keys and recursive string values encode controls")
+    func propertyRenderingEncodesTerminalControls() {
+        let rendered = ThunderboltProbe.renderProperties(
+            [
+                "Unsafe\u{1B}]key\u{7}": [
+                    "nested\rkey": "Dock\u{9B}31m\nforged",
+                ],
+            ],
+            indent: "  "
+        )
+
+        #expect(!rendered.contains("\u{1B}]key"))
+        #expect(!rendered.contains("\u{7}"))
+        #expect(!rendered.contains("\u{9B}"))
+        #expect(
+            rendered.contains(
+                #"Unsafe\u{1B}]key\u{7} = {nested\u{D}key="Dock\u{9B}31m\u{A}forged"}"#
+            )
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- add a shared terminal-field encoder that renders C0/C1 controls as visible `\\u{HEX}` text
- apply it at the human-readable CLI, `--watch`, `--raw`, and `--tb-debug` output boundaries
- preserve formatter-owned ANSI/newlines and leave structured JSON strings unchanged

## Security impact

USB/Thunderbolt descriptors and raw IOKit properties are hardware-controlled. Encoding their control characters before terminal interpolation prevents OSC/title changes, injected ANSI state, and forged output rows while keeping the original values inspectable.

## Validation

- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift build --quiet`
- `xcrun swift test --quiet --filter TextFormatterTests` — 21 passed
- `xcrun swift test --quiet --filter ANSITests` — 5 passed
- `xcrun swift test --quiet --filter Terminal` — 6 passed
- `xcrun swift test --quiet --filter terminalEncodingDoesNotAlterJSON` — 1 passed
- pre-fix regression tests reproduced raw OSC/BEL/newline injection; the same tests pass with this patch

The full suite was also compared against a clean `origin/main` worktree. Both runs report the same 76 existing corpus issues because `research/customer-probes` and several `research/dumps` fixtures are absent from this checkout; the candidate run includes all 8 new tests, which pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added terminal-safe encoding for user-provided and diagnostic text by escaping C0/C1 control characters.
  * Expanded encoding across text output and Thunderbolt probe rendering to prevent raw terminal escape sequences.
* **Bug Fixes**
  * Improved ANSI wrapping behavior consistency between enabled/disabled terminal modes.
  * Ensured JSON rendering preserves original strings (including non-ASCII and escape sequences).
* **Tests**
  * Added regression and safety tests covering terminal encoding, ANSI behavior, Unicode preservation, and JSON integrity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->