### PR TITLE
Traditional Chinese language update

### DIFF
--- a/Sources/WhatCable/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/WhatCable/Resources/zh-Hant.lproj/Localizable.strings
@@ -186,4 +186,4 @@
 "You installed WhatCable with Homebrew. Running brew upgrade may replace a beta with the current stable release." = "您是透過 Homebrew 安裝 WhatCable。執行 brew upgrade 可能會用目前的穩定版取代 Beta 版本。";
 
 /* Brick ID analog charger identity note (issue #592) */
-"Analog charger identifier, no PD profiles" = "類比充電器識別碼，無 PD 設定檔";
+"Analog charger identifier, no PD profiles" = "類比充電器識別資訊，無 PD 供電配置";

--- a/Sources/WhatCableCore/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/WhatCableCore/Resources/zh-Hant.lproj/Localizable.strings
@@ -545,8 +545,8 @@
 "This cable has no e-marker, so it can't be tracked." = "這條線材沒有 e-marker，因此無法追蹤。";
 "This cable can't be tracked" = "這條線材無法追蹤";
 "Matches your saved cable %@. Two units of the same model can't be told apart, so their history will merge if you save this one too." = "與您已儲存的線材 %@ 相符。相同型號的兩條線材無法區分，如果您也儲存這條線材，它們的歷史記錄將會合併。";
-"Identified by its MagSafe cable ID (VID 0x%04X, PID 0x%04X). Cables of this exact model look identical, so this record tracks the model, not one physical cable." = "已透過 MagSafe 線材 ID 識別（VID 0x%04X，PID 0x%04X）。相同型號的線材外觀完全相同，因此此記錄代表的是型號，而非某條具體線材。";
-"You already have this MagSafe cable saved as %@. Cables of this model can't be told apart, so add its history to that one instead." = "您已將這條 MagSafe 線材儲存為 %@。相同型號的線材無法區分，請改為將記錄新增至該線材。";
+"Identified by its MagSafe cable ID (VID 0x%04X, PID 0x%04X). Cables of this exact model look identical, so this record tracks the model, not one physical cable." = "已透過 MagSafe 線材 ID 識別（VID 0x%04X，PID 0x%04X）。相同型號的線材外觀完全相同，因此此記錄追蹤的是型號，而非某一條實體線材。";
+"You already have this MagSafe cable saved as %@. Cables of this model can't be told apart, so add its history to that one instead." = "您已將這條 MagSafe 線材儲存為 %@。相同型號的線材無法區分，請改為將這條線材的歷史記錄加入該線材。";
 "This cable has no e-marker, so nothing new can be recorded for it. Its existing history stays available." = "這條線材沒有 e-marker，因此無法再為它記錄新資料。現有的歷史記錄仍可查看。";
 "Can't add this cable" = "無法新增此線材";
 "OK" = "好";
@@ -600,4 +600,4 @@
 "Connect a charger to identify the cable." = "請連接充電器來識別線材。";
 
 /* Power Monitor: a charge path that never negotiates a contract (issue #592) */
-"No PD contract on this port. Incoming power shows in System Power Input below." = "此連接埠沒有 PD 合約。輸入功率會顯示在下方的「系統電源輸入」圖表中。";
+"No PD contract on this port. Incoming power shows in System Power Input below." = "此連接埠沒有 PD 協議。輸入功率會顯示在下方的「系統電源輸入」圖表中。";

--- a/Sources/WhatCableCore/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/WhatCableCore/Resources/zh-Hant.lproj/Localizable.strings
@@ -281,7 +281,7 @@
 "The Mac entered or exited sleep, causing port controller state changes." = "Mac 進入或結束睡眠，導致連接埠控制器狀態變更。";
 "The charger or power source advertised what voltages and currents it can provide." = "充電器或電源宣告了可提供的電壓和電流。";
 "The data role flipped: the port switched between host and device mode." = "資料角色已切換：連接埠在主機和裝置模式之間切換。";
