### PR TITLE
Traditional Chinese language update

### DIFF
--- a/Sources/WhatCable/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/WhatCable/Resources/zh-Hant.lproj/Localizable.strings
@@ -98,10 +98,10 @@
 "Privacy" = "隱私權";
 "Pro" = "Pro";
 "Proceed" = "繼續";
-"Raw IOKit registry properties, a list of the driver classes present on your Mac, plus your macOS version and chip type. This is data macOS already exposes on your Mac." = "Raw IOKit 登錄屬性、您的 Mac 上現有的驅動程式類別清單，以及您的 macOS 版本與晶片類型。這些也是 macOS 本身可提供的資料。";
+"Raw IOKit registry properties, a list of the driver classes present on your Mac, plus your macOS version and chip type. This is data macOS already exposes on your Mac." = "Raw IOKit 登錄屬性、您的 Mac 上現有的驅動程式類別清單，以及您的 macOS 版本與晶片類型。這些都是 macOS 已在您的 Mac 上提供的資料。";
 "What happens" = "會發生什麼";
 "What is collected" = "會收集哪些資料";
-"WhatCable runs %lld IOKit probes that read hardware data your Mac already publishes. The results are sent to a secure server to help improve cable and port detection." = "WhatCable 會執行 %lld 項 IOKit 探測，讀取您的 Mac 本身可提供的硬體資料。結果會傳送至安全伺服器，以協助改善線材與連接埠偵測。";
+"WhatCable runs %lld IOKit probes that read hardware data your Mac already publishes. The results are sent to a secure server to help improve cable and port detection." = "WhatCable 會執行 %lld 項 IOKit 探測，讀取您的 Mac 已提供的硬體資料。結果會傳送至安全伺服器，以協助改善線材與連接埠偵測。";
 "Your machine's hardware UUID is hashed with SHA-256 before sending. No names, accounts, your Mac's serial number, or personal data are collected or stored." = "裝置的硬體 UUID 會在傳送前經過 SHA-256 雜湊處理。不會收集或儲存您的姓名、帳號、Mac 序號或任何個人資料。";
 
 /* Negotiation diagnostics + Pro UX (PR #55). English; non-English to be refined by the community translation flow. */

--- a/Sources/WhatCable/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/WhatCable/Resources/zh-Hant.lproj/Localizable.strings
@@ -9,7 +9,7 @@
 "Active cable electronics" = "主動式線材電子元件";
 "All raw IOKit properties (%lld)" = "所有原始 IOKit 屬性 (%lld)";
 "Behavior" = "行為";
-"Built by %@." = "由 %@ 建置。";
+"Built by %@." = "由 %@ 開發。";
 "Cable trust signals" = "線材驗證資訊";
 "Cancel" = "取消";
 "Charger connected" = "充電器已連接";
@@ -32,7 +32,7 @@
 "Host (%@)" = "主機 (%@)";
 "Include Mac model and macOS version" = "包含 Mac 機型與 macOS 版本";
 "Install failed: %@" = "安裝失敗：%@";
-"This account can't update apps in this location. Download the new version from whatcable.uk, or update with Homebrew." = "此帳戶無法更新安裝於此位置的應用程式。請從 whatcable.uk 下載新版本，或使用 Homebrew 更新。";
+"This account can't update apps in this location. Download the new version from whatcable.uk, or update with Homebrew." = "此帳號無法更新安裝於此位置的應用程式。請從 whatcable.uk 下載新版本，或使用 Homebrew 更新。";
 "WhatCable can't update itself from its current folder. Move WhatCable into your Applications folder, relaunch it, and try again, or download the latest version from whatcable.uk." = "WhatCable 無法從目前的檔案夾自我更新。請將 WhatCable 移動到「應用程式」檔案夾，重新啟動後再試一次，或從 whatcable.uk 下載最新版本。";
 "Install update" = "安裝更新";
 "Installing, WhatCable will relaunch" = "正在安裝，WhatCable 將重新啟動";
@@ -101,7 +101,7 @@
 "Raw IOKit registry properties, a list of the driver classes present on your Mac, plus your macOS version and chip type. This is data macOS already exposes on your Mac." = "原始 IOKit 登錄屬性、您的 Mac 上現有的驅動程式類別清單，以及您的 macOS 版本與晶片類型。這些也是 macOS 本身可提供的資料。";
 "What happens" = "會發生什麼";
 "What is collected" = "會收集哪些資料";
