### PR TITLE
fix(charging): honour battery-full/charge-hold state in the macLimit diagnostic

### DIFF
--- a/Sources/WhatCableCore/Power/ChargingDiagnostic.swift
+++ b/Sources/WhatCableCore/Power/ChargingDiagnostic.swift
@@ -144,8 +144,22 @@ extension ChargingDiagnostic {
         } else if let n = negotiatedW, n < chargerMaxW - max(5, chargerMaxW / 10),
                   (cableMaxW.map { n < $0 - max(5, $0 / 10) } ?? true) {
             self.bottleneck = .macLimit(negotiatedW: n, chargerW: chargerMaxW, cableW: cableMaxW)
-            self.summary = String(localized: "Charging at \(n)W (charger can do up to \(chargerMaxW)W)", bundle: _coreLocalizedBundle)
-            self.detail = String(localized: "Both the charger and cable can do more, but the Mac is currently asking for less. This is normal once the battery is mostly full, or when the system is idle.", bundle: _coreLocalizedBundle)
+            // The Mac negotiated below the charger ceiling, but it may still not
+            // be actively charging (battery full / charge on hold). Surface those
+            // states with the same summaries the `.fine` arm uses, instead of
+            // implying active charging with "Charging at XW". The bottleneck
+            // stays `.macLimit`; only the human-facing copy branches on battery
+            // state, and these reuse the existing localised keys verbatim.
+            if batteryFullyCharged == true {
+                self.summary = String(localized: "Battery full, not charging", bundle: _coreLocalizedBundle)
+                self.detail = String(localized: "Charger and cable are fine. The Mac will draw up to \(n)W when it needs to.", bundle: _coreLocalizedBundle)
+            } else if batteryIsCharging == false {
+                self.summary = String(localized: "Plugged in, charging on hold", bundle: _coreLocalizedBundle)
+                self.detail = String(localized: "Charger and cable are fine. macOS has paused charging for now, usually a battery charge limit or Optimized Battery Charging. The Mac still draws power from the charger.", bundle: _coreLocalizedBundle)
+            } else {
+                self.summary = String(localized: "Charging at \(n)W (charger can do up to \(chargerMaxW)W)", bundle: _coreLocalizedBundle)
+                self.detail = String(localized: "Both the charger and cable can do more, but the Mac is currently asking for less. This is normal once the battery is mostly full, or when the system is idle.", bundle: _coreLocalizedBundle)
+            }
         } else if let n = negotiatedW {
             self.bottleneck = .fine(negotiatedW: n)
             if batteryFullyCharged == true {

--- a/Tests/WhatCableCoreTests/ChargingDiagnosticTests.swift
+++ b/Tests/WhatCableCoreTests/ChargingDiagnosticTests.swift
@@ -215,6 +215,75 @@ struct ChargingDiagnosticTests {
         #expect(diag!.isWarning == false)
     }
 
+    // MARK: - macLimit + battery state (the intersection)
+
+    @Test("macLimit with a full battery reports 'Battery full', not 'Charging at XW'")
+    func macLimitWithFullBatterySaysNotCharging() {
+        // 100W charger, Mac negotiated only 30W (would be .macLimit), but the
+        // battery is full. The banner must say so, not imply active charging
+        // with "Charging at 30W" — the same rule the `.fine` arm already applies.
+        let diag = ChargingDiagnostic(
+            port: port,
+            sources: [usbPD(maxW: 100, winningW: 30)],
+            identities: [],
+            batteryFullyCharged: true
+        )
+        guard case .macLimit(let n, let chargerW, let cableW) = diag?.bottleneck else {
+            Issue.record("expected .macLimit, got \(String(describing: diag?.bottleneck))")
+            return
+        }
+        #expect(n == 30)
+        #expect(chargerW == 100)
+        #expect(cableW == nil)
+        // The bottleneck stays .macLimit; only the copy reflects battery state.
+        #expect(diag!.isWarning == false)
+        #expect(diag!.summary == "Battery full, not charging")
+        #expect(diag!.detail == "Charger and cable are fine. The Mac will draw up to 30W when it needs to.")
+    }
+
+    @Test("macLimit with charging on hold reports 'charging on hold', not 'Charging at XW'")
+    func macLimitWithChargeHoldSaysOnHold() {
+        // 100W charger, Mac negotiated only 30W (.macLimit), but charging is on
+        // hold (charge limit / Optimized Battery Charging). The banner must
+        // reflect the hold, mirroring the `.fine` arm — not "Charging at 30W".
+        // An adapter is supplied because `onBattery` is true when
+        // batteryIsCharging == false with no adapter (see chargeHoldIsNotAWarning).
+        let diag = ChargingDiagnostic(
+            port: port,
+            sources: [usbPD(maxW: 100, winningW: 30)],
+            identities: [],
+            adapter: AdapterInfo(watts: 100, isCharging: nil, source: "AC"),
+            batteryIsCharging: false
+        )
+        guard case .macLimit(let n, _, _) = diag?.bottleneck else {
+            Issue.record("expected .macLimit, got \(String(describing: diag?.bottleneck))")
+            return
+        }
+        #expect(n == 30)
+        #expect(diag!.isWarning == false)
+        #expect(diag!.summary == "Plugged in, charging on hold")
+        #expect(diag!.detail == "Charger and cable are fine. macOS has paused charging for now, usually a battery charge limit or Optimized Battery Charging. The Mac still draws power from the charger.")
+    }
+
+    @Test("macLimit while actively charging keeps the 'Charging at XW' summary")
+    func macLimitWithActiveChargingReportsNegotiatedWatts() {
+        // 100W charger, Mac negotiated 30W, battery charging normally / state
+        // unknown. The legitimate macLimit summary is unchanged by the fix.
+        let diag = ChargingDiagnostic(
+            port: port,
+            sources: [usbPD(maxW: 100, winningW: 30)],
+            identities: []
+        )
+        guard case .macLimit(let n, let chargerW, _) = diag?.bottleneck else {
+            Issue.record("expected .macLimit, got \(String(describing: diag?.bottleneck))")
+            return
+        }
+        #expect(n == 30)
+        #expect(chargerW == 100)
+        #expect(diag!.isWarning == false)
+        #expect(diag!.summary == "Charging at 30W (charger can do up to 100W)")
+    }
+
     @Test("Everything matched")
     func everythingMatched() {
         // 96W charger + 100W cable + 96W winning -> .fine


### PR DESCRIPTION
## Summary
- `ChargingDiagnostic` now reports **"Battery full, not charging"** /
  **"Plugged in, charging on hold"** (the same summaries the `.fine` arm uses)
  when the Mac has negotiated a PDO below the charger ceiling **and** the
  battery is full or charging is on hold — instead of **"Charging at XW
  (charger can do up to YW)"**, which implied active charging.
- The `Bottleneck` case stays `.macLimit`; `isWarning` stays `false`. No new
  localised strings — the existing `.fine`-arm keys are reused verbatim.

## Root cause
The `.macLimit` arm of the suspicion chain (`ChargingDiagnostic.swift`) checks
`negotiatedW < chargerMaxW - max(5, chargerMaxW/10)` and assigned its
`summary`/`detail` **without consulting `batteryFullyCharged` /
`batteryIsCharging`**. Only the next arm (`.fine`) consulted battery state, so
the intersection *battery-state set AND negotiated-below-max* fell into
`.macLimit` and showed "Charging at XW" even when the Mac was full / on hold.
It was latent because every existing battery-state test sets
`winningW == maxW` (→ `.fine`); the lone `.macLimit` test left battery-state at
`nil`.

## Changes
- **`Sources/WhatCableCore/Power/ChargingDiagnostic.swift`** — in the `.macLimit`
  arm, branch on `batteryFullyCharged` / `batteryIsCharging` before assigning
  copy; reuse the `.fine`-arm `String(localized:)` keys unchanged. Arm order,
  the threshold, the enum case, and `isWarning` are untouched.
- **`Tests/WhatCableCoreTests/ChargingDiagnosticTests.swift`** — 3 regression
  tests for the `macLimit × battery-state` intersection (full, on-hold, and the
  unchanged actively-charging path).

## Test plan
Verified on **MacBook Pro (Mac16,8), Apple M4 Pro, macOS 26.6**, Swift 6.3.1.
- [x] `swift test --filter ChargingDiagnosticTests` → 56/56 pass (new tests
  fail on `main` with `summary → "Charging at 30W…"`, pass after the fix)
- [x] `swift build` → all products build
- [x] `swift test` → `Localisation` + `Charging Diagnostic` suites pass; the
  only failing suites are pre-existing corpus sweeps (missing
  `research/customer-probes/corpus.jsonl` in this checkout), identical with and
  without this change
- [x] `python3 scripts/check-localisation.py` → no new keys (all reported items
  are pre-existing `KNOWN_MISSING` entries for the proprietary Plugins subtree)
- [ ] Optional: confirm the on-device banner on a Mac that holds a low PDO at
  100% (no such capture available headlessly)
