### PR TITLE
fix(display): count EDID detailed-timing borders in preferredRefreshHz

### DIFF
--- a/Sources/WhatCableCore/Display/EDIDInfo.swift
+++ b/Sources/WhatCableCore/Display/EDIDInfo.swift
@@ -104,8 +104,15 @@ public struct EDIDInfo: Hashable, Sendable {
             let hBlank  = Int(bytes[off + 3]) | ((Int(bytes[off + 4]) & 0x0F) << 8)
             let vActive = Int(bytes[off + 5]) | ((Int(bytes[off + 7]) >> 4) << 8)
             let vBlank  = Int(bytes[off + 6]) | ((Int(bytes[off + 7]) & 0x0F) << 8)
-            let hTotal = hActive + hBlank
-            let vTotal = vActive + vBlank
+            // Per-side borders (EDID 1.4 detailed-timing bytes +15/+16) frame
+            // the image on BOTH sides, so a full line/column carries 2x each.
+            // They are active pixels/lines the pixel clock still has to scan, so
+            // omitting them shrinks the totals and inflates the computed refresh
+            // for any descriptor that declares a non-zero border.
+            let hBorder = Int(bytes[off + 15])
+            let vBorder = Int(bytes[off + 16])
+            let hTotal = hActive + hBlank + 2 * hBorder
+            let vTotal = vActive + vBlank + 2 * vBorder
             width = hActive
             height = vActive
             pixelClockHz = clockHz

--- a/Tests/WhatCableCoreTests/EDIDInfoTests.swift
+++ b/Tests/WhatCableCoreTests/EDIDInfoTests.swift
@@ -167,4 +167,85 @@ struct EDIDInfoTests {
         // The name is truncated to nothing before the bad byte, so it should be nil.
         #expect(edid.monitorName == nil)
     }
+
+    // MARK: - Detailed-timing border bytes and the refresh rate
+
+    /// Build a minimal 128-byte EDID 1.4 base block carrying a single
+    /// detailed-timing descriptor in the first descriptor slot (offset 54, the
+    /// preferred-timing slot) with the supplied active area, blanking, and
+    /// per-side borders. Every other byte is zero apart from the fixed 8-byte
+    /// header and a correct block checksum. It lets the border math be exercised
+    /// on a hand-computed timing, in isolation from a real capture's confounding
+    /// fields (sync, image size, range limits).
+    static func syntheticEDID(
+        clock10kHz: Int,
+        hActive: Int, hBlank: Int,
+        vActive: Int, vBlank: Int,
+        hBorder: Int, vBorder: Int
+    ) -> [UInt8] {
+        var bytes = [UInt8](repeating: 0, count: 128)
+        // Fixed EDID header: 00 FF FF FF FF FF FF 00.
+        bytes[0] = 0x00
+        for i in 1...6 { bytes[i] = 0xFF }
+        bytes[7] = 0x00
+        bytes[18] = 1  // EDID structure version
+        bytes[19] = 4  // revision 4 (EDID 1.4)
+
+        let off = 54 // first detailed-timing descriptor = the preferred timing
+        bytes[off]      = UInt8(truncatingIfNeeded: clock10kHz)
+        bytes[off + 1]  = UInt8(truncatingIfNeeded: clock10kHz >> 8)
+        bytes[off + 2]  = UInt8(truncatingIfNeeded: hActive)
+        bytes[off + 3]  = UInt8(truncatingIfNeeded: hBlank)
+        bytes[off + 4]  = UInt8(truncatingIfNeeded: ((hActive >> 8) << 4) | (hBlank >> 8))
+        bytes[off + 5]  = UInt8(truncatingIfNeeded: vActive)
+        bytes[off + 6]  = UInt8(truncatingIfNeeded: vBlank)
+        bytes[off + 7]  = UInt8(truncatingIfNeeded: ((vActive >> 8) << 4) | (vBlank >> 8))
+        // Per the EDID 1.4 detailed-timing layout, bytes +15/+16 are the
+        // per-side horizontal/vertical borders. Each side of the image carries
+        // that many pixels/lines, so a full frame includes 2x each.
+        bytes[off + 15] = UInt8(truncatingIfNeeded: hBorder)
+        bytes[off + 16] = UInt8(truncatingIfNeeded: vBorder)
+
+        // EDID block checksum: byte 127 makes the 128-byte sum a multiple of 256.
+        var sum = 0
+        for b in bytes[0..<127] { sum += Int(b) }
+        bytes[127] = UInt8(truncatingIfNeeded: 256 - sum)
+        return bytes
+    }
+
+    @Test("Preferred refresh is 60 Hz for a borderless 1080p timing")
+    func controlTimingWithoutBorders() throws {
+        // 1920x1080 at a 148.5 MHz pixel clock: a 2200x1125 frame is exactly
+        // 60.00 Hz. No borders, so this is the anchor the bordered case is
+        // compared against.
+        let edid = try #require(EDIDInfo(Data(Self.syntheticEDID(
+            clock10kHz: 14850,
+            hActive: 1920, hBlank: 280,
+            vActive: 1080, vBlank: 45,
+            hBorder: 0, vBorder: 0))))
+        #expect(edid.preferredWidth == 1920)
+        #expect(edid.preferredHeight == 1080)
+        #expect(edid.preferredRefreshHz == 60)
+    }
+
+    @Test("Preferred refresh drops when the detailed timing declares borders")
+    func borderedTimingLowerRefresh() throws {
+        // Same 1920x1080 active area and 148.5 MHz clock as the control, but
+        // with a 20-pixel horizontal border on each side and a 5-line vertical
+        // border on each side. Those border pixels/lines are part of every
+        // frame, so the totals grow to 2240x1135 and the refresh falls:
+        // 148,500,000 / (2240 * 1135) = 58.37 Hz -> 58 Hz. Before the border fix
+        // the totals ignored the borders (2200x1125) and the mode read as 60 Hz,
+        // i.e. too high — exactly the regression this test pins down.
+        let edid = try #require(EDIDInfo(Data(Self.syntheticEDID(
+            clock10kHz: 14850,
+            hActive: 1920, hBlank: 280,
+            vActive: 1080, vBlank: 45,
+            hBorder: 20, vBorder: 5))))
+        // The addressable image (the resolution the monitor runs at) is
+        // unchanged: borders are black bars around the image, not part of it.
+        #expect(edid.preferredWidth == 1920)
+        #expect(edid.preferredHeight == 1080)
+        #expect(edid.preferredRefreshHz == 58)
+    }
 }