-"WhatCable runs %lld IOKit probes that read hardware data your Mac already publishes. The results are sent to a secure server to help improve cable and port detection." = "WhatCable 會執行 %lld 個 IOKit 探測器，讀取您的 Mac 本身可提供的硬體資料。結果會傳送至安全伺服器，以協助改善線材與連接埠偵測。";
+"WhatCable runs %lld IOKit probes that read hardware data your Mac already publishes. The results are sent to a secure server to help improve cable and port detection." = "WhatCable 會執行 %lld 項 IOKit 探測，讀取您的 Mac 本身可提供的硬體資料。結果會傳送至安全伺服器，以協助改善線材與連接埠偵測。";
 "Your machine's hardware UUID is hashed with SHA-256 before sending. No names, accounts, your Mac's serial number, or personal data are collected or stored." = "裝置的硬體 UUID 會在傳送前經過 SHA-256 雜湊處理。不會收集或儲存您的姓名、帳號、Mac 序號或任何個人資料。";
 
 /* Negotiation diagnostics + Pro UX (PR #55). English; non-English to be refined by the community translation flow. */
@@ -176,7 +176,7 @@
 
 /* Intel Macs are unsupported; notice shown on every launch. */
 "WhatCable can't read cables on this Mac" = "WhatCable 無法讀取這台 Mac 的線材資訊";
-"This Mac has an Intel processor. WhatCable gets its cable and port data from Apple Silicon's port controller, and Intel Macs don't expose it, so the app will show nothing useful.\n\nIt'll stay open if you want to look around, but there's nothing behind it." = "這台 Mac 使用 Intel 處理器。WhatCable 的線材與連接埠資料來自 Apple Silicon 的連接埠控制器，但 Intel Mac 不會提供這些資料，因此 App 無法顯示任何有用的資訊。\n\n若您仍想查看介面，App 會繼續保持開啟，但其中沒有任何可用資料。";
+"This Mac has an Intel processor. WhatCable gets its cable and port data from Apple Silicon's port controller, and Intel Macs don't expose it, so the app will show nothing useful.\n\nIt'll stay open if you want to look around, but there's nothing behind it." = "這台 Mac 使用 Intel 處理器。WhatCable 的線材與連接埠資料來自 Apple Silicon 的連接埠控制器，但 Intel Mac 不會提供這些資料，因此應用程式無法顯示任何有用的資訊。\n\n若您仍想查看介面，應用程式會繼續保持開啟，但其中沒有任何可用資料。";
 "OK" = "知道了";
 "Learn more" = "了解更多";
 /* USB device detail rows (downstream device enrichment). Labels for the

--- a/Sources/WhatCable/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/WhatCable/Resources/zh-Hant.lproj/Localizable.strings
@@ -7,7 +7,7 @@
 "About %@" = "關於 %@";
 "Active" = "作用中";
 "Active cable electronics" = "主動式線材電子元件";
-"All raw IOKit properties (%lld)" = "所有原始 IOKit 屬性 (%lld)";
+"All raw IOKit properties (%lld)" = "所有 raw IOKit 屬性 (%lld)";
 "Behavior" = "行為";
 "Built by %@." = "由 %@ 開發。";
 "Cable trust signals" = "線材驗證資訊";
@@ -98,7 +98,7 @@
 "Privacy" = "隱私權";
 "Pro" = "Pro";
 "Proceed" = "繼續";
-"Raw IOKit registry properties, a list of the driver classes present on your Mac, plus your macOS version and chip type. This is data macOS already exposes on your Mac." = "原始 IOKit 登錄屬性、您的 Mac 上現有的驅動程式類別清單，以及您的 macOS 版本與晶片類型。這些也是 macOS 本身可提供的資料。";
+"Raw IOKit registry properties, a list of the driver classes present on your Mac, plus your macOS version and chip type. This is data macOS already exposes on your Mac." = "Raw IOKit 登錄屬性、您的 Mac 上現有的驅動程式類別清單，以及您的 macOS 版本與晶片類型。這些也是 macOS 本身可提供的資料。";
 "What happens" = "會發生什麼";
 "What is collected" = "會收集哪些資料";
 "WhatCable runs %lld IOKit probes that read hardware data your Mac already publishes. The results are sent to a secure server to help improve cable and port detection." = "WhatCable 會執行 %lld 項 IOKit 探測，讀取您的 Mac 本身可提供的硬體資料。結果會傳送至安全伺服器，以協助改善線材與連接埠偵測。";

--- a/Sources/WhatCableCore/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/WhatCableCore/Resources/zh-Hant.lproj/Localizable.strings
@@ -158,7 +158,7 @@
 "Cable Identity" = "線材識別資訊";
 "Cancel" = "取消";
 "Capability mismatch" = "規格不一致";
-"Connect a USB-C power source to view live telemetry." = "連接 USB-C 電源以查看即時電源資料。";
+"Connect a USB-C power source to view live telemetry." = "連接 USB-C 電源來查看即時電源資料。";
 "Connector" = "連接器";
 "Controller alert: could indicate overcurrent, overtemperature, or a protocol error. Check Port Health for details." = "控制器警示：可能表示過電流、過熱或協定錯誤。請查看「連接埠健康狀況」了解詳細資訊。";
 "Controller app loaded" = "控制器應用程式已載入";
@@ -178,9 +178,9 @@
 "Discover Identity response received on SOP channel. Carries the connected partner's VID, PID, and capability VDOs (not the cable; cable identity uses SOP')." = "在 SOP 通道上收到 Discover Identity 回應。包含已連接對端的 VID、PID 和規格 VDO（不是線材；線材識別資訊使用 SOP'）。";
 "Display Output" = "顯示輸出";
 "Enabled" = "已啟用";
-"Enter your licence key to unlock pro features." = "輸入授權金鑰以解鎖 Pro 功能。";
-"Measuring while your Mac charges…" = "正在測量,Mac 充電中…";
-"Waiting for charging load to vary. Use your Mac normally to finish the reading." = "等待充電負載變化。請正常使用 Mac 以完成測量。";
+"Enter your licence key to unlock pro features." = "輸入授權金鑰來解鎖 Pro 功能。";
+"Measuring while your Mac charges…" = "正在測量，Mac 充電中…";
+"Waiting for charging load to vary. Use your Mac normally to finish the reading." = "正在等待充電負載變化。請照常使用 Mac 來完成測量。";
 "Event Log" = "事件記錄";
 "FET enable failures" = "FET 啟用失敗次數";
 "FET status" = "FET 狀態";
@@ -295,9 +295,9 @@
 "WhatCable Pro" = "WhatCable Pro";
 "Year of manufacture" = "製造年份";
 "Yes" = "是";
-"Charging resistance" = "充電電阻";
+"Charging resistance" = "充電路徑電阻";
 "experimental" = "實驗性";
-"Resistance of the whole charging path: cable, plugs and charger together. Lower is better. To judge a cable, compare cables on the same charger and port." = "整個充電路徑的電阻:線材、接頭與充電器的總和。數值越低越好。要判斷線材,請在同一充電器與同一連接埠上比較不同線材。";
+"Resistance of the whole charging path: cable, plugs and charger together. Lower is better. To judge a cable, compare cables on the same charger and port." = "整個充電路徑的電阻：包含線材、接頭與充電器。數值越低越好。若要評估線材，請使用相同的充電器與連接埠，再比較不同的線材。";
 
 /* Pro plugin format strings */
 "%@ Port %lld" = "%1$@ 連接埠 %2$lld";
