### PR TITLE
fix: stop stale PDO charging reports

### DIFF
--- a/Sources/WhatCable/Services/WidgetDataWriter.swift
+++ b/Sources/WhatCable/Services/WidgetDataWriter.swift
@@ -245,7 +245,8 @@ final class WidgetDataWriter {
                 cioCapability: trmWatcher.cioCapabilities.first { $0.canonicallyMatches(port: port) },
                 isConnectedOverride: isLive,
                 batteryFullyCharged: batteryFull,
-                batteryIsCharging: batteryCharging
+                batteryIsCharging: batteryCharging,
+                adapter: adapter
             )
 
             let status = WidgetSnapshot.Status(from: summary.status)

--- a/Sources/WhatCable/Views/ContentView.swift
+++ b/Sources/WhatCable/Views/ContentView.swift
@@ -723,7 +723,7 @@ struct PortCard: View {
                     .padding(.leading, 48)
             }
 
-            if let diag = ChargingDiagnostic(port: port, sources: powerSources, identities: identities, wattageSource: chargerWattageSource, batteryFullyCharged: batteryFullyCharged, batteryIsCharging: batteryIsCharging, anotherPortActivelyCharging: anotherPortActivelyCharging) {
+            if let diag = ChargingDiagnostic(port: port, sources: powerSources, identities: identities, adapter: adapter, wattageSource: chargerWattageSource, batteryFullyCharged: batteryFullyCharged, batteryIsCharging: batteryIsCharging, anotherPortActivelyCharging: anotherPortActivelyCharging) {
                 DiagnosticBanner(diagnostic: diag)
                     .padding(.leading, 48)
             }

--- a/Sources/WhatCableCore/Output/PortSummary.swift
+++ b/Sources/WhatCableCore/Output/PortSummary.swift
@@ -186,10 +186,19 @@ extension PortSummary {
             }
         }
 
+        // A controller can retain a winning PDO while the system rejects
+        // external power. In that state the source still describes the port's
+        // last negotiation, but it must not drive charging copy or wattage.
+        let systemPowerUnavailable = batteryIsCharging == false
+            && batteryFullyCharged != true
+            && adapter == nil
+
         // Hoist the charging source lookup early. The identity-block
         // wording below and the e-marker guard further down both need
         // to know whether something is sourcing power on this port.
-        let chargingSource = PowerSource.preferredChargingSource(in: sources)
+        let chargingSource = systemPowerUnavailable
+            ? nil
+            : PowerSource.preferredChargingSource(in: sources)
 
         // Whether we'll emit a richer "Charger: <Manufacturer> <Name>"
         // line later (in the charger details block). We use this to
@@ -442,7 +451,8 @@ extension PortSummary {
                 let watts = win.wattsLabel
                 bullets.append(String(localized: "Currently negotiated: \(volts) @ \(amps) (\(watts))", bundle: _coreLocalizedBundle))
             }
