### PR TITLE
Traditional Chinese language update

### DIFF
--- a/Sources/WhatCable/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/WhatCable/Resources/zh-Hant.lproj/Localizable.strings
@@ -183,4 +183,4 @@
 "Vendor" = "廠商";
 "Serial" = "序號";
 "USB" = "USB";
-"Hide hubs" = "隱藏集線器";
+"Hide hubs" = "隱藏 Hub";

--- a/Sources/WhatCable/Resources/zh-Hant.lproj/Localizable.stringsdict
+++ b/Sources/WhatCable/Resources/zh-Hant.lproj/Localizable.stringsdict
@@ -45,9 +45,9 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>lld</string>
 			<key>one</key>
-			<string>顯示 %lld 個集線器</string>
+			<string>顯示 %lld 個 Hub</string>
 			<key>other</key>
-			<string>顯示 %lld 個集線器</string>
+			<string>顯示 %lld 個 Hub</string>
 		</dict>
 	</dict>
 </dict>

--- a/Sources/WhatCableCore/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/WhatCableCore/Resources/zh-Hant.lproj/Localizable.strings
@@ -569,7 +569,7 @@
 
 /* Header for a USB controller group in the connected-devices tree. */
 "USB bus" = "USB 匯流排";
-"USB device, data blocked" = "USB 裝置，資料已封鎖";
-"macOS is holding data back until you approve the accessory." = "在你允許此配件之前，macOS 會阻擋資料傳輸。";
-"Video is working. macOS is holding data back until you approve the accessory." = "影像正常。在你允許此配件之前，macOS 會阻擋資料傳輸。";
-"USB device, data blocked · %lldW charger" = "USB 裝置，資料已封鎖 · %lldW 充電器";
+"USB device, data blocked" = "USB 裝置，資料傳輸已封鎖";
+"macOS is holding data back until you approve the accessory." = "在您允許此配件連接前，macOS 會封鎖資料傳輸。";
+"Video is working. macOS is holding data back until you approve the accessory." = "影像傳輸正常。在您允許此配件連接前，macOS 會封鎖資料傳輸。";
+"USB device, data blocked · %lldW charger" = "USB 裝置，資料傳輸已封鎖 · %lldW 充電器";

--- a/Sources/WhatCableCore/Resources/zh-Hant.lproj/Localizable.stringsdict
+++ b/Sources/WhatCableCore/Resources/zh-Hant.lproj/Localizable.stringsdict
@@ -13,9 +13,9 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>lld</string>
 			<key>one</key>
-			<string>經由 %lld 個集線器</string>
+			<string>透過 %lld 個 Hub</string>
 			<key>other</key>
-			<string>經由 %lld 個集線器</string>
+			<string>透過 %lld 個 Hub</string>
 		</dict>
 	</dict>
 </dict>


### PR DESCRIPTION
Refine translations for newly introduced strings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Updated Traditional Chinese terminology to use “Hub” consistently instead of “集線器.”
  * Clarified Traditional Chinese accessory-security messages with more formal and precise wording.
  * Improved descriptions of blocked USB data and permitted video transmission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->