### PR TITLE
Group downstream devices by USB controller, and show per-device detail

### DIFF
--- a/Sources/WhatCable/Resources/de.lproj/Localizable.strings
+++ b/Sources/WhatCable/Resources/de.lproj/Localizable.strings
@@ -178,3 +178,8 @@
 "This Mac has an Intel processor. WhatCable gets its cable and port data from Apple Silicon's port controller, and Intel Macs don't expose it, so the app will show nothing useful.\n\nIt'll stay open if you want to look around, but there's nothing behind it." = "Dieser Mac hat einen Intel-Prozessor. WhatCable bezieht seine Kabel- und Anschlussdaten vom Port-Controller von Apple Silicon, und Intel-Macs geben diese nicht preis. Die App wird daher nichts Brauchbares anzeigen.\n\nSie bleibt geöffnet, falls Sie sich umsehen möchten, aber dahinter steckt nichts.";
 "OK" = "OK";
 "Learn more" = "Mehr erfahren";
+/* USB device detail rows (downstream device enrichment). Labels for the
+   per-device expander: vendor, serial and USB version. */
+"Vendor" = "Hersteller";
+"Serial" = "Seriennummer";
+"USB" = "USB";

--- a/Sources/WhatCable/Resources/en.lproj/Localizable.strings
+++ b/Sources/WhatCable/Resources/en.lproj/Localizable.strings
@@ -177,3 +177,8 @@
 "This Mac has an Intel processor. WhatCable gets its cable and port data from Apple Silicon's port controller, and Intel Macs don't expose it, so the app will show nothing useful.\n\nIt'll stay open if you want to look around, but there's nothing behind it." = "This Mac has an Intel processor. WhatCable gets its cable and port data from Apple Silicon's port controller, and Intel Macs don't expose it, so the app will show nothing useful.\n\nIt'll stay open if you want to look around, but there's nothing behind it.";
 "OK" = "OK";
 "Learn more" = "Learn more";
+/* USB device detail rows (downstream device enrichment). Labels for the
+   per-device expander: vendor, serial and USB version. */
+"Vendor" = "Vendor";
+"Serial" = "Serial";
+"USB" = "USB";

--- a/Sources/WhatCable/Resources/es.lproj/Localizable.strings
+++ b/Sources/WhatCable/Resources/es.lproj/Localizable.strings
@@ -178,3 +178,8 @@
 "This Mac has an Intel processor. WhatCable gets its cable and port data from Apple Silicon's port controller, and Intel Macs don't expose it, so the app will show nothing useful.\n\nIt'll stay open if you want to look around, but there's nothing behind it." = "Este Mac tiene un procesador Intel. WhatCable obtiene los datos de cables y puertos del controlador de puertos de Apple Silicon, y los Mac con Intel no lo exponen, así que la app no mostrará nada útil.\n\nSeguirá abierta por si quieres echar un vistazo, pero no hay nada detrás.";
 "OK" = "OK";
 "Learn more" = "Más información";
+/* USB device detail rows (downstream device enrichment). Labels for the
+   per-device expander: vendor, serial and USB version. */
+"Vendor" = "Fabricante";
+"Serial" = "Número de serie";
+"USB" = "USB";

--- a/Sources/WhatCable/Resources/fr.lproj/Localizable.strings
+++ b/Sources/WhatCable/Resources/fr.lproj/Localizable.strings
@@ -178,3 +178,8 @@
 "This Mac has an Intel processor. WhatCable gets its cable and port data from Apple Silicon's port controller, and Intel Macs don't expose it, so the app will show nothing useful.\n\nIt'll stay open if you want to look around, but there's nothing behind it." = "Ce Mac est équipé d'un processeur Intel. WhatCable obtient ses données de câbles et de ports auprès du contrôleur de ports d'Apple Silicon, que les Mac Intel n'exposent pas. L'app n'affichera donc rien d'utile.\n\nElle reste ouverte si vous voulez y jeter un œil, mais il n'y a rien derrière.";
 "OK" = "OK";
 "Learn more" = "En savoir plus";
+/* USB device detail rows (downstream device enrichment). Labels for the
+   per-device expander: vendor, serial and USB version. */
+"Vendor" = "Fabricant";
+"Serial" = "Numéro de série";
+"USB" = "USB";

--- a/Sources/WhatCable/Resources/hi.lproj/Localizable.strings
+++ b/Sources/WhatCable/Resources/hi.lproj/Localizable.strings
@@ -177,3 +177,8 @@
 "This Mac has an Intel processor. WhatCable gets its cable and port data from Apple Silicon's port controller, and Intel Macs don't expose it, so the app will show nothing useful.\n\nIt'll stay open if you want to look around, but there's nothing behind it." = "इस Mac में Intel प्रोसेसर है। WhatCable अपना केबल और पोर्ट डेटा Apple Silicon के पोर्ट कंट्रोलर से लेता है, और Intel Mac इसे उपलब्ध नहीं कराते, इसलिए ऐप में कुछ भी उपयोगी नहीं दिखेगा।\n\nअगर आप देखना चाहें तो यह खुला रहेगा, लेकिन इसके पीछे कुछ नहीं है।";
 "OK" = "ठीक है";
 "Learn more" = "और जानें";
+/* USB device detail rows (downstream device enrichment). Labels for the
+   per-device expander: vendor, serial and USB version. */
+"Vendor" = "निर्माता";
+"Serial" = "सीरियल नंबर";
+"USB" = "USB";

--- a/Sources/WhatCable/Resources/hy.lproj/Localizable.strings
+++ b/Sources/WhatCable/Resources/hy.lproj/Localizable.strings
@@ -178,3 +178,8 @@
 "This Mac has an Intel processor. WhatCable gets its cable and port data from Apple Silicon's port controller, and Intel Macs don't expose it, so the app will show nothing useful.\n\nIt'll stay open if you want to look around, but there's nothing behind it." = "Այս Mac-ն ունի Intel պրոցեսոր։ WhatCable-ը մալուխների և պորտերի տվյալները ստանում է Apple Silicon-ի պորտի կարգավորիչից, իսկ Intel Mac-երն այն չեն տրամադրում, ուստի հավելվածը ոչ մի օգտակար բան ցույց չի տա։\n\nԱյն կմնա բաց, եթե ուզում եք նայել, բայց դրա հետևում ոչինչ չկա։";
 "OK" = "Լավ";
 "Learn more" = "Իմանալ ավելին";
+/* USB device detail rows (downstream device enrichment). Labels for the
+   per-device expander: vendor, serial and USB version. */
+"Vendor" = "Արտադրող";
+"Serial" = "Սերիական համար";
+"USB" = "USB";

--- a/Sources/WhatCable/Resources/it.lproj/Localizable.strings
+++ b/Sources/WhatCable/Resources/it.lproj/Localizable.strings
@@ -177,3 +177,8 @@
 "This Mac has an Intel processor. WhatCable gets its cable and port data from Apple Silicon's port controller, and Intel Macs don't expose it, so the app will show nothing useful.\n\nIt'll stay open if you want to look around, but there's nothing behind it." = "Questo Mac ha un processore Intel. WhatCable ricava i dati di cavi e porte dal controller porte Apple Silicon, che i Mac Intel non espongono, quindi l'app non visualizzerà nulla di utile.\n\nSe vuoi dare un'occhiata resterà aperta , ma dietro non c'è nulla.";
 "OK" = "OK";
 "Learn more" = "Maggiori info";
+/* USB device detail rows (downstream device enrichment). Labels for the
+   per-device expander: vendor, serial and USB version. */
+"Vendor" = "Produttore";
+"Serial" = "Seriale";
+"USB" = "USB";

--- a/Sources/WhatCable/Resources/ja.lproj/Localizable.strings
+++ b/Sources/WhatCable/Resources/ja.lproj/Localizable.strings
@@ -178,3 +178,8 @@
 "This Mac has an Intel processor. WhatCable gets its cable and port data from Apple Silicon's port controller, and Intel Macs don't expose it, so the app will show nothing useful.\n\nIt'll stay open if you want to look around, but there's nothing behind it." = "このMacはIntelプロセッサを搭載しています。WhatCableはケーブルとポートのデータをApple Siliconのポートコントローラから取得しますが、Intel Macはこれを公開していないため、有用な情報は何も表示されません。\n\n見て回りたい場合は開いたままにできますが、その先には何もありません。";
 "OK" = "OK";
 "Learn more" = "詳しく見る";
+/* USB device detail rows (downstream device enrichment). Labels for the
+   per-device expander: vendor, serial and USB version. */
+"Vendor" = "製造元";
+"Serial" = "シリアル番号";
+"USB" = "USB";

--- a/Sources/WhatCable/Resources/ko.lproj/Localizable.strings
+++ b/Sources/WhatCable/Resources/ko.lproj/Localizable.strings
@@ -177,3 +177,8 @@
 "This Mac has an Intel processor. WhatCable gets its cable and port data from Apple Silicon's port controller, and Intel Macs don't expose it, so the app will show nothing useful.\n\nIt'll stay open if you want to look around, but there's nothing behind it." = "이 Mac은 Intel 프로세서를 사용합니다. WhatCable은 케이블과 포트 데이터를 Apple Silicon의 포트 컨트롤러에서 가져오는데, Intel Mac은 이를 제공하지 않으므로 앱에 유용한 정보가 표시되지 않습니다.\n\n둘러보고 싶다면 열어 둘 수 있지만, 그 뒤에는 아무것도 없습니다.";
 "OK" = "확인";
 "Learn more" = "자세히 알아보기";
+/* USB device detail rows (downstream device enrichment). Labels for the
+   per-device expander: vendor, serial and USB version. */
+"Vendor" = "제조사";
+"Serial" = "일련번호";
+"USB" = "USB";

--- a/Sources/WhatCable/Resources/lv.lproj/Localizable.strings
+++ b/Sources/WhatCable/Resources/lv.lproj/Localizable.strings
@@ -177,3 +177,8 @@
 "This Mac has an Intel processor. WhatCable gets its cable and port data from Apple Silicon's port controller, and Intel Macs don't expose it, so the app will show nothing useful.\n\nIt'll stay open if you want to look around, but there's nothing behind it." = "Šim Mac datoram ir Intel procesors. WhatCable iegūst kabeļu un portu datus no Apple Silicon portu kontrollera, un Intel Mac datori to nepadara pieejamu, tāpēc lietotne nerādīs neko noderīgu.\n\nTā paliks atvērta, ja vēlaties paskatīties, bet aiz tās nekā nav.";
 "OK" = "Labi";
 "Learn more" = "Uzzināt vairāk";