-        } else if case .systemAdapterFallback(let w) = chargerWattageSource, w > 0 {
+        } else if !systemPowerUnavailable,
+                  case .systemAdapterFallback(let w) = chargerWattageSource, w > 0 {
             // No live USB-PD source on this port (e.g. the battery is full so
             // macOS tore the contract down), but the system adapter reading
             // still resolves to a charger for this port. Surface its brand and
@@ -463,6 +473,7 @@ extension PortSummary {
         // Headline wattage: prefer the resolved source, fall back to
         // the per-port PD options for callers that don't pass a source.
         let chargerW: Int? = {
+            if systemPowerUnavailable { return nil }
             if let w = chargerWattageSource.watts, w > 0 { return w }
             guard let chargingSource, !chargingSource.options.isEmpty else { return nil }
             let w = Int((Double(chargingSource.maxPowerMW) / 1000).rounded())
@@ -584,7 +595,7 @@ extension PortSummary {
             // so the subtitle here would just repeat it. Left empty; the
             // render sites skip an empty subtitle.
             self.subtitle = ""
-        } else if active.isEmpty && supported.contains("USB2") {
+        } else if active.isEmpty && supported.contains("USB2") && !systemPowerUnavailable {
             self.status = .charging
             self.headline = String(localized: "Charging only", bundle: _coreLocalizedBundle)
             self.subtitle = String(localized: "Power is flowing but no data link is established.", bundle: _coreLocalizedBundle)

--- a/Sources/WhatCableCore/Power/ChargingDiagnostic.swift
+++ b/Sources/WhatCableCore/Power/ChargingDiagnostic.swift
@@ -58,9 +58,14 @@ extension ChargingDiagnostic {
         // the PowerSource node alone.
         guard port.connectionActive == true else { return nil }
 
-        // Adapter wattage resolution moved to ChargerWattageSource.resolve;
-        // parameter kept for API compatibility.
-        _ = adapter
+        // A controller can retain a winning PDO while the system rejects
+        // external power. If the battery is not charging, is not full, and
+        // IOPSCopyExternalPowerAdapterDetails reports no adapter, the PDO is
+        // not enough evidence to show a charging diagnostic.
+        guard batteryIsCharging != false
+            || batteryFullyCharged == true
+            || adapter != nil
+        else { return nil }
 
         let chargerMaxW: Int
         let isAdapterFallback: Bool

--- a/Sources/WhatCableCore/Power/PowerSource.swift
+++ b/Sources/WhatCableCore/Power/PowerSource.swift
@@ -144,12 +144,10 @@ extension PowerSource {
         return nil
     }
 
-    /// True when these sources hold a live, negotiated charging contract,
-    /// meaning the Mac is actually drawing power through this port (a
-    /// `winning` PDO with positive wattage). A charger that is merely
-    /// connected and advertising capability, but that the Mac has not
-    /// chosen to draw from, returns false. Used to tell a standby second
-    /// charger apart from one whose negotiation is still in progress.
+    /// True when these sources expose a negotiated contract: a `winning` PDO
+    /// with positive wattage. This does not prove that the system accepted
+    /// external power. Callers that make a charging claim must also check the
+    /// system adapter and battery state.
     public static func hasLiveChargingContract(in sources: [PowerSource]) -> Bool {
         guard let source = preferredChargingSource(in: sources),
               let winning = source.winning else { return false }

--- a/Sources/WhatCableCore/Snapshot/WidgetSnapshot.swift
+++ b/Sources/WhatCableCore/Snapshot/WidgetSnapshot.swift
@@ -293,7 +293,8 @@ extension WidgetSnapshot {
                 cioCapability: cio,
                 isConnectedOverride: isLive,
                 batteryFullyCharged: batteryFullyCharged,
-                batteryIsCharging: batteryIsCharging
+                batteryIsCharging: batteryIsCharging,
+                adapter: adapter
             )
 
             let status = Status(from: summary.status)

--- a/Tests/WhatCableCoreTests/ChargingDiagnosticTests.swift
+++ b/Tests/WhatCableCoreTests/ChargingDiagnosticTests.swift
@@ -852,6 +852,7 @@ struct ChargingDiagnosticTests {
             port: port,
             sources: [usbPD(maxW: 96, winningW: 96)],
             identities: [cableIdentity(watts: 100)],
+            adapter: AdapterInfo(watts: 96, isCharging: nil, source: "AC"),
             batteryIsCharging: false
         )
         #expect(diag != nil)
@@ -866,6 +867,7 @@ struct ChargingDiagnosticTests {
             port: port,
             sources: [usbPD(maxW: 96, winningW: 96)],
             identities: [cableIdentity(watts: 100)],
+            adapter: AdapterInfo(watts: 96, isCharging: nil, source: "AC"),
             batteryFullyCharged: true,
             batteryIsCharging: false
         )
@@ -884,5 +886,18 @@ struct ChargingDiagnosticTests {
         )
         #expect(diag != nil)
         #expect(diag!.summary.contains("Charging well"))
+    }
+
+    @Test("Stale PDO: no diagnostic when the system has no adapter")
+    func stalePDOWithNoSystemAdapterReturnsNil() {
+        let diag = ChargingDiagnostic(
+            port: port,
+            sources: [usbPD(maxW: 96, winningW: 96)],
+            identities: [],
+            adapter: nil,
+            batteryFullyCharged: false,
+            batteryIsCharging: false
+        )
+        #expect(diag == nil)
     }
 }

--- a/Tests/WhatCableCoreTests/PortSummaryTests.swift
+++ b/Tests/WhatCableCoreTests/PortSummaryTests.swift
@@ -1597,11 +1597,28 @@ struct PortSummaryTests {
         let summary = PortSummary(
             port: port,
             sources: [usbPD(maxW: 96, winningW: 96)],
-            batteryIsCharging: false
+            batteryIsCharging: false,
+            adapter: adapter()
         )
         #expect(summary.status == .charging)
         #expect(summary.headline.hasPrefix("Plugged in"))
         #expect(summary.headline.contains("96W"))
+    }
+
+    @Test("Stale PDO: no charging claim when the system has no adapter")
+    func stalePDOWithNoSystemAdapterIsConnected() {
+        let port = makePort(connected: true, active: [], supported: ["USB2"])
+        let summary = PortSummary(
+            port: port,
+            sources: [usbPD(maxW: 96, winningW: 96)],
+            batteryFullyCharged: false,
+            batteryIsCharging: false,
+            adapter: nil
+        )
+        #expect(summary.status == .unknown)
+        #expect(summary.headline == "Connected")
+        #expect(summary.subtitle.contains("Power is flowing") == false)
+        #expect(summary.bullets.contains { $0.contains("Currently negotiated") } == false)
     }
 
     @Test("Charge hold: headline shows 'Plugged in' without wattage when no chargerW")


### PR DESCRIPTION
A winning PDO can remain after macOS stops accepting external power. WhatCable then reports charging even when `IsCharging` is false and no system adapter exists.

Ignore that PDO when the battery is not full, not charging, and `IOPSCopyExternalPowerAdapterDetails()` returns nil. Real charge holds still work when adapter data is present.

Test: `swift test --filter "ChargingDiagnosticTests|PortSummaryTests"` (124 passed)