-"This Mac's slot could not be released on the licence server, so it may still be held. Free it from Settings on another Mac, or contact support." = "無法在授權伺服器上釋放這台 Mac 的名額，因此可能仍被佔用。請在另一台 Mac 的「設定」中釋放此名額，或聯絡支援團隊。
+"This Mac's slot could not be released on the licence server, so it may still be held. Free it from Settings on another Mac, or contact support." = "無法在授權伺服器上釋放這台 Mac 的名額，因此可能仍被佔用。請在另一台 Mac 的「設定」中釋放此名額，或聯絡支援團隊。";
 "The port controller firmware finished initialising and is ready." = "連接埠控制器韌體已完成初始化並準備就緒。";
 "The port controller raised an alert (overcurrent, overtemperature, or similar fault)." = "連接埠控制器發出警示（過電流、過熱或類似故障）。";
 "The power direction flipped: the port switched between providing and receiving power." = "電源方向已切換：連接埠在供電與受電之間切換。";

--- a/Sources/WhatCableCore/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/WhatCableCore/Resources/zh-Hant.lproj/Localizable.strings
@@ -143,6 +143,7 @@
 "%@ (spec, not measured)" = "%@（規格值，非實測）";
 "%@ Diagnostics" = "%@ 診斷";
 "%lld (%lld failed)" = "%1$lld（%2$lld 次失敗）";
+"%lld of %lld devices used" = "已使用 %lld/%lld 台裝置";
 "A DR_Swap completed successfully. The port changed between DFP (host) and UFP (device) roles." = "DR_Swap 已成功完成。連接埠已在 DFP（主機）和 UFP（裝置）角色之間切換。";
 "A PR_Swap completed successfully. Common when a hub or dock renegotiates which end supplies power." = "PR_Swap 已成功完成。常見於 Hub 或 Dock 重新協商由哪一端供電時。";
 "A USB 2.0 connection was detected on the legacy D+/D- pins." = "在傳統 D+/D- 針腳上偵測到 USB 2.0 連線。";
@@ -173,6 +174,7 @@
 "Default USB (500/900 mA)" = "USB 預設 (500/900 mA)";
 "Detach count" = "中斷連接次數";
 "Device Identity" = "裝置識別資訊";
+"Devices" = "裝置";
 "Diagnostics" = "診斷";
 "Disabled" = "已停用";
 "Discover Identity response received on SOP channel. Carries the connected partner's VID, PID, and capability VDOs (not the cable; cable identity uses SOP')." = "在 SOP 通道上收到 Discover Identity 回應。包含已連接對端的 VID、PID 和規格 VDO（不是線材；線材識別資訊使用 SOP'）。";
@@ -188,6 +190,7 @@
 "General port controller status change (connection state, error flags)." = "一般連接埠控制器狀態變更（連線狀態、錯誤旗標）。";
 "Generic controller status register changed. Covers plug state, orientation, and error conditions." = "通用控制器狀態暫存器已變更。涵蓋連接狀態、方向和錯誤情況。";
 "Hard reset count" = "硬重設次數";
+"Could not load the device list. Try again later." = "無法載入裝置清單，請稍後再試。";
 "Could not reach the licence server. Check your internet connection and try again." = "無法連接授權伺服器。請檢查網路連線後再試一次。";
 "I2C error count" = "I2C 錯誤次數";
 "Inactive" = "未作用中";
@@ -200,6 +203,7 @@
 "Liquid Detection" = "液體偵測";
 "Liquid detected" = "偵測到液體";
 "Live" = "Live";
+"Loading devices…" = "正在載入裝置…";
 "MagSafe 3" = "MagSafe 3";
 "MagSafe Charger" = "MagSafe 充電器";
 "Manufacturer" = "製造商";
@@ -219,6 +223,7 @@
 "No SOP identity data" = "沒有 SOP 識別資料";
 "No cable connected." = "未連接線材。";
 "No cable identity data" = "沒有線材識別資料";