+/* USB device detail rows (downstream device enrichment). Labels for the
+   per-device expander: vendor, serial and USB version. */
+"Vendor" = "Ražotājs";
+"Serial" = "Sērijas numurs";
+"USB" = "USB";

--- a/Sources/WhatCable/Resources/nb.lproj/Localizable.strings
+++ b/Sources/WhatCable/Resources/nb.lproj/Localizable.strings
@@ -178,3 +178,8 @@
 "This Mac has an Intel processor. WhatCable gets its cable and port data from Apple Silicon's port controller, and Intel Macs don't expose it, so the app will show nothing useful.\n\nIt'll stay open if you want to look around, but there's nothing behind it." = "Denne Macen har en Intel-prosessor. WhatCable henter kabel- og portdata fra portkontrolleren i Apple Silicon, og Intel-Macer eksponerer den ikke, så appen vil ikke vise noe nyttig.\n\nDen blir stående åpen hvis du vil se deg om, men det er ingenting bak den.";
 "OK" = "OK";
 "Learn more" = "Finn ut mer";
+/* USB device detail rows (downstream device enrichment). Labels for the
+   per-device expander: vendor, serial and USB version. */
+"Vendor" = "Produsent";
+"Serial" = "Serienummer";
+"USB" = "USB";

--- a/Sources/WhatCable/Resources/nl.lproj/Localizable.strings
+++ b/Sources/WhatCable/Resources/nl.lproj/Localizable.strings
@@ -177,3 +177,8 @@
 "This Mac has an Intel processor. WhatCable gets its cable and port data from Apple Silicon's port controller, and Intel Macs don't expose it, so the app will show nothing useful.\n\nIt'll stay open if you want to look around, but there's nothing behind it." = "Deze Mac heeft een Intel-processor. WhatCable haalt kabel- en poortgegevens op bij de poortcontroller van Apple Silicon, en Intel-Macs stellen die niet beschikbaar. De app laat dus niets nuttigs zien.\n\nHij blijft open als je wilt rondkijken, maar er zit niets achter.";
 "OK" = "OK";
 "Learn more" = "Meer informatie";
+/* USB device detail rows (downstream device enrichment). Labels for the
+   per-device expander: vendor, serial and USB version. */
+"Vendor" = "Fabrikant";
+"Serial" = "Serienummer";
+"USB" = "USB";

--- a/Sources/WhatCable/Resources/pl.lproj/Localizable.strings
+++ b/Sources/WhatCable/Resources/pl.lproj/Localizable.strings
@@ -177,3 +177,8 @@
 "This Mac has an Intel processor. WhatCable gets its cable and port data from Apple Silicon's port controller, and Intel Macs don't expose it, so the app will show nothing useful.\n\nIt'll stay open if you want to look around, but there's nothing behind it." = "Ten Mac ma procesor Intel. WhatCable pobiera dane o kablach i portach z kontrolera portów Apple Silicon, a Maki z procesorem Intel go nie udostępniają, więc aplikacja nie pokaże nic użytecznego.\n\nZostanie otwarta, jeśli chcesz się rozejrzeć, ale nic za nią nie stoi.";
 "OK" = "OK";
 "Learn more" = "Dowiedz się więcej";
+/* USB device detail rows (downstream device enrichment). Labels for the
+   per-device expander: vendor, serial and USB version. */
+"Vendor" = "Producent";
+"Serial" = "Numer seryjny";
+"USB" = "USB";

--- a/Sources/WhatCable/Resources/pt-BR.lproj/Localizable.strings
+++ b/Sources/WhatCable/Resources/pt-BR.lproj/Localizable.strings
@@ -177,3 +177,8 @@
 "This Mac has an Intel processor. WhatCable gets its cable and port data from Apple Silicon's port controller, and Intel Macs don't expose it, so the app will show nothing useful.\n\nIt'll stay open if you want to look around, but there's nothing behind it." = "Este Mac tem um processador Intel. O WhatCable obtém os dados de cabos e portas do controlador de portas do Apple Silicon, e os Macs com Intel não o expõem, então o app não vai mostrar nada útil.\n\nEle continua aberto se você quiser dar uma olhada, mas não há nada por trás.";
 "OK" = "OK";
 "Learn more" = "Saiba mais";
+/* USB device detail rows (downstream device enrichment). Labels for the
+   per-device expander: vendor, serial and USB version. */
+"Vendor" = "Fabricante";
+"Serial" = "Número de série";
+"USB" = "USB";

--- a/Sources/WhatCable/Resources/ru.lproj/Localizable.strings
+++ b/Sources/WhatCable/Resources/ru.lproj/Localizable.strings
@@ -177,3 +177,8 @@
 "This Mac has an Intel processor. WhatCable gets its cable and port data from Apple Silicon's port controller, and Intel Macs don't expose it, so the app will show nothing useful.\n\nIt'll stay open if you want to look around, but there's nothing behind it." = "В этом Mac установлен процессор Intel. WhatCable получает данные о кабелях и портах от контроллера портов Apple Silicon, а Mac с Intel его не предоставляют, поэтому приложение не покажет ничего полезного.\n\nОно останется открытым, если хотите осмотреться, но за ним ничего нет.";
 "OK" = "ОК";
 "Learn more" = "Подробнее";
+/* USB device detail rows (downstream device enrichment). Labels for the
+   per-device expander: vendor, serial and USB version. */
+"Vendor" = "Производитель";
+"Serial" = "Серийный номер";
+"USB" = "USB";

--- a/Sources/WhatCable/Resources/tr.lproj/Localizable.strings
+++ b/Sources/WhatCable/Resources/tr.lproj/Localizable.strings
@@ -177,3 +177,8 @@
 "This Mac has an Intel processor. WhatCable gets its cable and port data from Apple Silicon's port controller, and Intel Macs don't expose it, so the app will show nothing useful.\n\nIt'll stay open if you want to look around, but there's nothing behind it." = "Bu Mac'te Intel işlemci var. WhatCable kablo ve bağlantı noktası verilerini Apple Silicon'un bağlantı noktası denetleyicisinden alır; Intel Mac'ler bunu sunmaz, bu yüzden uygulama işe yarar hiçbir şey göstermeyecek.\n\nBakmak isterseniz açık kalır, ama arkasında hiçbir şey yok.";
 "OK" = "Tamam";
 "Learn more" = "Daha fazla bilgi";
+/* USB device detail rows (downstream device enrichment). Labels for the
+   per-device expander: vendor, serial and USB version. */
+"Vendor" = "Üretici";
+"Serial" = "Seri numarası";
+"USB" = "USB";

--- a/Sources/WhatCable/Resources/uk.lproj/Localizable.strings
+++ b/Sources/WhatCable/Resources/uk.lproj/Localizable.strings
@@ -177,3 +177,8 @@
 "This Mac has an Intel processor. WhatCable gets its cable and port data from Apple Silicon's port controller, and Intel Macs don't expose it, so the app will show nothing useful.\n\nIt'll stay open if you want to look around, but there's nothing behind it." = "У цьому Mac встановлено процесор Intel. WhatCable отримує дані про кабелі та порти від контролера портів Apple Silicon, а Mac з процесором Intel його не надають, тож застосунок не покаже нічого корисного.\n\nВін залишиться відкритим, якщо хочете роздивитися, але за ним нічого немає.";
 "OK" = "ОК";
 "Learn more" = "Докладніше";
+/* USB device detail rows (downstream device enrichment). Labels for the
+   per-device expander: vendor, serial and USB version. */
+"Vendor" = "Виробник";
+"Serial" = "Серійний номер";
+"USB" = "USB";

--- a/Sources/WhatCable/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/WhatCable/Resources/zh-Hans.lproj/Localizable.strings
@@ -178,3 +178,8 @@
 "This Mac has an Intel processor. WhatCable gets its cable and port data from Apple Silicon's port controller, and Intel Macs don't expose it, so the app will show nothing useful.\n\nIt'll stay open if you want to look around, but there's nothing behind it." = "这台 Mac 使用 Intel 处理器。WhatCable 的线缆和端口数据来自 Apple Silicon 的端口控制器，而 Intel Mac 不提供这些数据，因此 App 不会显示任何有用的内容。\n\n如果你想看看，它会保持打开，但背后没有任何数据。";
 "OK" = "好";
 "Learn more" = "了解更多";
+/* USB device detail rows (downstream device enrichment). Labels for the
+   per-device expander: vendor, serial and USB version. */
+"Vendor" = "厂商";
+"Serial" = "序列号";
+"USB" = "USB";

--- a/Sources/WhatCable/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/WhatCable/Resources/zh-Hant.lproj/Localizable.strings
@@ -178,3 +178,8 @@
 "This Mac has an Intel processor. WhatCable gets its cable and port data from Apple Silicon's port controller, and Intel Macs don't expose it, so the app will show nothing useful.\n\nIt'll stay open if you want to look around, but there's nothing behind it." = "這台 Mac 使用 Intel 處理器。WhatCable 的線材與連接埠資料來自 Apple Silicon 的連接埠控制器，但 Intel Mac 不會提供這些資料，因此 App 無法顯示任何有用的資訊。\n\n若您仍想查看介面，App 會繼續保持開啟，但其中沒有任何可用資料。";
 "OK" = "知道了";
 "Learn more" = "了解更多";
+/* USB device detail rows (downstream device enrichment). Labels for the
+   per-device expander: vendor, serial and USB version. */
+"Vendor" = "廠商";
+"Serial" = "序號";
+"USB" = "USB";