### PR DESCRIPTION
# fix(display): count EDID detailed-timing borders in preferredRefreshHz

## Summary

`EDIDInfo.preferredRefreshHz` reported a refresh rate that was **too high** for any monitor
whose first detailed-timing descriptor declares non-zero horizontal/vertical borders, because
the frame total it divided the pixel clock by omitted the border pixels/lines. The borders
are part of every frame the pixel clock scans, so leaving them out shrank the denominator and
inflated the Hz.

- Reads the per-side border bytes from the EDID 1.4 detailed-timing descriptor and adds `2 ×`
  each (both sides) to the horizontal/vertical totals used by the refresh formula.
- Only `preferredRefreshHz` changes. `preferredWidth`/`preferredHeight` (the addressable
  resolution the monitor runs at) are unchanged — borders are black bars around the image, not
  part of the resolution, and `DisplayDiagnostic` computes throughput over the addressable
  pixels.
- For every borderless descriptor (border bytes = 0) the new math is a no-op, so existing
  golden samples are bit-for-bit unchanged.

## Root cause

In `Sources/WhatCableCore/Display/EDIDInfo.swift`, the detailed-timing parse built the refresh
denominator from active area + blanking only:

```swift
let hTotal = hActive + hBlank
let vTotal = vActive + vBlank
```

The per-side **border** bytes — descriptor offset **+15** (horizontal) and **+16** (vertical)
per the EDID 1.4 detailed-timing layout — were never read. Each border applies to **both**
sides of the image, so a full frame carries `2 ×` each; the pixel clock still has to scan
them. Omitting them made `hTotal * vTotal` too small and the reported refresh too high.

Concrete: a 1920×1080 @ 148.5 MHz timing with a 20 px horizontal border and a 5 line vertical
border per side has a real frame total of `2240 × 1135` → **58 Hz**, but HEAD reported
`2200 × 1125` → **60 Hz**.

## Changes

- `Sources/WhatCableCore/Display/EDIDInfo.swift` — read the border bytes at descriptor `+15`/`+16`
  and include `2 × hBorder` / `2 × vBorder` in the totals:
  ```swift
  let hBorder = Int(bytes[off + 15])
  let vBorder = Int(bytes[off + 16])
  let hTotal = hActive + hBlank + 2 * hBorder
  let vTotal = vActive + vBlank + 2 * vBorder
  ```
- `Tests/WhatCableCoreTests/EDIDInfoTests.swift` — a `syntheticEDID(...)` helper that builds a
  minimal 128-byte EDID 1.4 base block carrying one detailed timing, plus two tests: a
  borderless 1080p control (anchors **60 Hz**) and the same timing with borders (asserts
  **58 Hz**, and that `preferredWidth/Height` are unchanged). RED at HEAD, GREEN after the fix.

No other EDID field, the descriptor-selection logic, or any other path is touched. No
localisation (`.strings`) changes.

## Test plan

Headless pure-decode change; `swift test` is the gate (no Swift CI on Actions, so the local run
is the contract). On this checkout the corpus-sweep tests need `research/dumps/**` and
`probes/**` data that isn't in the worktree, so ~100 of them fail on clean `main` too — the
bar is **0 NEW failures**.

- [x] `swift test --filter EDIDInfo` — the new bordered test is RED on clean HEAD
      (`preferredRefreshHz → 60 == 58`), GREEN after the fix; all existing EDID tests stay green.
- [x] `swift test` (full) — **baseline 1538 tests / 100 issues → after 1540 tests / 100 issues**;
      the failing-issue set is byte-identical before/after, the +2 delta is exactly the two new
      passing tests. 0 new failures.
- [x] Verified the existing golden samples are unaffected by recomputation: Lenovo G34w-10
      (`g34wBaseBlock`) and LG UltraFine 4K (`lgUltraFineHex`) both have border bytes `+15`/`+16`
      = `0x00`, so both stay exactly 60 Hz.
- [ ] Real-hardware confirm on a monitor whose preferred detailed timing declares non-zero
      borders (none available locally; the regression is pinned by the deterministic decode test).

## Notes for review

- The border bytes are at descriptor offset **+15/+16**, not +14/+15. The off-by-one trap is
  byte **+11** (a sync high-bits byte), which places image size at +12/+13/+14 and the borders
  at +15/+16. Cross-checked against the two real captured EDIDs in the test suite: their image
  sizes decode to the panels' true physical dimensions only under this layout, and both are
  borderless at +15/+16 — so a `+14/+15` reading would have broken both real monitors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved refresh-rate calculations for displays with horizontal or vertical borders.
  * Reported active resolutions remain unchanged while timing totals and calculated refresh rates are now more accurate.

* **Tests**
  * Added coverage for borderless timings and timings with display borders to verify correct refresh-rate results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->