@@ -325,8 +325,8 @@
 /* Widget strings */
 "Cable Status" = "線材狀態";
 "No cable data" = "沒有線材資料";
-"Open WhatCable to start monitoring." = "開啟 WhatCable 以開始監控。";
-"See what your USB-C cables can do at a glance." = "一眼查看 USB-C 線材能做什麼。";
+"Open WhatCable to start monitoring." = "開啟 WhatCable 即可開始監控。";
+"See what your USB-C cables can do at a glance." = "一眼看懂 USB-C 線材能做什麼。";
 
 /* Negotiation diagnostics + Pro UX (PR #55). */
 "The cable's e-marker and the Thunderbolt controller disagree on its speed. The controller measured a higher, confirmed rate, so that figure is used." = "線材的 e-marker 與 Thunderbolt 控制器對速度的判定不一致。控制器測得更高且已確認的速率，因此會使用該數值。";
@@ -582,4 +582,4 @@
 "Made by %@ (%@), per our bundled vendor list" = "根據內建廠商清單，製造商為 %1$@ (%2$@)";
 "Answered, but reported no capability data." = "e-marker 有回應，但未回報任何規格資料。";
 "Certification ID" = "認證 ID";
-"Connect a charger to identify the cable." = "請連接充電器以識別連接線。";
+"Connect a charger to identify the cable." = "請連接充電器來辨識線材。";

--- a/Sources/WhatCableCore/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/WhatCableCore/Resources/zh-Hant.lproj/Localizable.strings
@@ -73,7 +73,7 @@
 "Plug a cable into %@ to see what it can do." = "將線材接到 %@，即可查看它能做什麼。";
 "Power is flowing but no data link is established." = "正在供電，但未建立資料連線。";
 "Power is flowing. No data connection." = "正在供電。沒有資料連線。";