--- a/Sources/WhatCable/Views/ContentView.swift
+++ b/Sources/WhatCable/Views/ContentView.swift
@@ -565,7 +565,6 @@ struct OtherUSBDevicesCard: View {
     }
 
     var body: some View {
-        let tree = USBDeviceNode.flatten(USBDeviceNode.buildTree(from: devices))
         VStack(alignment: .leading, spacing: 6) {
             HStack(spacing: 8) {
                 Image(systemName: "cable.connector.horizontal")
@@ -573,11 +572,24 @@ struct OtherUSBDevicesCard: View {
                 Text(title)
                     .scaledFont(.headline, weight: .semibold)
             }
-            ForEach(tree) { node in
-                let prefix = node.depth > 0 ? "\u{21B3} " : "\u{2022} "
-                Text(verbatim: "\(prefix)\(node.device.displayName) - \(node.device.speedLabel)")
-                    .scaledFont(.callout)
-                    .padding(.leading, CGFloat(node.depth) * 16)
+            // A dock fans its devices out across several USB controllers, so
+            // group them by bus to show which ones share one. Nil when there
+            // is only one bus: the flat tree then renders exactly as before.
+            if let groups = USBDeviceNode.groupedByBus(from: devices) {
+                ForEach(groups, id: \.bus) { group in
+                    Text(verbatim: USBDeviceNode.busLabel(group.bus))
+                        .scaledFont(.caption, weight: .semibold)
+                        .foregroundStyle(.secondary)
+                        .padding(.top, 2)
+                    ForEach(USBDeviceNode.flatten(group.roots)) { node in
+                        USBDeviceRow(node: node)
+                            .padding(.leading, 12)
+                    }
+                }
+            } else {
+                ForEach(USBDeviceNode.flatten(USBDeviceNode.buildTree(from: devices))) { node in
+                    USBDeviceRow(node: node)
+                }
             }
             Text(footer)
                 .scaledFont(.caption)
@@ -586,6 +598,67 @@ struct OtherUSBDevicesCard: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(14)
         .background(.quaternary.opacity(0.4), in: RoundedRectangle(cornerRadius: 10))
+    }
+}
+
+/// One device in a downstream USB tree, rendered as an expandable disclosure
+/// row. Collapsed (the default) it shows name and speed, indented by hub depth,
+/// with the DisclosureGroup chevron as the leading affordance (replacing the old
+/// "•" bullet). Expanded it reveals the detail the `USBDevice` model
+/// already carries: vendor (with VID:PID), serial and USB version. Shared by
+/// `OtherUSBDevicesCard` and `PortCard`'s device tree so the two render the
+/// same content. No new data is read here; every value comes off `USBDevice`.
+struct USBDeviceRow: View {
+    let node: USBDeviceNode
+
+    @State private var expanded = false
+    @Environment(\.fontScale) private var fontScale
+
+    private var device: USBDevice { node.device }
+
+    /// The detail rows to show when expanded, as (label, value) pairs. A row is
+    /// included only when its value is present, so an absent serial or power
+    /// figure leaves no empty line.
+    private var detailRows: [(label: String, value: String)] {
+        var rows: [(String, String)] = []
+        rows.append((String(localized: "Vendor", bundle: _appLocalizedBundle), device.vendorDisplay))
+        if let serial = device.serialNumber?.trimmingCharacters(in: .whitespacesAndNewlines), !serial.isEmpty {
+            rows.append((String(localized: "Serial", bundle: _appLocalizedBundle), serial))
+        }
+        if let version = device.usbVersion {
+            rows.append((String(localized: "USB", bundle: _appLocalizedBundle), version))
+        }
+        return rows
+    }
+
+    var body: some View {
+        let name = device.productName ?? String(localized: "Unknown", bundle: _appLocalizedBundle)
+        // No leading bullet: DisclosureGroup draws its own chevron as the row's
+        // leading affordance, so a bullet here would double up. The "↳" on
+        // nested devices stays — it marks "behind a hub", which the chevron and
+        // indentation alone don't convey.
+        let prefix = node.depth > 0 ? "\u{21B3} " : ""
+        DisclosureGroup(isExpanded: $expanded) {
+            VStack(alignment: .leading, spacing: 2) {
+                ForEach(detailRows, id: \.label) { row in
+                    HStack(alignment: .top, spacing: 8) {
+                        Text(row.label)
+                            .scaledFont(.caption)
+                            .foregroundStyle(.secondary)
+                            .frame(width: 70 * fontScale, alignment: .leading)
+                        Text(row.value)
+                            .scaledFont(.caption)
+                            .textSelection(.enabled)
+                        Spacer(minLength: 0)
+                    }
+                }
+            }
+            .padding(.top, 2)
+        } label: {
+            Text(verbatim: "\(prefix)\(name) - \(device.speedLabel)")
+                .scaledFont(.callout)
+        }
+        .padding(.leading, CGFloat(node.depth) * 16)
     }
 }
 
@@ -678,10 +751,7 @@ struct PortCard: View {
                 .scaledFont(.subheadline, weight: .semibold)
                 .foregroundStyle(.secondary)
             ForEach(tree) { node in
-                let prefix = node.depth > 0 ? "\u{21B3} " : "\u{2022} "
-                Text(verbatim: "\(prefix)\(node.device.displayName) - \(node.device.speedLabel)")
-                    .scaledFont(.callout)
-                    .padding(.leading, CGFloat(node.depth) * 16)
+                USBDeviceRow(node: node)
             }
             if let note {
                 Text(note)
@@ -703,14 +773,33 @@ struct PortCard: View {
             Text(title)
                 .scaledFont(.subheadline, weight: .semibold)
                 .foregroundStyle(.secondary)
-            // Offset-keyed: rows are value snapshots rebuilt on every state
-            // change, and two identical monitors would collide on a
-            // label-derived id.
-            ForEach(Array(rows.enumerated()), id: \.offset) { _, row in
-                let prefix = row.depth > 0 ? "\u{21B3} " : "\u{2022} "
-                Text(verbatim: "\(prefix)\(row.label)")
-                    .scaledFont(.callout)
-                    .padding(.leading, CGFloat(row.depth) * 16)
+            // Device rows key on the IOKit entry ID so USBDeviceRow's expanded
+            // state follows its device across a replug that reorders the list.
+            // Offset-keying them would migrate the state to whichever device
+            // landed at that index. Non-device rows (the Thunderbolt root, a
+            // display, a bus header) stay offset-keyed: they hold no state, and
+            // two identical monitors would collide on a label-derived id.
+            let identified = rows.enumerated().map { offset, row in
+                (id: row.device.map { "device-\($0.id)" } ?? "row-\(offset)", row: row)
+            }
+            ForEach(identified, id: \.id) { _, row in
+                // A row carrying its node is a USB device, so it gets the same
+                // expandable detail as the Thunderbolt-tunnelled list. Rows
+                // without one describe the Thunderbolt root, a display, or a
+                // bus header, and stay plain text.
+                if let node = row.device {
+                    // USBDeviceRow already indents by its own hub depth, so
+                    // only the structural depth above that (the Thunderbolt
+                    // root, a bus header) is added here. Applying row.depth
+                    // whole would indent hub children twice.
+                    USBDeviceRow(node: node)
+                        .padding(.leading, CGFloat(max(0, row.depth - node.depth)) * 16)
+                } else {
+                    let prefix = row.depth > 0 ? "\u{21B3} " : "\u{2022} "
+                    Text(verbatim: "\(prefix)\(row.label)")
+                        .scaledFont(.callout)
+                        .padding(.leading, CGFloat(row.depth) * 16)
+                }
             }
         }
         .padding(.leading, 48)

--- a/Sources/WhatCable/Views/ContentView.swift
+++ b/Sources/WhatCable/Views/ContentView.swift
@@ -632,7 +632,7 @@ struct USBDeviceRow: View {
     }
 
     var body: some View {
-        let name = device.productName ?? String(localized: "Unknown", bundle: _appLocalizedBundle)
+        let name = device.displayName
         // No leading bullet: DisclosureGroup draws its own chevron as the row's
         // leading affordance, so a bullet here would double up. The "↳" on
         // nested devices stays — it marks "behind a hub", which the chevron and

--- a/Sources/WhatCableCore/Output/JSONFormatter.swift
+++ b/Sources/WhatCableCore/Output/JSONFormatter.swift
@@ -960,17 +960,35 @@ private struct USBDeviceDTO: Codable {
     let vendorID: Int
     let productID: Int
     let vendorName: String?
+    let serialNumber: String?
+    let usbVersion: String?
     let speed: String
     let locationID: String
     let children: [USBDeviceDTO]?
 
     init(node: USBDeviceNode) {
-        self.name = node.device.productName
-        self.vendorID = Int(node.device.vendorID)
-        self.productID = Int(node.device.productID)
-        self.vendorName = node.device.vendorName
-        self.speed = node.device.speedLabel
-        self.locationID = String(format: "0x%08x", node.device.locationID)
+        let device = node.device
+        self.name = device.productName
+        self.vendorID = Int(device.vendorID)
+        self.productID = Int(device.productID)
+        // Match the UI: device-reported name, else the VID database. Gate the
+        // DB fallback on a real registration so the sentinel sentences
+        // VendorDB.name(for:) returns for VID 0 / 0xFFFF ("No vendor reported",
+        // "No vendor ID assigned …") never leak into this machine-readable
+        // field — downstream consumers parse it, so it stays null when there is
+        // no genuine vendor name (preserving the pre-fallback contract).
+        if let reported = device.vendorName?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !reported.isEmpty {
+            self.vendorName = reported
+        } else if VendorDB.isRegistered(Int(device.vendorID)) {
+            self.vendorName = VendorDB.name(for: Int(device.vendorID))
+        } else {
+            self.vendorName = nil
+        }
+        self.serialNumber = device.serialNumber
+        self.usbVersion = device.usbVersion
+        self.speed = device.speedLabel
+        self.locationID = String(format: "0x%08x", device.locationID)
         self.children = node.children.isEmpty ? nil : node.children.map { USBDeviceDTO(node: $0) }
     }
 }

--- a/Sources/WhatCableCore/Output/TextFormatter.swift
+++ b/Sources/WhatCableCore/Output/TextFormatter.swift
@@ -136,17 +136,33 @@ public enum TextFormatter {
             ? String(localized: "Connected over Thunderbolt", bundle: _coreLocalizedBundle)
             : String(localized: "Other USB devices", bundle: _coreLocalizedBundle)
         out += ANSI.wrap(ANSI.bold, title + ":") + "\n"
-        let tree = USBDeviceNode.flatten(USBDeviceNode.buildTree(from: devices))
-        for node in tree {
-            let indent = String(repeating: "  ", count: node.depth + 1)
-            // displayName folds in the device-reported vendor name, so it is
-            // device-supplied text and still has to go through terminalField.
-            let name = terminalField(node.device.displayName)
-            let prefix = node.depth > 0 ? "\u{21B3}" : ANSI.wrap(ANSI.gray, "\u{2022}")
-            out += "\(indent)\(prefix) \(name) - \(node.device.speedLabel)\n"
+        // A dock fans its devices out across several USB controllers; the
+        // grouping shows which ones share a bus. Nil when there is only one
+        // bus, in which case the tree renders flat exactly as before.
+        if let groups = USBDeviceNode.groupedByBus(from: devices) {
+            for group in groups {
+                out += "  " + ANSI.wrap(ANSI.gray, "\u{2022}") + " "
+                    + ANSI.wrap(ANSI.dim, USBDeviceNode.busLabel(group.bus)) + "\n"
+                for node in USBDeviceNode.flatten(group.roots) {
+                    out += renderTunnelledRow(node, extraIndent: 1)
+                }
+            }
+        } else {
+            for node in USBDeviceNode.flatten(USBDeviceNode.buildTree(from: devices)) {
+                out += renderTunnelledRow(node, extraIndent: 0)
+            }
         }
         out += "  " + ANSI.wrap(ANSI.dim, String(localized: "Reached through a Thunderbolt dock or display, so there's no cable, power, or Thunderbolt data for them.", bundle: _coreLocalizedBundle)) + "\n"
         return out
+    }
+
+    /// One device row in the tunnelled block. `extraIndent` shifts the row
+    /// under a bus header when the devices are grouped by controller.
+    private static func renderTunnelledRow(_ node: USBDeviceNode, extraIndent: Int) -> String {
+        let indent = String(repeating: "  ", count: node.depth + 1 + extraIndent)
+        let name = terminalField(node.device.productName ?? String(localized: "Unknown", bundle: _coreLocalizedBundle))
+        let prefix = node.depth > 0 ? "\u{21B3}" : ANSI.wrap(ANSI.gray, "\u{2022}")
+        return "\(indent)\(prefix) \(name) - \(node.device.speedLabel)\n"
     }
 
     /// Render the internal-hub devices block (issue #348). These are devices

--- a/Sources/WhatCableCore/Output/TextFormatter.swift
+++ b/Sources/WhatCableCore/Output/TextFormatter.swift
@@ -160,7 +160,9 @@ public enum TextFormatter {
     /// under a bus header when the devices are grouped by controller.
     private static func renderTunnelledRow(_ node: USBDeviceNode, extraIndent: Int) -> String {
         let indent = String(repeating: "  ", count: node.depth + 1 + extraIndent)
-        let name = terminalField(node.device.productName ?? String(localized: "Unknown", bundle: _coreLocalizedBundle))
+        // displayName folds in the device-reported vendor name, so it is
+        // device-supplied text and still has to go through terminalField.
+        let name = terminalField(node.device.displayName)
         let prefix = node.depth > 0 ? "\u{21B3}" : ANSI.wrap(ANSI.gray, "\u{2022}")
         return "\(indent)\(prefix) \(name) - \(node.device.speedLabel)\n"
     }

--- a/Sources/WhatCableCore/Resources/de.lproj/Localizable.strings
+++ b/Sources/WhatCableCore/Resources/de.lproj/Localizable.strings
@@ -566,3 +566,6 @@
 "USB-IF certified. Manufacturer: %@" = "USB-IF-zertifiziert. Hersteller: %1$@";
 "The cable's declared maker matches the USB-IF certificate" = "Der angegebene Hersteller des Kabels stimmt mit dem USB-IF-Zertifikat überein";
 "Carries a USB-IF certification ID (%@) that isn't in the public registry" = "Enthält eine USB-IF-Zertifizierungs-ID (%1$@), die nicht im öffentlichen Register steht";
+
+/* Header for a USB controller group in the connected-devices tree. */
+"USB bus" = "USB-Bus";

--- a/Sources/WhatCableCore/Resources/en.lproj/Localizable.strings
+++ b/Sources/WhatCableCore/Resources/en.lproj/Localizable.strings
@@ -571,3 +571,6 @@
 "USB-IF certified. Manufacturer: %@" = "USB-IF certified. Manufacturer: %1$@";
 "The cable's declared maker matches the USB-IF certificate" = "The cable's declared maker matches the USB-IF certificate";
 "Carries a USB-IF certification ID (%@) that isn't in the public registry" = "Carries a USB-IF certification ID (%1$@) that isn't in the public registry";
+
+/* Header for a USB controller group in the connected-devices tree. */
+"USB bus" = "USB bus";

--- a/Sources/WhatCableCore/Resources/es.lproj/Localizable.strings
+++ b/Sources/WhatCableCore/Resources/es.lproj/Localizable.strings
@@ -566,3 +566,6 @@
 "USB-IF certified. Manufacturer: %@" = "Certificado por USB-IF. Fabricante: %1$@";
 "The cable's declared maker matches the USB-IF certificate" = "El fabricante declarado del cable coincide con el certificado USB-IF";
 "Carries a USB-IF certification ID (%@) that isn't in the public registry" = "Incluye un ID de certificación USB-IF (%1$@) que no está en el registro público";
+
+/* Header for a USB controller group in the connected-devices tree. */
+"USB bus" = "Bus USB";

--- a/Sources/WhatCableCore/Resources/fr.lproj/Localizable.strings
+++ b/Sources/WhatCableCore/Resources/fr.lproj/Localizable.strings
@@ -566,3 +566,6 @@
 "USB-IF certified. Manufacturer: %@" = "Certifié USB-IF. Fabricant: %1$@";
 "The cable's declared maker matches the USB-IF certificate" = "Le fabricant déclaré du câble correspond au certificat USB-IF";
 "Carries a USB-IF certification ID (%@) that isn't in the public registry" = "Porte un identifiant de certification USB-IF (%1$@) absent du registre public";
+
+/* Header for a USB controller group in the connected-devices tree. */
+"USB bus" = "Bus USB";

--- a/Sources/WhatCableCore/Resources/hi.lproj/Localizable.strings
+++ b/Sources/WhatCableCore/Resources/hi.lproj/Localizable.strings
@@ -565,3 +565,6 @@
 "USB-IF certified. Manufacturer: %@" = "USB-IF प्रमाणित। निर्माता: %1$@";
 "The cable's declared maker matches the USB-IF certificate" = "केबल का घोषित निर्माता USB-IF प्रमाणपत्र से मेल खाता है";
 "Carries a USB-IF certification ID (%@) that isn't in the public registry" = "इसमें एक USB-IF प्रमाणन आईडी (%1$@) है जो सार्वजनिक रजिस्ट्री में नहीं है";
+
+/* Header for a USB controller group in the connected-devices tree. */
+"USB bus" = "USB बस";

--- a/Sources/WhatCableCore/Resources/hy.lproj/Localizable.strings
+++ b/Sources/WhatCableCore/Resources/hy.lproj/Localizable.strings
@@ -566,3 +566,6 @@
 "USB-IF certified. Manufacturer: %@" = "USB-IF հավաստագրված։ Արտադրող: %1$@";
 "The cable's declared maker matches the USB-IF certificate" = "Մալուխի հայտարարված արտադրողը համընկնում է USB-IF վկայականի հետ";
 "Carries a USB-IF certification ID (%@) that isn't in the public registry" = "Կրում է USB-IF հավաստագրման ID (%1$@), որը հանրային ռեգիստրում չկա";
+
+/* Header for a USB controller group in the connected-devices tree. */
+"USB bus" = "USB մագիստրալ";

--- a/Sources/WhatCableCore/Resources/it.lproj/Localizable.strings
+++ b/Sources/WhatCableCore/Resources/it.lproj/Localizable.strings
@@ -567,3 +567,6 @@
 "USB-IF certified. Manufacturer: %@" = "Certificato USB-IF. Produttore: %1$@";
 "The cable's declared maker matches the USB-IF certificate" = "Il produttore dichiarato del cavo corrisponde al certificato USB-IF";
 "Carries a USB-IF certification ID (%@) that isn't in the public registry" = "Riporta un ID certificazione USB-IF (%1$@) non presente nel registro pubblico";
+
+/* Header for a USB controller group in the connected-devices tree. */
+"USB bus" = "Bus USB";

--- a/Sources/WhatCableCore/Resources/ja.lproj/Localizable.strings
+++ b/Sources/WhatCableCore/Resources/ja.lproj/Localizable.strings
@@ -567,3 +567,6 @@
 "USB-IF certified. Manufacturer: %@" = "USB-IF認証済み。 製造元: %1$@";
 "The cable's declared maker matches the USB-IF certificate" = "ケーブルが申告する製造元がUSB-IF認証と一致します";
 "Carries a USB-IF certification ID (%@) that isn't in the public registry" = "公開レジストリに存在しないUSB-IF認証ID (%1$@) を保持しています";
+
+/* Header for a USB controller group in the connected-devices tree. */
+"USB bus" = "USBバス";

--- a/Sources/WhatCableCore/Resources/ko.lproj/Localizable.strings
+++ b/Sources/WhatCableCore/Resources/ko.lproj/Localizable.strings
@@ -565,3 +565,6 @@
 "USB-IF certified. Manufacturer: %@" = "USB-IF 인증됨. 제조사: %1$@";
 "The cable's declared maker matches the USB-IF certificate" = "케이블이 보고한 제조사가 USB-IF 인증서와 일치합니다";
 "Carries a USB-IF certification ID (%@) that isn't in the public registry" = "공개 레지스트리에 없는 USB-IF 인증 ID(%1$@)를 포함합니다";
+
+/* Header for a USB controller group in the connected-devices tree. */
+"USB bus" = "USB 버스";

--- a/Sources/WhatCableCore/Resources/lv.lproj/Localizable.strings
+++ b/Sources/WhatCableCore/Resources/lv.lproj/Localizable.strings
@@ -565,3 +565,6 @@
 "USB-IF certified. Manufacturer: %@" = "USB-IF sertificēts. Ražotājs: %1$@";
 "The cable's declared maker matches the USB-IF certificate" = "Kabeļa norādītais ražotājs atbilst USB-IF sertifikātam";
 "Carries a USB-IF certification ID (%@) that isn't in the public registry" = "Satur USB-IF sertifikācijas ID (%1$@), kas nav publiskajā reģistrā";
+
+/* Header for a USB controller group in the connected-devices tree. */
+"USB bus" = "USB kopne";

--- a/Sources/WhatCableCore/Resources/nb.lproj/Localizable.strings
+++ b/Sources/WhatCableCore/Resources/nb.lproj/Localizable.strings
@@ -566,3 +566,6 @@
 "USB-IF certified. Manufacturer: %@" = "USB-IF-sertifisert. Produsent: %1$@";
 "The cable's declared maker matches the USB-IF certificate" = "Kabelens oppgitte produsent samsvarer med USB-IF-sertifikatet";
 "Carries a USB-IF certification ID (%@) that isn't in the public registry" = "Har en USB-IF-sertifiserings-ID (%1$@) som ikke finnes i det offentlige registeret";
+
+/* Header for a USB controller group in the connected-devices tree. */
+"USB bus" = "USB-buss";

--- a/Sources/WhatCableCore/Resources/nl.lproj/Localizable.strings
+++ b/Sources/WhatCableCore/Resources/nl.lproj/Localizable.strings
@@ -565,3 +565,6 @@
 "USB-IF certified. Manufacturer: %@" = "USB-IF-gecertificeerd. Fabrikant: %1$@";
 "The cable's declared maker matches the USB-IF certificate" = "De opgegeven fabrikant van de kabel komt overeen met het USB-IF-certificaat";
 "Carries a USB-IF certification ID (%@) that isn't in the public registry" = "Bevat een USB-IF-certificerings-ID (%1$@) die niet in het openbare register staat";
+
+/* Header for a USB controller group in the connected-devices tree. */
+"USB bus" = "USB-bus";

--- a/Sources/WhatCableCore/Resources/pl.lproj/Localizable.strings
+++ b/Sources/WhatCableCore/Resources/pl.lproj/Localizable.strings
@@ -565,3 +565,6 @@
 "USB-IF certified. Manufacturer: %@" = "Certyfikat USB-IF. Producent: %1$@";
 "The cable's declared maker matches the USB-IF certificate" = "Zadeklarowany producent kabla zgadza się z certyfikatem USB-IF";
 "Carries a USB-IF certification ID (%@) that isn't in the public registry" = "Zawiera identyfikator certyfikacji USB-IF (%1$@), którego nie ma w publicznym rejestrze";
+
+/* Header for a USB controller group in the connected-devices tree. */
+"USB bus" = "Magistrala USB";

--- a/Sources/WhatCableCore/Resources/pt-BR.lproj/Localizable.strings
+++ b/Sources/WhatCableCore/Resources/pt-BR.lproj/Localizable.strings
@@ -565,3 +565,6 @@
 "USB-IF certified. Manufacturer: %@" = "Certificado USB-IF. Fabricante: %1$@";
 "The cable's declared maker matches the USB-IF certificate" = "O fabricante declarado do cabo corresponde ao certificado USB-IF";
 "Carries a USB-IF certification ID (%@) that isn't in the public registry" = "Contém um ID de certificação USB-IF (%1$@) que não está no registro público";
+
+/* Header for a USB controller group in the connected-devices tree. */
+"USB bus" = "Barramento USB";

--- a/Sources/WhatCableCore/Resources/ru.lproj/Localizable.strings
+++ b/Sources/WhatCableCore/Resources/ru.lproj/Localizable.strings
@@ -565,3 +565,6 @@
 "USB-IF certified. Manufacturer: %@" = "Сертифицировано USB-IF. Производитель: %1$@";
 "The cable's declared maker matches the USB-IF certificate" = "Заявленный производитель кабеля совпадает с сертификатом USB-IF";
 "Carries a USB-IF certification ID (%@) that isn't in the public registry" = "Содержит идентификатор сертификации USB-IF (%1$@), которого нет в публичном реестре";
+
+/* Header for a USB controller group in the connected-devices tree. */
+"USB bus" = "Шина USB";

--- a/Sources/WhatCableCore/Resources/tr.lproj/Localizable.strings
+++ b/Sources/WhatCableCore/Resources/tr.lproj/Localizable.strings
@@ -565,3 +565,6 @@
 "USB-IF certified. Manufacturer: %@" = "USB-IF sertifikalı. Üretici: %1$@";
 "The cable's declared maker matches the USB-IF certificate" = "Kablonun bildirdiği üretici USB-IF sertifikasıyla eşleşiyor";
 "Carries a USB-IF certification ID (%@) that isn't in the public registry" = "Genel kayıtta bulunmayan bir USB-IF sertifika kimliği (%1$@) taşıyor";
+
+/* Header for a USB controller group in the connected-devices tree. */
+"USB bus" = "USB veri yolu";

--- a/Sources/WhatCableCore/Resources/uk.lproj/Localizable.strings
+++ b/Sources/WhatCableCore/Resources/uk.lproj/Localizable.strings
@@ -565,3 +565,6 @@
 "USB-IF certified. Manufacturer: %@" = "Сертифіковано USB-IF. Виробник: %1$@";
 "The cable's declared maker matches the USB-IF certificate" = "Заявлений виробник кабелю збігається із сертифікатом USB-IF";
 "Carries a USB-IF certification ID (%@) that isn't in the public registry" = "Містить ідентифікатор сертифікації USB-IF (%1$@), якого немає в публічному реєстрі";
+
+/* Header for a USB controller group in the connected-devices tree. */
+"USB bus" = "Шина USB";

--- a/Sources/WhatCableCore/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/WhatCableCore/Resources/zh-Hans.lproj/Localizable.strings
@@ -566,3 +566,6 @@
 "USB-IF certified. Manufacturer: %@" = "USB-IF 认证。 制造商: %1$@";
 "The cable's declared maker matches the USB-IF certificate" = "线缆声明的制造商与 USB-IF 认证一致";
 "Carries a USB-IF certification ID (%@) that isn't in the public registry" = "含有一个不在公开注册表中的 USB-IF 认证 ID (%1$@)";
+
+/* Header for a USB controller group in the connected-devices tree. */
+"USB bus" = "USB 总线";

--- a/Sources/WhatCableCore/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/WhatCableCore/Resources/zh-Hant.lproj/Localizable.strings
@@ -565,3 +565,6 @@
 "USB-IF certified. Manufacturer: %@" = "已通過 USB-IF 認證。製造商：%1$@";
 "The cable's declared maker matches the USB-IF certificate" = "線材宣告的製造商與 USB-IF 認證資料相符";
 "Carries a USB-IF certification ID (%@) that isn't in the public registry" = "具有未收錄於公開登錄資料庫的 USB-IF 認證 ID (%1$@)";
+
+/* Header for a USB controller group in the connected-devices tree. */
+"USB bus" = "USB 匯流排";

--- a/Sources/WhatCableCore/USB/ConnectedDeviceTree.swift
+++ b/Sources/WhatCableCore/USB/ConnectedDeviceTree.swift
@@ -22,13 +22,29 @@ import Foundation
 public enum ConnectedDeviceTree {
     /// One rendered row: a complete display label plus its indent depth.
     /// The renderers add only their own bullet/arrow prefix and indentation.
+    ///
+    /// `device` carries the node a device row was built from, so a renderer
+    /// that can show more than a label (the app's expandable row) has the
+    /// model to hand. It is `nil` on rows that describe something other than a
+    /// USB device: the Thunderbolt root, a display, a bus header. Text
+    /// renderers ignore it and draw `label` exactly as before.
     public struct Row: Equatable {
         public let label: String
         public let depth: Int
+        public let device: USBDeviceNode?
 
-        public init(label: String, depth: Int) {
+        public init(label: String, depth: Int, device: USBDeviceNode? = nil) {
             self.label = label
             self.depth = depth
+            self.device = device
+        }
+
+        /// Equality is on what the row draws: its label and depth. `device` is
+        /// the model the label was derived from, carried for renderers that can
+        /// show more than text, so two rows that render identically compare
+        /// equal whether or not the node came along.
+        public static func == (lhs: Row, rhs: Row) -> Bool {
+            lhs.label == rhs.label && lhs.depth == rhs.depth
         }
     }
 
@@ -49,12 +65,7 @@ public enum ConnectedDeviceTree {
         thunderboltSwitches: [IOThunderboltSwitch],
         displayPorts: [IOPortTransportStateDisplayPort]
     ) -> [Row] {
-        let deviceRows = USBDeviceNode.flatten(USBDeviceNode.buildTree(from: devices)).map { node in
-            Row(
-                label: "\(node.device.displayName) - \(node.device.speedLabel)",
-                depth: node.depth
-            )
-        }
+        let deviceRows = deviceRowsGroupedByBus(devices)
 
         guard let hostRoot = thunderboltHostRoot(port: port, switches: thunderboltSwitches),
               let root = thunderboltRootRow(hostRoot: hostRoot, switches: thunderboltSwitches)
@@ -100,8 +111,37 @@ public enum ConnectedDeviceTree {
                 rows.append(Row(label: displayLabel(for: dp), depth: 1))
             }
         }
-        rows.append(contentsOf: deviceRows.map { Row(label: $0.label, depth: $0.depth + 1) })
+        // Shift the device rows one level to sit under the Thunderbolt root,
+        // carrying `device` across. Dropping it here would make the expandable
+        // detail work everywhere except behind a dock, which is where the
+        // device tree is longest and the detail is most wanted.
+        rows.append(contentsOf: deviceRows.map {
+            Row(label: $0.label, depth: $0.depth + 1, device: $0.device)
+        })
         return rows
+    }
+
+    /// Device rows, grouped under a header per USB controller when the port
+    /// has more than one. Falls back to the plain tree otherwise, so the
+    /// single-bus case and every directly-attached port render as before.
+    private static func deviceRowsGroupedByBus(_ devices: [USBDevice]) -> [Row] {
+        guard let groups = USBDeviceNode.groupedByBus(from: devices) else {
+            return USBDeviceNode.flatten(USBDeviceNode.buildTree(from: devices)).map {
+                Row(label: deviceLabel(for: $0), depth: $0.depth, device: $0)
+            }
+        }
+        return groups.flatMap { group in
+            [Row(label: USBDeviceNode.busLabel(group.bus), depth: 0)]
+                + USBDeviceNode.flatten(group.roots).map {
+                    Row(label: deviceLabel(for: $0), depth: $0.depth + 1, device: $0)
+                }
+        }
+    }
+
+    private static func deviceLabel(for node: USBDeviceNode) -> String {
+        let name = node.device.productName
+            ?? String(localized: "Unknown", bundle: _coreLocalizedBundle)
+        return "\(name) - \(node.device.speedLabel)"
     }
 
     /// The host root switch for this port, if it maps to one. Shared by

--- a/Sources/WhatCableCore/USB/ConnectedDeviceTree.swift
+++ b/Sources/WhatCableCore/USB/ConnectedDeviceTree.swift
@@ -138,10 +138,11 @@ public enum ConnectedDeviceTree {
         }
     }
 
+    /// One device row's label. Names go through `USBDevice.displayName` so
+    /// this tree, the CLI and the dashboard can never disagree about how a
+    /// device is named; it also carries the localized "Unknown" fallback.
     private static func deviceLabel(for node: USBDeviceNode) -> String {
-        let name = node.device.productName
-            ?? String(localized: "Unknown", bundle: _coreLocalizedBundle)
-        return "\(name) - \(node.device.speedLabel)"
+        "\(node.device.displayName) - \(node.device.speedLabel)"
     }
 
     /// The host root switch for this port, if it maps to one. Shared by

--- a/Sources/WhatCableCore/USB/USBDevice.swift
+++ b/Sources/WhatCableCore/USB/USBDevice.swift
@@ -155,6 +155,36 @@ public struct USBDevice: Identifiable, Hashable {
         return String(localized: "Billboard device present", bundle: bundle)
     }
 
+    /// Vendor label for the detail view: the device-reported `USB Vendor Name`
+    /// when present, else the bundled USB-IF database name for the VID, always
+    /// suffixed with `0xVID:0xPID`. Falls back to bare hex when no name is
+    /// known. Mirrors `VendorDB.label(for:)` so the vendor wording can't drift
+    /// from the cable view, and adds the PID the per-device view wants.
+    ///
+    /// Only the two sentinel VIDs are excluded from the database fallback. For
+    /// VID 0 and 0xFFFF, `VendorDB.name(for:)` returns explanatory sentences
+    /// ("No vendor reported", "No vendor ID assigned …") written for the cable
+    /// view, which would read here as a vendor literally called "No vendor
+    /// reported".
+    ///
+    /// Deliberately not gated on `VendorDB.isRegistered`, which is narrower
+    /// than this view wants: by its own definition it excludes community
+    /// `usb.ids` entries, which resolve to perfectly good vendor names. The
+    /// JSON `vendorName` field does use that stricter gate, because it is a
+    /// machine-readable field where "present" should mean a real registration.
+    /// Here the goal is to show the user the best name available.
+    public var vendorDisplay: String {
+        let ids = String(format: "0x%04X:0x%04X", vendorID, productID)
+        let name = vendorName?.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let name, !name.isEmpty {
+            return "\(name) (\(ids))"
+        }
+        if vendorID != 0, vendorID != 0xFFFF, let dbName = VendorDB.name(for: Int(vendorID)) {
+            return "\(dbName) (\(ids))"
+        }
+        return ids
+    }
+
     public var speedLabel: String {
         // IOUSBHostDevice "Device Speed" enum values
         switch speedRaw {
@@ -329,6 +359,56 @@ public struct USBDeviceNode: Identifiable {
             result.append(contentsOf: flatten(node.children))
         }
         return result
+    }
+
+    /// One group of top-level devices sharing a USB controller.
+    public struct BusGroup {
+        /// Upper byte of the controller's `locationID`, e.g. `0x21`.
+        public let bus: Int
+        /// Top-level nodes on this controller, each with its hub children.
+        public let roots: [USBDeviceNode]
+    }
+
+    /// Top-level nodes grouped by the USB controller they enumerate on, in
+    /// first-seen order.
+    ///
+    /// A dock spreads its downstream devices across the several USB
+    /// controllers inside it, and which devices share a bus is the difference
+    /// between diagnosing a bandwidth problem and guessing at it.
+    ///
+    /// Returns `nil` when the devices span fewer than two buses, or when any
+    /// device has no `busIndex`: callers render their plain tree then. A lone
+    /// group header would add a level of indentation and no information, and a
+    /// partial grouping would imply a device sits on a bus we could not read.
+    ///
+    /// The completeness check covers every device in the tree, not just the
+    /// roots. A hub child with no readable bus index would otherwise render
+    /// under its parent's header, silently claiming a controller assignment
+    /// nothing established.
+    ///
+    /// Grouping itself is by top-level node, because everything behind a hub
+    /// reaches the Mac through the same controller as the hub itself.
+    public static func groupedByBus(from devices: [USBDevice]) -> [BusGroup]? {
+        let tree = buildTree(from: devices)
+        guard flatten(tree).allSatisfy({ $0.device.busIndex != nil }) else { return nil }
+
+        var order: [Int] = []
+        var byBus: [Int: [USBDeviceNode]] = [:]
+        for root in tree {
+            guard let bus = root.device.busIndex else { return nil }
+            if byBus[bus] == nil { order.append(bus) }
+            byBus[bus, default: []].append(root)
+        }
+        guard order.count > 1 else { return nil }
+        return order.map { BusGroup(bus: $0, roots: byBus[$0] ?? []) }
+    }
+
+    /// "USB bus 0x21", the header shown above a `BusGroup`. The hex identifier
+    /// is kept as-is: it is raw registry truth and the join key people use
+    /// when comparing against `system_profiler` output.
+    public static func busLabel(_ bus: Int) -> String {
+        let word = String(localized: "USB bus", bundle: _coreLocalizedBundle)
+        return "\(word) \(String(format: "0x%02X", bus))"
     }
 
     /// A flat list of (name, speed, depth) tuples for the device tree rooted

--- a/Tests/WhatCableCoreTests/ConnectedDeviceTreeTests.swift
+++ b/Tests/WhatCableCoreTests/ConnectedDeviceTreeTests.swift
@@ -744,6 +744,12 @@ struct ConnectedDeviceTreeCorpusTests {
                 speedRaw: value("Device Speed").flatMap { UInt8($0) },
                 busPowerMA: nil,
                 currentMA: nil,
+                // Upper byte of the locationID is the USB controller index,
+                // exactly how USBWatcher derives it live. Without this every
+                // corpus device would have a nil busIndex, grouping would be
+                // suppressed on every folder, and the sweep would silently
+                // stop covering the grouping path.
+                busIndex: Int(loc >> 24),
                 deviceClass: value("bDeviceClass").flatMap { UInt8($0) },
                 rawProperties: [:]
             )
@@ -771,6 +777,8 @@ struct ConnectedDeviceTreeCorpusTests {
         let folders = (try? FileManager.default.contentsOfDirectory(atPath: Self.probeRoot.path))?.sorted() ?? []
         var swept = 0
         var devicesSeen = 0
+        var withBusIndex = 0
+        var grouped = 0
         for folder in folders {
             let url = Self.probeRoot.appendingPathComponent(folder).appendingPathComponent("38_usb_device_tree.json")
             guard FileManager.default.fileExists(atPath: url.path),
@@ -787,23 +795,22 @@ struct ConnectedDeviceTreeCorpusTests {
                 devices: devices, port: Self.port(),
                 thunderboltSwitches: [], displayPorts: []
             )
-            let expected = USBDeviceNode.flatten(USBDeviceNode.buildTree(from: devices))
-            try #require(rows.count == expected.count, "\(folder): row count diverged from the USB tree")
-            for (row, node) in zip(rows, expected) {
-                // Validates that ConnectedDeviceTree reproduces USBDeviceNode's
-                // tree on every real topology (same devices, order, depth,
-                // routing) AND that the name matches an INDEPENDENT
-                // reimplementation of the naming rule (`referenceName`, below),
-                // not `displayName` itself. Building the expected label from the
-                // property under test would be circular: a regression in
-                // `displayName` would change both sides and the sweep would
-                // still pass. Re-deriving names here means a naming regression
-                // diverges on real corpus data and fails the sweep, per the
-                // project's "a check that reads the same source as the thing it
-                // checks is not a check" rule.
-                let expectedName = Self.referenceName(product: node.device.productName, vendor: node.device.vendorName)
-                let expectedLabel = "\(expectedName) - \(node.device.speedLabel)"
-                #expect(row == ConnectedDeviceTree.Row(label: expectedLabel, depth: node.depth),
+            if devices.contains(where: { $0.busIndex != nil }) { withBusIndex += 1 }
+            let expected = Self.expectedRows(devices)
+            if expected.contains(where: { $0.depth == 0 && $0.label.hasPrefix("USB bus") }) { grouped += 1 }
+
+            // Validates that ConnectedDeviceTree reproduces the expected tree on
+            // every real topology (same devices, order, depth, routing, and bus
+            // grouping) against an INDEPENDENT reimplementation of both rules
+            // (`expectedRows` / `referenceName` below), never against the
+            // production properties themselves. Building the expectation from
+            // `displayName` or `groupedByBus` would be circular: a regression
+            // would change both sides and the sweep would still pass. Per the
+            // project's "a check that reads the same source as the thing it
+            // checks is not a check" rule.
+            try #require(rows.count == expected.count, "\(folder): row count diverged from the expected tree")
+            for (row, want) in zip(rows, expected) {
+                #expect(row == ConnectedDeviceTree.Row(label: want.label, depth: want.depth),
                     "\(folder): row diverged from the canonical rendering: \(row.label)")
             }
         }
@@ -812,6 +819,58 @@ struct ConnectedDeviceTreeCorpusTests {
         // If this fires at 0, the sweep is vacuous, not passing.
         #expect(swept >= 1, "Sweep ran on zero folders; corpus probes missing")
         #expect(devicesSeen > 0)
+        // Non-vacuity floors for the bus grouping specifically. The parser
+        // derives busIndex from the locationID, so every corpus device has one;
+        // without these, a parser that silently stopped setting busIndex would
+        // send every folder down the ungrouped path and the sweep would still
+        // pass while testing nothing about grouping. Real multi-controller
+        // machines exist in the corpus, so `grouped` must not be zero either.
+        if swept > 1 {
+            #expect(withBusIndex == swept, "every corpus folder should carry a bus index")
+            #expect(grouped > 0, "no corpus machine exercised the bus grouping path")
+        }
+    }
+
+    /// Independent reimplementation of the rows `ConnectedDeviceTree.rows`
+    /// should produce for the no-Thunderbolt path, covering both the bus
+    /// grouping rule and the naming rule. Deliberately does not call
+    /// `USBDeviceNode.groupedByBus` or `USBDevice.displayName`; it re-derives
+    /// both so a regression in either diverges here on real corpus data.
+    ///
+    /// The grouping rule restated: group the top-level devices under one header
+    /// per USB controller, but only when every device in the tree has a readable
+    /// bus index and the top-level devices span more than one controller. A lone
+    /// header adds indentation and no information; a partial grouping would
+    /// imply a device sits on a controller nothing established.
+    private static func expectedRows(_ devices: [USBDevice]) -> [(label: String, depth: Int)] {
+        let tree = USBDeviceNode.buildTree(from: devices)
+        func label(_ node: USBDeviceNode) -> String {
+            let name = referenceName(product: node.device.productName, vendor: node.device.vendorName)
+            return "\(name) - \(node.device.speedLabel)"
+        }
+
+        var busOrder: [Int] = []
+        for root in tree {
+            guard let bus = root.device.busIndex else { continue }
+            if !busOrder.contains(bus) { busOrder.append(bus) }
+        }
+        let everyDeviceHasABus = USBDeviceNode.flatten(tree).allSatisfy { $0.device.busIndex != nil }
+
+        guard everyDeviceHasABus, busOrder.count > 1 else {
+            return USBDeviceNode.flatten(tree).map { (label: label($0), depth: $0.depth) }
+        }
+
+        var out: [(label: String, depth: Int)] = []
+        for bus in busOrder {
+            let word = String(localized: "USB bus", bundle: _coreLocalizedBundle)
+            out.append((label: "\(word) \(String(format: "0x%02X", bus))", depth: 0))
+            for root in tree where root.device.busIndex == bus {
+                for node in USBDeviceNode.flatten([root]) {
+                    out.append((label: label(node), depth: node.depth + 1))
+                }
+            }
+        }
+        return out
     }
 
     /// Independent reimplementation of `USBDevice.displayName`'s naming rule,

--- a/Tests/WhatCableCoreTests/ConnectedDeviceTreeTests.swift
+++ b/Tests/WhatCableCoreTests/ConnectedDeviceTreeTests.swift
@@ -541,6 +541,153 @@ struct ConnectedDeviceTreeTests {
         try #require(rows.count == 1, "Root row alone: no display rows to suffix")
         #expect(rows[0].depth == 0)
     }
+
+    // MARK: - Grouping by USB controller
+
+    /// Same shape as `device`, plus the controller bus the device enumerates
+    /// on. A dock exposes several controllers, and that is what the grouping
+    /// keys off.
+    private func busDevice(
+        id: UInt64,
+        locationID: UInt32,
+        name: String?,
+        speedRaw: UInt8,
+        busIndex: Int
+    ) -> USBDevice {
+        USBDevice(
+            id: id,
+            locationID: locationID,
+            vendorID: 0x1234,
+            productID: 0x5678,
+            vendorName: nil,
+            productName: name,
+            serialNumber: nil,
+            usbVersion: nil,
+            speedRaw: speedRaw,
+            busPowerMA: nil,
+            currentMA: nil,
+            busIndex: busIndex,
+            rawProperties: [:]
+        )
+    }
+
+    @Test("Two USB controllers: devices group under a bus header each")
+    func twoBusesGroup() throws {
+        let devices = [
+            busDevice(id: 1, locationID: 0x2020_0000, name: "Audio", speedRaw: 1, busIndex: 0x20),
+            busDevice(id: 2, locationID: 0x2070_0000, name: "Extreme Pro", speedRaw: 4, busIndex: 0x20),
+            busDevice(id: 3, locationID: 0x2120_0000, name: "Shure MV7", speedRaw: 1, busIndex: 0x21),
+        ]
+        let rows = ConnectedDeviceTree.rows(
+            devices: devices, port: makePort(),
+            thunderboltSwitches: [], displayPorts: []
+        )
+        let labels = rows.map { $0.label }
+        #expect(labels.contains("USB bus 0x20"))
+        #expect(labels.contains("USB bus 0x21"))
+
+        // Headers sit at depth 0 with their devices indented one level under.
+        let header20 = try #require(rows.firstIndex { $0.label == "USB bus 0x20" })
+        #expect(rows[header20].depth == 0)
+        #expect(rows[header20 + 1].depth == 1)
+        #expect(rows[header20 + 1].label.hasPrefix("Audio"))
+
+        // Every device still appears exactly once.
+        #expect(labels.filter { $0.hasPrefix("Shure MV7") }.count == 1)
+        #expect(rows.count == 5)
+    }
+
+    @Test("A device with no readable bus suppresses grouping entirely")
+    func unknownBusSuppressesGrouping() {
+        // Partial grouping would imply the ungrouped device sits on a bus we
+        // could not read, so the whole set falls back to the plain tree.
+        let devices = [
+            busDevice(id: 1, locationID: 0x2020_0000, name: "Audio", speedRaw: 1, busIndex: 0x20),
+            device(id: 2, locationID: 0x2120_0000, name: "Shure MV7", speedRaw: 1),
+        ]
+        let rows = ConnectedDeviceTree.rows(
+            devices: devices, port: makePort(),
+            thunderboltSwitches: [], displayPorts: []
+        )
+        #expect(!rows.contains { $0.label.hasPrefix("USB bus") })
+        #expect(rows.count == 2)
+    }
+
+    @Test("A hub child with no readable bus suppresses grouping")
+    func unknownBusOnHubChildSuppressesGrouping() {
+        // The child hangs off the hub by locationID, so it is a descendant
+        // rather than a root. Checking roots alone would let it render under
+        // its parent's header, claiming a controller nothing established.
+        let devices = [
+            busDevice(id: 1, locationID: 0x2010_0000, name: "USB3 HUB", speedRaw: 4, busIndex: 0x20),
+            device(id: 2, locationID: 0x2011_0000, name: "LAN", speedRaw: 3),
+            busDevice(id: 3, locationID: 0x2120_0000, name: "Shure MV7", speedRaw: 1, busIndex: 0x21),
+        ]
+        let rows = ConnectedDeviceTree.rows(
+            devices: devices, port: makePort(),
+            thunderboltSwitches: [], displayPorts: []
+        )
+        #expect(!rows.contains { $0.label.hasPrefix("USB bus") })
+        #expect(rows.count == 3)
+    }
+
+    @Test("Device rows carry their node so the app can expand them")
+    func deviceRowsCarryTheirNode() throws {
+        let rows = ConnectedDeviceTree.rows(
+            devices: hubAndChild, port: makePort(),
+            thunderboltSwitches: [], displayPorts: []
+        )
+        try #require(rows.count == 2)
+        #expect(rows.allSatisfy { $0.device != nil })
+        #expect(rows[0].device?.device.productName == "USB3 HUB")
+    }
+
+    @Test("Devices under a Thunderbolt root keep their node")
+    func devicesUnderDockKeepTheirNode() throws {
+        // The dock path re-maps rows to shift depth. Dropping the node there
+        // would leave the expander working everywhere except behind a dock.
+        let rows = ConnectedDeviceTree.rows(
+            devices: hubAndChild, port: makePort(),
+            thunderboltSwitches: [hostRoot(), dockSwitch()], displayPorts: []
+        )
+        let root = try #require(rows.first)
+        #expect(root.device == nil, "the Thunderbolt root row is not a USB device")
+
+        let deviceRows = rows.dropFirst()
+        try #require(deviceRows.count == 2)
+        #expect(deviceRows.allSatisfy { $0.device != nil })
+        #expect(deviceRows.allSatisfy { $0.depth >= 1 }, "shifted under the root")
+    }
+
+    @Test("Bus header rows carry no node")
+    func busHeaderRowsCarryNoNode() throws {
+        let devices = [
+            busDevice(id: 1, locationID: 0x2020_0000, name: "Audio", speedRaw: 1, busIndex: 0x20),
+            busDevice(id: 2, locationID: 0x2120_0000, name: "Shure MV7", speedRaw: 1, busIndex: 0x21),
+        ]
+        let rows = ConnectedDeviceTree.rows(
+            devices: devices, port: makePort(),
+            thunderboltSwitches: [], displayPorts: []
+        )
+        let header = try #require(rows.first { $0.label.hasPrefix("USB bus") })
+        #expect(header.device == nil)
+    }
+
+    @Test("One USB controller: no bus header, rows unchanged")
+    func oneBusIsNotGrouped() {
+        let devices = [
+            busDevice(id: 1, locationID: 0x2020_0000, name: "Audio", speedRaw: 1, busIndex: 0x20),
+            busDevice(id: 2, locationID: 0x2070_0000, name: "Extreme Pro", speedRaw: 4, busIndex: 0x20),
+        ]
+        let rows = ConnectedDeviceTree.rows(
+            devices: devices, port: makePort(),
+            thunderboltSwitches: [], displayPorts: []
+        )
+        // A lone header would add indentation and no information.
+        #expect(!rows.contains { $0.label.hasPrefix("USB bus") })
+        #expect(rows.count == 2)
+        #expect(rows.allSatisfy { $0.depth == 0 })
+    }
 }
 
 /// Corpus-replay sweep: with no Thunderbolt switches, `ConnectedDeviceTree`

--- a/Tests/WhatCableCoreTests/JSONFormatterTests.swift
+++ b/Tests/WhatCableCoreTests/JSONFormatterTests.swift
@@ -120,6 +120,63 @@ struct JSONFormatterTests {
         #expect(devices.first?["name"] as? String == hardwareName)
     }
 
+    @Test("USB device DTO carries serial and USB version detail fields")
+    func usbDeviceDetailFields() throws {
+        let drive = USBDevice(
+            id: 7, locationID: 0x2011_0000, vendorID: 0x0BC2, productID: 0x2322,
+            vendorName: "Seagate", productName: "Expansion",
+            serialNumber: "NA8XYZ12", usbVersion: "3.10",
+            speedRaw: 4, busPowerMA: nil, currentMA: nil,
+            isThunderboltTunnelled: true,
+            rawProperties: [:]
+        )
+        let json = parse(try JSONFormatter.render(
+            ports: [makePort()], sources: [], identities: [], showRaw: false,
+            usbDevices: [drive]))
+        let dev = (json["otherUSBDevices"] as? [String: Any])?["devices"] as? [[String: Any]]
+        let first = try #require(dev?.first)
+        #expect(first["serialNumber"] as? String == "NA8XYZ12")
+        #expect(first["usbVersion"] as? String == "3.10")
+    }
+
+    @Test("USB device DTO vendorName falls back to the VID database")
+    func usbDeviceVendorFallback() throws {
+        // Device reports no USB Vendor Name; 0x05AC resolves to Apple in the DB.
+        let dev = USBDevice(
+            id: 8, locationID: 0x2011_0000, vendorID: 0x05AC, productID: 0x12A8,
+            vendorName: nil, productName: "Unnamed",
+            serialNumber: nil, usbVersion: nil, speedRaw: 4,
+            busPowerMA: nil, currentMA: nil, isThunderboltTunnelled: true,
+            rawProperties: [:]
+        )
+        let json = parse(try JSONFormatter.render(
+            ports: [makePort()], sources: [], identities: [], showRaw: false,
+            usbDevices: [dev]))
+        let devices = (json["otherUSBDevices"] as? [String: Any])?["devices"] as? [[String: Any]]
+        #expect(devices?.first?["vendorName"] as? String == "Apple")
+    }
+
+    @Test("USB device DTO vendorName stays null for unregistered VID 0 (no sentinel prose)")
+    func usbDeviceVendorNoSentinel() throws {
+        // VID 0 makes VendorDB.name(for:) return the human sentence
+        // "No vendor reported". That display prose must NOT leak into the
+        // machine-readable JSON field, which downstream consumers parse.
+        let dev = USBDevice(
+            id: 9, locationID: 0x2011_0000, vendorID: 0, productID: 0,
+            vendorName: nil, productName: "Mystery",
+            serialNumber: nil, usbVersion: nil, speedRaw: 2,
+            busPowerMA: nil, currentMA: nil, isThunderboltTunnelled: true,
+            rawProperties: [:]
+        )
+        let json = parse(try JSONFormatter.render(
+            ports: [makePort()], sources: [], identities: [], showRaw: false,
+            usbDevices: [dev]))
+        let devices = (json["otherUSBDevices"] as? [String: Any])?["devices"] as? [[String: Any]]
+        let first = try #require(devices?.first)
+        // Field is absent (encoded as nil → omitted), not the sentence.
+        #expect(first["vendorName"] == nil)
+    }
+
     // MARK: - Built-in USB ports (issue #348)
 
     @Test("builtInUSBDevices appears only on a desktop Mac with front-port devices")

--- a/Tests/WhatCableCoreTests/USBDeviceDetailTests.swift
+++ b/Tests/WhatCableCoreTests/USBDeviceDetailTests.swift
@@ -1,0 +1,75 @@
+import Foundation
+import Testing
+@testable import WhatCableCore
+
+@Suite("USB device detail display helpers")
+struct USBDeviceDetailTests {
+
+    private func device(
+        vendorID: UInt16 = 0,
+        productID: UInt16 = 0,
+        vendorName: String? = nil,
+        serialNumber: String? = nil,
+        usbVersion: String? = nil
+    ) -> USBDevice {
+        USBDevice(
+            id: 1, locationID: 0x0100_0000, vendorID: vendorID, productID: productID,
+            vendorName: vendorName, productName: "Widget", serialNumber: serialNumber,
+            usbVersion: usbVersion, speedRaw: nil, busPowerMA: nil, currentMA: nil,
+            rawProperties: [:]
+        )
+    }
+
+    // MARK: - vendorDisplay
+
+    @Test("vendorDisplay prefers the device-reported vendor name and appends VID:PID")
+    func vendorDisplayUsesReportedName() {
+        let d = device(vendorID: 0x05AC, productID: 0x12A8, vendorName: "Apple Inc.")
+        #expect(d.vendorDisplay == "Apple Inc. (0x05AC:0x12A8)")
+    }
+
+    @Test("vendorDisplay falls back to the VID database when the device reports no name")
+    func vendorDisplayFallsBackToDB() {
+        // 0x05AC is Apple in the bundled USB-IF list.
+        let d = device(vendorID: 0x05AC, productID: 0x12A8, vendorName: nil)
+        #expect(d.vendorDisplay == "Apple (0x05AC:0x12A8)")
+    }
+
+    @Test("vendorDisplay shows bare hex when no name is available anywhere")
+    func vendorDisplayBareHex() {
+        // Sanity-check the precondition: this VID must be unknown to the DB for
+        // the test to mean anything. 0xF00D is absent from the bundled list.
+        #expect(VendorDB.name(for: 0xF00D) == nil)
+        let d = device(vendorID: 0xF00D, productID: 0x0002, vendorName: nil)
+        #expect(d.vendorDisplay == "0xF00D:0x0002")
+    }
+
+    @Test("vendorDisplay keeps community usb.ids names that are not USB-IF registrations")
+    func vendorDisplayKeepsCommunityNames() throws {
+        // VendorDB.isRegistered is narrower than name(for:) by design: it
+        // excludes community usb.ids entries. Gating the fallback on it would
+        // drop good vendor names and show bare hex instead.
+        let vid = 0x01B6
+        try #require(VendorDB.name(for: vid) != nil, "precondition: VID resolves to a name")
+        try #require(!VendorDB.isRegistered(vid), "precondition: VID is not a USB-IF registration")
+
+        let d = device(vendorID: UInt16(vid), productID: 0x0002, vendorName: nil)
+        #expect(d.vendorDisplay.hasSuffix("(0x01B6:0x0002)"))
+        #expect(d.vendorDisplay != "0x01B6:0x0002", "the community name should be shown")
+    }
+
+    @Test("vendorDisplay never renders the VID 0 sentinel as a vendor name")
+    func vendorDisplayVIDZeroStaysBareHex() {
+        // VendorDB.name(for: 0) returns the cable view's explanatory sentence,
+        // which would read here as a vendor literally called "No vendor
+        // reported".
+        let d = device(vendorID: 0, productID: 0x1234, vendorName: nil)
+        #expect(d.vendorDisplay == "0x0000:0x1234")
+    }
+
+    @Test("vendorDisplay never renders the 0xFFFF sentinel as a vendor name")
+    func vendorDisplayVIDFFFFStaysBareHex() {
+        let d = device(vendorID: 0xFFFF, productID: 0x1234, vendorName: nil)
+        #expect(d.vendorDisplay == "0xFFFF:0x1234")
+    }
+}


### PR DESCRIPTION
Closes #480.

## Motivation

I run a CalDigit TS3 Plus with seven USB devices behind it. WhatCable finds all seven, then renders them as one flat list, and that list hides the two things I keep needing: which devices share a controller, and what each device actually is.

On my dock the seven devices span four USB controllers. Three of them share `0x21`, and the others sit one per controller. When a device runs slower than I expect, the speed is already on screen, but whether it is contending for a shared bus is not. That is the gap this closes.

The detail is already there. `USBDevice` parses the vendor, serial number and USB version on every device and displays none of it, and the bus index is on the model too. This is a presentation gap, not a data-acquisition one.

## Summary

- Group the downstream device list by the USB controller each device enumerates on, when a port has more than one. Grouping is by top-level node, since everything behind a hub reaches the Mac through the same controller as the hub.
- Make each device row an expandable disclosure row showing vendor with VID:PID, serial number, and USB version. Collapsed by default.
- Add `serialNumber` and `usbVersion` to `USBDeviceDTO`, so `--json` consumers can identify a specific unit.
- Apply the existing `VendorDB` fallback to the JSON `vendorName`, gated on a real USB-IF registration so the sentinel strings for VID 0 and 0xFFFF never leak into a machine-readable field. It stays `null` when there is no genuine vendor name.
- Add the new UI label keys across all 19 locales.

Three deliberate constraints:

**No new IOKit reads.** Every value shown was already parsed and thrown away.

**Grouping only appears with two or more controllers.** A single group header would add a level of indentation and no information, so single-controller ports and every directly-attached port render exactly as before. If any device has an unreadable bus index, grouping is suppressed for the whole set rather than showing a partial grouping that implies the rest are complete.

**No declared power, no Alt Mode detail.** Your closing note on #354 says the per-device panel with power requested and available ships in Pro's Cable Diagnostics, so I left it out rather than duplicate it in the free tier. Alt Mode detail is out for the same reason, next to Pro's DP Alt Mode feature. Both are implemented on separate branches if you want them somewhere.

## Test plan

- [x] `swift build` clean, including the GUI target
- [x] 3 new unit tests: grouping with two controllers, no grouping with one, grouping suppressed when a bus index is missing
- [x] 6 new unit tests for the detail fields: `vendorDisplay` with reported name, DB fallback and bare-hex fallback; JSON serial and USB version; JSON `vendorName` null for an unregistered VID
- [x] All 22 existing `ConnectedDeviceTreeTests` pass unedited, which is the check that the grouping did not disturb the shipping tree
- [x] `Localisation key + format-specifier parity` passes across all 19 locales
- [x] Verified against real hardware, M-series laptop on macOS 27, CalDigit TS3 Plus with 7 devices across 4 controllers

Test suite goes from 1072 to 1081 tests with no change in the pre-existing failure count on my clone (42, all from `research/` corpus files that are not in the repo).

Before:

```
Connected over Thunderbolt:
  • CalDigit Thunderbolt 3 Audio - Full Speed (12 Mbps)
  • Extreme Pro 55AF - Super Speed (5 Gbps)
  • Shure MV7 - Full Speed (12 Mbps)
  • USB Capture HDMI - Super Speed (5 Gbps)
  • Card Reader - Super Speed (5 Gbps)
  • Extreme 55AE - Super Speed (5 Gbps)
  • PSSD T7 - High Speed (480 Mbps)
```

After:

```
Connected over Thunderbolt:
  • USB bus 0x20
    • CalDigit Thunderbolt 3 Audio - Full Speed (12 Mbps)
    • Extreme Pro 55AF - Super Speed (5 Gbps)
  • USB bus 0x21
    • Shure MV7 - Full Speed (12 Mbps)
    • USB Capture HDMI - Super Speed (5 Gbps)
    • Card Reader - Super Speed (5 Gbps)
  • USB bus 0x22
    • Extreme 55AE - Super Speed (5 Gbps)
  • USB bus 0x23
    • PSSD T7 - High Speed (480 Mbps)
```

## Open questions

The bus label is `USB bus 0x21`, the controller's `locationID` upper byte. It is raw registry truth and it matches what people see in `system_profiler`, but it is not friendly. The IOKit class of the controller is available on the same walk, so the row could read `ASMedia USB controller` instead. That needs one new field on `USBDevice` and a small watcher change, so I left it out of this PR. Happy to add it if you would prefer the friendlier label.

Authored-By: [Jesse Robbins](https://jesserobbins.com) (@jesserobbins)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * USB device rows are now expandable, showing vendor (VID:PID), trimmed serial (when available), and USB version.
  * Connected USB devices can be organized under “USB bus” headers when multiple buses are detected.
  * JSON export now includes serial numbers and USB versions, with improved vendor name reporting.
* **Localization**
  * Added translations for USB detail labels (Vendor, Serial, USB) and the “USB bus” header.
* **Bug Fixes**
  * Improved vendor display when names are missing/blank, avoiding misleading placeholder text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->