+"No devices registered." = "沒有已註冊的裝置。";
 "No health counters" = "沒有健康狀況計數資料";
 "No liquid detection data" = "沒有液體偵測資料";
 "None" = "無";
@@ -253,6 +258,12 @@
 "Product Type" = "Product Type";
 "Raw VDOs" = "Raw VDOs";
 "Raw cable VDOs" = "Raw cable VDOs";
+"Refresh" = "重新整理";
+"Registered %@" = "註冊於 %@";
+"Registration date unknown" = "註冊日期不明";
+"Remove" = "移除";
+"Remove %@ from your licence?" = "要將 %@ 從授權中移除嗎？";
+"Removing this Mac will lock Pro here until you activate again." = "移除這台 Mac 後，Pro 功能將在這台 Mac 上保持鎖定，直到您再次啟用。";
 "Rp current level" = "Rp 電流等級";
 "Rp resistor" = "Rp 電阻";
 "SOP identity received" = "已收到 SOP 識別資訊";
@@ -266,12 +277,15 @@
 "Status update" = "狀態更新";
 "System Power Input" = "系統電源輸入";
 "System sleep/wake transition. The port controller state is saved and restored across sleep boundaries." = "系統睡眠/喚醒轉換。連接埠控制器狀態會在睡眠前後儲存並還原。";
+"That Mac will lose Pro until it activates again." = "該 Mac 將無法使用 Pro 功能，直到再次啟用。";
 "The Mac entered or exited sleep, causing port controller state changes." = "Mac 進入或結束睡眠，導致連接埠控制器狀態變更。";
 "The charger or power source advertised what voltages and currents it can provide." = "充電器或電源宣告了可提供的電壓和電流。";
 "The data role flipped: the port switched between host and device mode." = "資料角色已切換：連接埠在主機和裝置模式之間切換。";
+"This Mac's slot could not be released on the licence server, so it may still be held. Free it from Settings on another Mac, or contact support." = "無法在授權伺服器上釋放這台 Mac 的名額，因此可能仍被佔用。請在另一台 Mac 的「設定」中釋放此名額，或聯絡支援團隊。
 "The port controller firmware finished initialising and is ready." = "連接埠控制器韌體已完成初始化並準備就緒。";
 "The port controller raised an alert (overcurrent, overtemperature, or similar fault)." = "連接埠控制器發出警示（過電流、過熱或類似故障）。";
 "The power direction flipped: the port switched between providing and receiving power." = "電源方向已切換：連接埠在供電與受電之間切換。";
+"This Mac" = "這台 Mac";
 "This event code is not in the known TPS6598x interrupt table. May be firmware-specific." = "此事件代碼不在已知的 TPS6598x 中斷表中，可能是韌體特定的事件代碼。";
 "Tunneled" = "穿隧傳輸";
 "UVDM discovery started. The controller is probing for vendor-specific capabilities on the cable or partner." = "UVDM 探索已開始。控制器正在探測線材或對端所支援的廠商特定規格。";
@@ -282,6 +296,7 @@
 "USB-C Charger" = "USB-C 充電器";
 "Unknown" = "未知";
 "Unknown Device" = "未知裝置";
+"Unknown Mac" = "未知 Mac";
 "Unknown event %@" = "未知事件 %@";
 "Unrecognised event code from the port controller." = "無法辨識連接埠控制器回報的事件代碼。";
 "Unregistered cable (no e-marker)" = "未註冊線材（無 e-marker）";


### PR DESCRIPTION
Refine translations for newly introduced strings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Localization**
  * Updated Traditional Chinese wording for charger identifiers and PD profiles.
  * Added Traditional Chinese translations for Pro license and device management features, including device usage, registration, refreshing, removal, and activation status.
  * Clarified messages about removing Macs from a license and releasing license slots.
  * Improved terminology and readability across related licensing and device-management messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->