-"Raw IOKit properties:" = "原始 IOKit 屬性：";
+"Raw IOKit properties:" = "Raw IOKit 屬性：";
 "Re-driver" = "Re-driver";
 "Re-timer" = "Re-timer";
 "Reserved" = "保留";
@@ -125,7 +125,7 @@
 "Charger connected. Battery is full, so the Mac isn't drawing power." = "充電器已連接。電池已充滿，因此 Mac 未取用電力。";
 "Per-port negotiation data is not available. Wattage is from the system-wide adapter reading." = "無法取得各連接埠的協商資料。瓦數來自系統層級的電源轉接器讀數。";
 "Plugged in · battery full" = "已接上 · 電池已充滿";
-"Try a higher-wattage charger to identify the cable." = "嘗試使用更高瓦數的充電器來辨識線材。";
+"Try a higher-wattage charger to identify the cable." = "嘗試使用更高瓦數的充電器來識別線材。";
 "No data link or charger detected on this port." = "在此連接埠上未偵測到資料連線或充電器。";
 "USB4 Gen 3 (40 Gbps, Thunderbolt 4 class)" = "USB4 Gen 3（40 Gbps，Thunderbolt 4 等級）";
 "USB4 Gen 4 (80 Gbps, Thunderbolt 5 class)" = "USB4 Gen 4（80 Gbps，Thunderbolt 5 等級）";
@@ -219,7 +219,7 @@
 "No SOP identity data" = "沒有 SOP 識別資料";
 "No cable connected." = "未連接線材。";
 "No cable identity data" = "沒有線材識別資料";
-"No health counters" = "沒有健康狀況計數器";
+"No health counters" = "沒有健康狀況計數資料";
 "No liquid detection data" = "沒有液體偵測資料";
 "None" = "無";
 "Open Pro diagnostics for this port" = "開啟此連接埠的 Pro 診斷";
@@ -251,8 +251,8 @@
 "Pro required" = "需要 Pro";
 "Product ID" = "Product ID";
 "Product Type" = "產品類型";
-"Raw VDOs" = "原始 VDO";
-"Raw cable VDOs" = "原始線材 VDO";
+"Raw VDOs" = "Raw VDOs";
+"Raw cable VDOs" = "Raw cable VDOs";
 "Rp current level" = "Rp 電流等級";
 "Rp resistor" = "Rp 電阻";
 "SOP identity received" = "已收到 SOP 識別資訊";
@@ -272,9 +272,9 @@
 "The port controller firmware finished initialising and is ready." = "連接埠控制器韌體已完成初始化並準備就緒。";
 "The port controller raised an alert (overcurrent, overtemperature, or similar fault)." = "連接埠控制器發出警示（過電流、過熱或類似故障）。";
 "The power direction flipped: the port switched between providing and receiving power." = "電源方向已切換：連接埠在供電與受電之間切換。";
-"This event code is not in the known TPS6598x interrupt table. May be firmware-specific." = "此事件代碼不在已知的 TPS6598x 中斷表中。可能是韌體特定事件。";
+"This event code is not in the known TPS6598x interrupt table. May be firmware-specific." = "此事件代碼不在已知的 TPS6598x 中斷表中，可能是韌體特定的事件代碼。";
 "Tunneled" = "穿隧傳輸";
-"UVDM discovery started. The controller is probing for vendor-specific capabilities on the cable or partner." = "UVDM 探索已開始。控制器正在探測線材或對端上的廠商特定規格。";
+"UVDM discovery started. The controller is probing for vendor-specific capabilities on the cable or partner." = "UVDM 探索已開始。控制器正在探測線材或對端所支援的廠商特定規格。";
 "UVDM enumeration" = "UVDM 列舉";
 "UVDM status update" = "UVDM 狀態更新";
 "USB 2.0 plug event" = "USB 2.0 插拔事件";
@@ -283,13 +283,13 @@
 "Unknown" = "未知";
 "Unknown Device" = "未知裝置";
 "Unknown event %@" = "未知事件 %@";
-"Unrecognised event code from the port controller." = "來自連接埠控制器的無法辨識事件代碼。";
+"Unrecognised event code from the port controller." = "無法辨識連接埠控制器回報的事件代碼。";
 "Unregistered cable (no e-marker)" = "未註冊線材（無 e-marker）";
 "Unstructured VDM enumeration began (discovering vendor-specific capabilities)." = "非結構化 VDM 列舉已開始（正在探索廠商特定規格）。";
 "Unstructured VDM status changed (vendor-specific messaging like Alt Mode setup)." = "非結構化 VDM 狀態已變更（廠商特定訊息，例如 Alt Mode 設定）。";
 "VDO fail count" = "VDO 失敗次數";
 "Vendor ID" = "Vendor ID";
-"Vendor-specific unstructured VDM state changed. Used by Apple for custom Alt Mode setup and Thunderbolt negotiation." = "廠商特定的非結構化 VDM 狀態已變更。Apple 會用於自訂 Alt Mode 設定和 Thunderbolt 協商。";
+"Vendor-specific unstructured VDM state changed. Used by Apple for custom Alt Mode setup and Thunderbolt negotiation." = "廠商特定的非結構化 VDM 狀態已變更。Apple 會將其用於自訂 Alt Mode 設定和 Thunderbolt 協商。";
 "Voltage" = "電壓";
 "Voltage (V)" = "電壓 (V)";
 "WhatCable Pro" = "WhatCable Pro";
@@ -301,7 +301,7 @@
 
 /* Pro plugin format strings */
 "%@ Port %lld" = "%1$@ 連接埠 %2$lld";
-"APDO, %@ to %@ @ %@, %@ max" = "APDO，%1$@ 至 %2$@ @ %3$@，最大 %4$@";
+"APDO, %@ to %@ @ %@, %@ max" = "APDO，%1$@ 至 %2$@ @ %3$@，最高 %4$@";
 "Battery, %@ minimum, %@" = "電池，最低 %1$@，%2$@";
 "Battery, %@ to %@, %@" = "電池，%1$@ 至 %2$@，%3$@";
 "EPR AVS, %@ to %@, %@" = "EPR AVS，%1$@ 至 %2$@，%3$@";
@@ -359,16 +359,16 @@
 "Charger" = "充電器";
 "AC Power" = "交流電源";
 "bottleneck" = "限制因素";
-"Cable signals disagree" = "線材訊號不一致";
+"Cable signals disagree" = "線材驗證資訊不一致";
 "an unknown speed" = "未知速度";
 "a higher speed" = "更高速度";
 "The cable's own e-marker reports %@, but the Thunderbolt controller measured it running at %@, faster than the e-marker claims. This can happen with active Thunderbolt cables whose e-marker under-reports (declaring themselves passive at a low speed). The controller's confirmed, higher reading is used above." = "線材本身的 e-marker 回報 %1$@，但 Thunderbolt 控制器測得其以 %2$@ 運作，高於 e-marker 宣告的速度。這可能發生在 e-marker 低報規格的主動式 Thunderbolt 線材上（將自身回報為低速的被動式線材）。上方會使用控制器已確認的較高讀數。";
 /* Pro overview screen + footer pill (Pro funnel). */
 "Cable Diagnostics" = "線材診斷";
-"Deep per-port pin maps, plug orientation, and protocol detail." = "深入查看各連接埠的針腳配置、連接器方向與協定詳細資訊。";
+"Deep per-port pin maps, plug orientation, and protocol detail." = "深入查看各連接埠的針腳配置、連接器方向與協定細節。";
 "Licence Key" = "授權金鑰";
 "Live MagSafe pin layout for charging and diagnostics." = "即時顯示用於充電與診斷的 MagSafe 針腳配置。";
-"Live multi-port power graphs and event history." = "即時多連接埠功率圖表與事件記錄。";
+"Live multi-port power graphs and event history." = "多連接埠即時功率圖表與事件記錄。";
 "MagSafe pin diagrams" = "MagSafe 針腳圖";
 "Manage Licence…" = "管理授權…";
 "See exactly what each link can do, and where the bottleneck is." = "精確查看每個連線能做什麼，以及限制因素在哪裡。";
@@ -582,4 +582,4 @@
 "Made by %@ (%@), per our bundled vendor list" = "根據內建廠商清單，製造商為 %1$@ (%2$@)";
 "Answered, but reported no capability data." = "e-marker 有回應，但未回報任何規格資料。";
 "Certification ID" = "認證 ID";
-"Connect a charger to identify the cable." = "請連接充電器來辨識線材。";
+"Connect a charger to identify the cable." = "請連接充電器來識別線材。";


### PR DESCRIPTION
- Refine translations for newly introduced strings.
- Refine wording in existing translations.
- Restore selected low-level diagnostic labels and headings, such as Raw IOKit and Raw VDOs, to English for consistency with their technical context.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Localization**
  * Improved Traditional Chinese translations across cable, charger, diagnostics, widget, and Pro features.
  * Clarified wording for charging resistance, cable identification, event details, monitoring guidance, and diagnostic data.
  * Refined app attribution, account update errors, Intel Mac limitations, punctuation, and terminology.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->